### PR TITLE
修复：Windows 使用应用内目录选择器

### DIFF
--- a/packages/host/directory-picker-auto/src/resolve.ts
+++ b/packages/host/directory-picker-auto/src/resolve.ts
@@ -37,17 +37,18 @@ const present = (value: string | undefined): boolean => value !== undefined && v
  * a loopback-only bind (an all-interfaces bind admits remote browsers no OS
  * chooser can reach), no SSH launch (under SSH port-forwarding the chooser
  * would open on the unattended server), and a servable display session —
- * assumed on darwin/win32, requiring `DISPLAY`/`WAYLAND_DISPLAY` plus a
- * chooser binary on linux, and never true elsewhere (the native backend
- * drives exactly darwin/win32/linux). Anything ambiguous resolves to
- * `browse`, which works everywhere.
+ * assumed on darwin, requiring `DISPLAY`/`WAYLAND_DISPLAY` plus a
+ * chooser binary on linux. Windows currently resolves to `browse` because
+ * its native dialog worker is not a reliable path. Anything ambiguous
+ * resolves to `browse`, which works everywhere.
  * @param facts - the sampled host facts.
  * @returns the backend kind to mount.
  */
 export function resolveDirectoryPickerBackend(facts: DirectoryPickerHostFacts): DirectoryPickerBackendKind {
   if (facts.bindHost !== '127.0.0.1') return 'browse'
   if (present(facts.env.SSH_CONNECTION) || present(facts.env.SSH_TTY)) return 'browse'
-  if (facts.platform === 'darwin' || facts.platform === 'win32') return 'native'
+  if (facts.platform === 'win32') return 'browse'
+  if (facts.platform === 'darwin') return 'native'
   if (facts.platform !== 'linux' || !facts.linuxChooser) return 'browse'
   return present(facts.env.DISPLAY) || present(facts.env.WAYLAND_DISPLAY) ? 'native' : 'browse'
 }

--- a/packages/host/directory-picker-auto/tests/resolve.spec.ts
+++ b/packages/host/directory-picker-auto/tests/resolve.spec.ts
@@ -15,9 +15,12 @@ const attended: DirectoryPickerHostFacts = {
 }
 
 describe('resolveDirectoryPickerBackend', () => {
-  it('resolves native for a loopback bind on a display platform', () => {
+  it('resolves native for a loopback bind on macOS', () => {
     expect(resolveDirectoryPickerBackend(attended)).toBe('native')
-    expect(resolveDirectoryPickerBackend({ ...attended, platform: 'win32' })).toBe('native')
+  })
+
+  it('resolves browse on Windows to avoid the native dialog worker', () => {
+    expect(resolveDirectoryPickerBackend({ ...attended, platform: 'win32' })).toBe('browse')
   })
 
   it('resolves browse for an all-interfaces bind regardless of other signals', () => {


### PR DESCRIPTION
## 概要

- Windows 改用应用内目录浏览器，绕过不稳定的原生目录对话框 worker。
- macOS 和 Linux 的原生目录选择行为保持不变。
- 为 Windows 的选择逻辑补充单元测试。

## 验证

- `pnpm exec vitest run packages/host/directory-picker-auto/tests/resolve.spec.ts`
- 仓库 pre-push 全量类型检查