### PR TITLE
docs: clarify profile bundle patch ownership

### DIFF
--- a/apps/cli/reference/README.i18n.yaml
+++ b/apps/cli/reference/README.i18n.yaml
@@ -2,5 +2,5 @@
 # side as of the last confirmed-consistent state. Both languages carry equal authority;
 # after editing either side, bring the other along and re-record with:
 #   pnpm run verify-translation-pairing --write apps/cli/reference/README.md
-README.md: 0be64fdfc0ad4e81d23f25a26881fa89f37565b0
-README.zh.md: 649bf15df814abf4875fed794c2e76c494bfcc25
+README.md: 1fd0aa700a9acbfe30873fac4e22843d1cdb1a7e
+README.zh.md: 228b9917a1bdd183caba64999c0cbf75072fe5ee

--- a/apps/cli/reference/README.md
+++ b/apps/cli/reference/README.md
@@ -79,6 +79,8 @@ Session telemetry stays local by default. `DSH_TELEMETRY_MODE=FULL` streams ever
 
 Install external plugin bundles through `dsh plugin --profile <name> add <package-or-git-spec>`. The installed package owns its dependencies and contributes its declared `cordis.patch.yml` layer. The CLI also ships `@deepseek-ai/dsh-mcp-client` as a dependency for patch layers, but no MCP server is enabled by default because each server command is trusted executable code outside the agent sandbox.
 
+Do not repeat a bundle's `insert` entries in the profile's own `cordis.patch.yml`: a package listed in `dsh.profile.bundles` already contributes its declared patch layer. Keep the profile patch as `[]` unless you are overriding an existing row or adding a separate row; inserting the same id twice makes Loader reject the profile with `duplicate loader entry id`.
+
 ## Source execution
 
 From the repository root, run `pnpm run build` separately after a fresh checkout and whenever artifacts need updating, then use `pnpm dsh <args...>`. The `package.json` script launches `apps/cli/src/bin.ts` with `node --import tsx/esm` without building and forwards every argument. Missing Typert host artifacts fail profile boot through module-resolution errors without a build instruction. Once those host artifacts exist, missing frontend or client-plugin bundles fail at startup with an instruction to run `pnpm run build`. The launcher does not check freshness, so existing stale bundles can run older browser code until rebuilt. The process inherits the launch environment; set `NODE_USE_ENV_PROXY=1` when a supporting Node version must honor `HTTP_PROXY` and `HTTPS_PROXY`. The installed form launches the built `apps/cli/lib/bin.js` without rebuilding the repository.

--- a/apps/cli/reference/README.zh.md
+++ b/apps/cli/reference/README.zh.md
@@ -79,6 +79,8 @@ dsh web --help
 
 通过 `dsh plugin --profile <name> add <package-or-git-spec>` 安装外部插件组合包。安装的包拥有其依赖，并贡献其声明的 `cordis.patch.yml` 层。CLI 还随附 `@deepseek-ai/dsh-mcp-client` 作为供 patch 层使用的依赖，但默认不启用 MCP 服务器，因为每条服务器命令都是 agent（智能体）沙箱之外的受信任可执行代码。
 
+不要在 profile 自己的 `cordis.patch.yml` 中重复 bundle 的 `insert` 条目：只要包列在 `dsh.profile.bundles` 中，它声明的 patch 层就会自动加入。除非要覆盖已有条目或添加另一个独立条目，否则应将 profile patch 保持为 `[]`；同一个 id 被插入两次会使 Loader 以 `duplicate loader entry id` 拒绝整个 profile。
+
 ## 源码执行
 
 请在仓库根目录中，于全新 checkout 之后及产物需要更新时单独运行 `pnpm run build`，然后使用 `pnpm dsh <args...>`。`package.json` 中的脚本不会构建，而是通过 `node --import tsx/esm` 启动 `apps/cli/src/bin.ts`，并转发所有参数。Typert Host 产物缺失时，profile 启动会因不含构建指引的模块解析错误而失败。这些 Host 产物存在后，如果前端或 Client plugin 组合包缺失，启动会失败并提示运行 `pnpm run build`。启动器不会检查产物是否为最新，因此已有的陈旧组合包可能继续运行旧版浏览器代码，直至重新构建。该进程会继承启动环境；当支持环境代理的 Node 版本必须遵循 `HTTP_PROXY` 和 `HTTPS_PROXY` 时，请设置 `NODE_USE_ENV_PROXY=1`。安装形式会直接启动构建后的 `apps/cli/lib/bin.js`，不会重新构建仓库。


### PR DESCRIPTION
## Summary

- clarify that a package listed in `dsh.profile.bundles` already contributes its declared `cordis.patch.yml`
- warn users not to manually insert the same loader id in the profile patch
- keep the English and Chinese CLI references in sync

This documents the duplicate `token-cost-meter` failure reported in #8.

## Validation

- `pnpm run verify-translation-pairing apps/cli/reference/README.md`
- `git diff --check`
- reproduced the local profile configuration and confirmed the packaged macOS Harness starts its Host after removing the duplicate insert
- the repository pre-push Host build is currently blocked in this checkout by the missing optional tsdown peer `unrun`; no source build files are changed by this docs-only PR