### PR TITLE
修复：桌面端复制按钮失效（权限策略拦截剪贴板写入）

### DIFF
--- a/.agents/notes/implemented/bug-fix/2026-08-14-clipboard-copy-permission-fallback.i18n.yaml
+++ b/.agents/notes/implemented/bug-fix/2026-08-14-clipboard-copy-permission-fallback.i18n.yaml
@@ -1,0 +1,6 @@
+# Bilingual-pair consistency record (docs/i18n/README.md): the git blob hash of each
+# side as of the last confirmed-consistent state. Both languages carry equal authority;
+# after editing either side, bring the other along and re-record with:
+#   pnpm run verify-translation-pairing --write .agents/notes/implemented/bug-fix/2026-08-14-clipboard-copy-permission-fallback.md
+2026-08-14-clipboard-copy-permission-fallback.md: b946439bea4c82bb816102c1c6ff74a6483013f8
+2026-08-14-clipboard-copy-permission-fallback.zh.md: 3d2bd319c28c866701b5a825c241e091e8d1ee16

--- a/.agents/notes/implemented/bug-fix/2026-08-14-clipboard-copy-permission-fallback.md
+++ b/.agents/notes/implemented/bug-fix/2026-08-14-clipboard-copy-permission-fallback.md
@@ -1,0 +1,59 @@
+# Agent Note: Desktop copy controls blocked by deny-all permission policy
+
+Status: implemented
+
+English | [中文](2026-08-14-clipboard-copy-permission-fallback.zh.md)
+
+## Problem
+
+The desktop shell installs a deny-all session permission policy before the
+first renderer loads (`setPermissionCheckHandler(() => false)`).
+`navigator.clipboard.writeText()` performs a `clipboard-sanitized-write`
+permission check, so every copy control in the Web UI — message bubble, code
+block, terminal, diff, search result, hover card, JSON tree — rejects with
+`NotAllowedError` in the desktop app. The renderer helper `writeClipboard`
+treated a rejecting async API as a hard failure: it ran the
+`execCommand('copy')` fallback only when `navigator.clipboard.writeText` was
+entirely absent, so on the desktop the fallback never ran and clicking copy
+silently did nothing.
+
+## Decision
+
+Two layers change together.
+
+`apps/desktop/src/main.ts` (`hardenSession`) allows exactly one permission —
+`clipboard-sanitized-write` — in both the permission-check and
+permission-request handlers; everything else stays denied, preserving the
+hardening intent.
+
+`packages/client/ui-primitives/src/clipboard.ts` (`writeClipboard`) falls
+through to the `execCommand('copy')` path when the async API exists but
+rejects, so a host whose policy denies the async API still copies through the
+legacy synchronous path, which does not consult the permission system.
+`JsonTree` routes its copy through `writeClipboard` instead of calling
+`navigator.clipboard.writeText` directly, gaining the same fallback and an
+honest failure state.
+
+## Alternatives considered
+
+**Allow the permission only in the desktop shell.** Rejected as the sole fix:
+the renderer fallback also protects every other policy-restricted host (iframe
+embeds, future web deployments) and gives `JsonTree` an honest failure state
+instead of an unreachable catch.
+
+**Renderer-only fallback.** Rejected because the shell denial is the root
+cause: the primary async path would stay broken there, and any host without an
+`execCommand('copy')` path would still fail.
+
+**Keep returning false on rejection.** Rejected because it is the observed
+defect: copy silently fails with no user feedback.
+
+## Consequences
+
+Copy works again in the desktop app through the async API with the
+`execCommand('copy')` fallback as defense in depth; the Web UI copies on any
+host where `writeText` exists but rejects; `JsonTree` reports an honest
+failure state when both paths refuse. The shell's hardening posture is
+unchanged except for the single clipboard-write permission. Unit coverage
+pins the new branches: rejection followed by execCommand success, rejection
+followed by execCommand refusal, and the existing missing-API paths.

--- a/.agents/notes/implemented/bug-fix/2026-08-14-clipboard-copy-permission-fallback.zh.md
+++ b/.agents/notes/implemented/bug-fix/2026-08-14-clipboard-copy-permission-fallback.zh.md
@@ -1,0 +1,49 @@
+# Agent Note: 桌面端复制控件被全拒绝权限策略阻断
+
+Status: implemented
+
+[English](2026-08-14-clipboard-copy-permission-fallback.md) | 中文
+
+## Problem
+
+桌面外壳在首个渲染进程加载前安装了全拒绝的会话权限策略
+（`setPermissionCheckHandler(() => false)`）。`navigator.clipboard.writeText()`
+会执行 `clipboard-sanitized-write` 权限检查，因此 Web UI 中所有复制控件——消息
+气泡、代码块、终端、diff、搜索结果、悬停卡片、JSON 树——在桌面端都会以
+`NotAllowedError` 拒绝。渲染层辅助函数 `writeClipboard` 把拒绝的异步 API 视为
+硬失败：它只在 `navigator.clipboard.writeText` 完全缺失时才走
+`execCommand('copy')` 兜底，因此在桌面端兜底永远不会执行，点击复制悄无声息地
+毫无效果。
+
+## Decision
+
+两层一起修改。
+
+`apps/desktop/src/main.ts`（`hardenSession`）在权限检查处理器和权限请求处理器中
+都只放行一个权限——`clipboard-sanitized-write`；其余权限保持拒绝，保留加固意图。
+
+`packages/client/ui-primitives/src/clipboard.ts`（`writeClipboard`）在异步 API
+存在但拒绝时落入 `execCommand('copy')` 路径，因此策略拒绝异步 API 的主机仍能通过
+不查询权限系统的传统同步路径完成复制。`JsonTree` 改为经由 `writeClipboard` 复制，
+而不是直接调用 `navigator.clipboard.writeText`，从而获得同样的兜底和诚实的失败
+状态。
+
+## Alternatives considered
+
+**只在桌面外壳放行权限。** 否决作为唯一修复：渲染层兜底同样保护其他受策略限制的
+主机（iframe 嵌入、未来的 Web 部署），并让 `JsonTree` 获得诚实的失败状态而不是
+不可达的 catch。
+
+**仅修复渲染层。** 否决，因为外壳的全拒绝是根因：那里的主异步路径仍然不可用，
+且任何没有 `execCommand('copy')` 路径的主机仍然失败。
+
+**保持拒绝时返回 false。** 否决，因为这正是被观察到的问题：复制静默失败，无任何
+用户反馈。
+
+## Consequences
+
+桌面端复制通过异步 API 恢复可用（权限已放行），`execCommand('copy')` 兜底作为纵深
+防御；在任何 `writeText` 存在但拒绝的主机上 Web UI 都能复制；两条路径都拒绝时
+`JsonTree` 报告诚实的失败状态。除单个剪贴板写入权限外，外壳的加固姿态不变。
+单元测试覆盖新分支：拒绝后跟 execCommand 成功、拒绝后跟 execCommand 拒绝，以及
+既有的缺失 API 路径。

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -90,8 +90,14 @@ function hasOrigin(raw: string, expected: string): boolean {
 /** Install navigation and permission policy before the first renderer loads. */
 function hardenSession(): void {
   const desktopSession = session.defaultSession
-  desktopSession.setPermissionCheckHandler(() => false)
-  desktopSession.setPermissionRequestHandler((_webContents, _permission, callback) => { callback(false) })
+  // The Web UI copy controls call `navigator.clipboard.writeText()`, which
+  // performs a `clipboard-sanitized-write` permission check; denying every
+  // permission silently breaks copy. Everything else stays denied.
+  const isAllowed = (permission: string): boolean => permission === 'clipboard-sanitized-write'
+  desktopSession.setPermissionCheckHandler((_webContents, permission) => isAllowed(permission))
+  desktopSession.setPermissionRequestHandler((_webContents, permission, callback) => {
+    callback(isAllowed(permission))
+  })
 }
 
 async function createMainWindow(): Promise<BrowserWindow> {

--- a/packages/client/ui-primitives/src/JsonTree.tsx
+++ b/packages/client/ui-primitives/src/JsonTree.tsx
@@ -7,6 +7,7 @@ import type {
   UIEvent as ReactUIEvent,
 } from 'react'
 import { IconCheckOutline16, IconCopyOutline16 } from './icons/index.tsx'
+import { writeClipboard } from './clipboard.ts'
 import { Menu } from './Menu.tsx'
 import type { MenuEntry } from './Menu.tsx'
 import css from './JsonTree.module.css'
@@ -530,12 +531,8 @@ export function JsonTree({
   const copy = async (mode: 'json' | 'path' | 'prettyJson' | 'value') => {
     /* v8 ignore next -- copy controls only render while their target exists. */
     if (copyTarget === undefined) return
-    try {
-      await navigator.clipboard.writeText(copyText(copyTarget, mode))
-      setCopyState('copied')
-    } catch {
-      setCopyState('failed')
-    }
+    const ok = await writeClipboard(copyText(copyTarget, mode))
+    setCopyState(ok ? 'copied' : 'failed')
     if (resetTimer.current !== undefined) clearTimeout(resetTimer.current)
     resetTimer.current = setTimeout(() => { setCopyState('idle') }, 1_500)
   }

--- a/packages/client/ui-primitives/src/clipboard.ts
+++ b/packages/client/ui-primitives/src/clipboard.ts
@@ -17,13 +17,15 @@ export async function writeClipboard(text: string): Promise<boolean> {
       await navigator.clipboard.writeText(text)
       return true
     } catch {
-      // Denied permissions / iframe policy — do not claim success.
-      return false
+      // Permission policies that deny `clipboard-sanitized-write` (Electron
+      // session handlers, cross-origin iframes) expose the async API but
+      // reject the write; fall through to the execCommand path below.
     }
   }
-  // jsdom and older hosts: best-effort execCommand path when present.
-  // execCommand('copy') is the only clipboard fallback where the async API
-  // is missing; deprecated but deliberately retained.
+  // jsdom, insecure contexts, and policy-denied hosts: best-effort execCommand
+  // path when present. execCommand('copy') is the legacy synchronous clipboard
+  // write and does not consult the permission system; deprecated but
+  // deliberately retained.
   /* oxlint-disable typescript/no-deprecated */
   const exec = typeof document.execCommand === 'function'
     ? document.execCommand.bind(document)

--- a/packages/client/ui-primitives/tests/terminal-block.client.spec.tsx
+++ b/packages/client/ui-primitives/tests/terminal-block.client.spec.tsx
@@ -376,11 +376,23 @@ describe('writeClipboard', () => {
     expect(writeText).toHaveBeenCalledWith('payload')
   })
 
-  it('reports false when the Clipboard API rejects', async () => {
+  it('falls back to execCommand when the async Clipboard API rejects', async () => {
     Object.defineProperty(navigator, 'clipboard', {
       configurable: true,
       value: { writeText: vi.fn().mockRejectedValue(new Error('denied')) },
     })
+    const exec = vi.fn(() => true)
+    Object.defineProperty(document, 'execCommand', { configurable: true, value: exec })
+    await expect(writeClipboard('payload')).resolves.toBe(true)
+    expect(exec).toHaveBeenCalledWith('copy')
+  })
+
+  it('reports false when the async API rejects and execCommand refuses', async () => {
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: { writeText: vi.fn().mockRejectedValue(new Error('denied')) },
+    })
+    Object.defineProperty(document, 'execCommand', { configurable: true, value: vi.fn(() => false) })
     await expect(writeClipboard('payload')).resolves.toBe(false)
   })
 


### PR DESCRIPTION
关联 Issue：该仓库已关闭 Issues。

<details>
<summary>变更与验证</summary>

- 变更：
  - `apps/desktop/src/main.ts`：`hardenSession()` 不再拒绝全部权限，仅放行 `clipboard-sanitized-write`（`navigator.clipboard.writeText()` 必需），其余权限保持拒绝。
  - `packages/client/ui-primitives/src/clipboard.ts`：`writeClipboard()` 在异步 Clipboard API 存在但被拒绝时（如桌面端权限策略）落入 `execCommand('copy')` 兜底路径，不再直接返回失败。
  - `packages/client/ui-primitives/src/JsonTree.tsx`：JSON 树复制改经 `writeClipboard()`，获得同样的兜底与诚实的失败状态。
  - 新增 Agent Note：`2026-08-14-clipboard-copy-permission-fallback`（中英双语 + 配对记录）。
- 验证：
  - `vitest run --coverage packages/client/ui-primitives`：全部通过；`clipboard.ts` 语句/分支/函数/行覆盖率 100%。
  - `pnpm --filter @deepseek-ai/dsh-desktop exec tsc -p tsconfig.json --noEmit` 通过。
  - pre-push 全量 `pnpm run typecheck` 通过。
  - 实测：在 Electron 渲染器（权限处理器全拒绝）中模拟 `writeText` 拒绝，修复后复制成功且文本进入系统剪贴板。

</details>