### PR TITLE
fix(desktop): add native edit context menu

### DIFF
--- a/.agents/notes/implemented/bug-fix/2026-08-15-desktop-native-edit-context-menu.i18n.yaml
+++ b/.agents/notes/implemented/bug-fix/2026-08-15-desktop-native-edit-context-menu.i18n.yaml
@@ -1,0 +1,6 @@
+# Bilingual-pair consistency record (docs/i18n/README.md): the git blob hash of each
+# side as of the last confirmed-consistent state. Both languages carry equal authority;
+# after editing either side, bring the other along and re-record with:
+#   pnpm run verify-translation-pairing --write .agents/notes/implemented/bug-fix/2026-08-15-desktop-native-edit-context-menu.md
+2026-08-15-desktop-native-edit-context-menu.md: 722388414a003a4769ac212bdb142f154dd06137
+2026-08-15-desktop-native-edit-context-menu.zh.md: 8ec8b2d9efb06e7b6c6947883e4660adb66ecead

--- a/.agents/notes/implemented/bug-fix/2026-08-15-desktop-native-edit-context-menu.md
+++ b/.agents/notes/implemented/bug-fix/2026-08-15-desktop-native-edit-context-menu.md
@@ -1,0 +1,25 @@
+# Agent Note: Native desktop edit context menu
+
+English | [中文](2026-08-15-desktop-native-edit-context-menu.zh.md)
+
+Status: implemented
+
+## Problem
+
+The desktop application hides its application menu and the reused Web renderer does not provide a context menu. Mouse users therefore cannot discover or invoke standard text editing actions such as paste from an editable field, even though the corresponding keyboard shortcuts remain available.
+
+## Decision
+
+The Electron main process handles the renderer's `context-menu` event and builds an operating-system-native menu from `ContextMenuParams.editFlags`. Editable fields expose undo, redo, cut, copy, paste, delete, and select all with the availability reported by Chromium. Read-only content exposes copy for a non-empty selection and select all when Chromium permits it.
+
+The menu uses Electron roles, so edit commands target the focused renderer frame without a preload bridge or additional renderer permissions. Link, media, download, navigation, and developer actions remain outside this text-editing menu.
+
+## Alternatives considered
+
+**Build a custom menu in the Web renderer.** This would duplicate platform menu behavior and require Web UI state, styling, accessibility, and layering work for a desktop-only capability.
+
+**Restore a visible application Edit menu.** A global menu would make the commands available but would not satisfy the pointer-local interaction requested by desktop users, and it would change the intentionally hidden application chrome.
+
+## Consequences
+
+Desktop users receive familiar pointer access to text editing while the renderer remains isolated and sandboxed. The menu deliberately follows Chromium's edit availability, so an action that cannot apply stays disabled or absent. Unit tests pin menu composition independently from Electron window startup; packaged interaction remains covered by platform smoke testing.

--- a/.agents/notes/implemented/bug-fix/2026-08-15-desktop-native-edit-context-menu.zh.md
+++ b/.agents/notes/implemented/bug-fix/2026-08-15-desktop-native-edit-context-menu.zh.md
@@ -1,0 +1,25 @@
+# Agent Note: 桌面端原生编辑右键菜单
+
+[English](2026-08-15-desktop-native-edit-context-menu.md) | 中文
+
+Status: implemented
+
+## Problem
+
+桌面应用隐藏了应用菜单，复用的 Web renderer 也没有提供右键菜单。因此，尽管相应键盘快捷键仍然可用，鼠标用户无法在可编辑字段中发现或调用粘贴等标准文本编辑操作。
+
+## Decision
+
+Electron 主进程处理 renderer 的 `context-menu` 事件，并根据 `ContextMenuParams.editFlags` 构建操作系统原生菜单。可编辑字段提供撤销、重做、剪切、复制、粘贴、删除和全选，各操作是否可用由 Chromium 报告。只读内容在存在非空选区时提供复制，并在 Chromium 允许时提供全选。
+
+该菜单使用 Electron role，使编辑命令直接作用于获得焦点的 renderer frame，无需 preload bridge 或额外的 renderer 权限。链接、媒体、下载、导航和开发者操作不纳入这个文本编辑菜单。
+
+## Alternatives considered
+
+**在 Web renderer 中构建自定义菜单。** 这会重复实现各平台菜单行为，并为桌面端专用功能引入 Web UI 状态、样式、无障碍和层叠管理工作。
+
+**恢复可见的应用“编辑”菜单。** 全局菜单可以提供这些命令，但无法满足桌面用户所需的指针就地交互，而且会改变项目刻意隐藏的应用外观。
+
+## Consequences
+
+桌面用户可以通过熟悉的指针操作使用文本编辑功能，同时 renderer 继续保持隔离和沙箱化。菜单严格遵循 Chromium 报告的编辑可用性，因此无法执行的操作会保持禁用或不出现。单元测试在不启动 Electron 窗口的情况下固定菜单组成；打包后的交互仍由各平台冒烟测试覆盖。

--- a/apps/desktop/README.i18n.yaml
+++ b/apps/desktop/README.i18n.yaml
@@ -2,5 +2,5 @@
 # side as of the last confirmed-consistent state. Both languages carry equal authority;
 # after editing either side, bring the other along and re-record with:
 #   pnpm run verify-translation-pairing --write apps/desktop/README.md
-README.md: aa83348f84b2282dfad6e3f8dafe4c152f2a6078
-README.zh.md: 3e797b0d477aa164443032a1720939bea76a7457
+README.md: 1472b8557ce924f0ada7b745d7e485191d6c08da
+README.zh.md: 94f7502c882ef9b8c59fec61c6902d7dd20d5f41

--- a/apps/desktop/README.md
+++ b/apps/desktop/README.md
@@ -16,6 +16,8 @@ Closing the window hides it. Use the tray menu to restore the window or quit the
 
 The desktop app accepts only the readiness URL emitted by `dsh web` for `127.0.0.1` or `localhost`. Navigation stays on that origin; HTTP and HTTPS links open in the system browser.
 
+Editable fields expose the operating system's native context menu for undo, redo, cut, copy, paste, delete, and select all. Selected read-only text exposes copy and select all without granting renderer permissions.
+
 Native chrome follows the host platform. macOS uses a frameless inset title bar, traffic lights, and sidebar vibrancy; its collapsed sidebar is 90px wide, with centered controls whose top edge aligns with the expanded logo row below the traffic lights. Windows retains its system frame, shadow, resize and Snap behavior, and Windows 11 rounded corners while a hidden title bar places the native caption buttons in the Session header's first row; the Windows sidebar has no traffic-light inset. The empty part of that row remains draggable, its controls remain clickable, and a resident drag band covers the same row when no Session header is visible. Windows acrylic and macOS vibrancy reach only the sidebar, while conversation and details stay opaque. Linux keeps a frameless window and an opaque sidebar fallback.
 
 ## Packaging

--- a/apps/desktop/README.zh.md
+++ b/apps/desktop/README.zh.md
@@ -16,6 +16,8 @@ pnpm run dev:desktop
 
 桌面应用只接受 `dsh web` 为 `127.0.0.1` 或 `localhost` 输出的就绪 URL。页面导航限制在该来源；HTTP 和 HTTPS 链接交给系统浏览器打开。
 
+可编辑字段提供操作系统原生右键菜单，包含撤销、重做、剪切、复制、粘贴、删除和全选。选中只读文本时提供复制和全选，且无需向 renderer 授予权限。
+
 原生窗口外观按宿主平台区分。macOS 使用无边框内嵌标题栏、交通灯和侧栏 vibrancy；收起侧栏宽 90px，其中的控件水平居中，最上方控件在交通灯下方与展开态 logo 行对齐。Windows 保留系统边框、阴影、缩放与 Snap 行为以及 Windows 11 圆角，同时用隐藏标题栏把原生窗口按钮放入 Session header 首行；Windows 侧栏不预留交通灯区域。该行的空白部分可拖动，控件仍可点击；没有 Session header 时，常驻拖拽带覆盖同一行。Windows acrylic 和 macOS vibrancy 只透过侧栏，会话区与详情区保持不透明。Linux 使用无边框窗口和不透明侧栏降级样式。
 
 ## 打包

--- a/apps/desktop/src/context-menu.ts
+++ b/apps/desktop/src/context-menu.ts
@@ -1,0 +1,40 @@
+/** Native edit-menu composition for the desktop renderer. */
+
+import type { ContextMenuParams, MenuItemConstructorOptions } from 'electron'
+
+/** Renderer state used to decide which native edit actions are available. */
+export type DesktopContextMenuParams = Pick<ContextMenuParams, 'editFlags' | 'isEditable' | 'selectionText'>
+
+/**
+ * Build the native edit menu for the renderer context under the pointer.
+ *
+ * @param params - Renderer editability, selection, and action availability.
+ * @returns Native menu items, or an empty list when the page has no relevant text action.
+ */
+export function createDesktopContextMenuTemplate(
+  params: DesktopContextMenuParams,
+): MenuItemConstructorOptions[] {
+  if (params.isEditable) {
+    return [
+      { role: 'undo', enabled: params.editFlags.canUndo },
+      { role: 'redo', enabled: params.editFlags.canRedo },
+      { type: 'separator' },
+      { role: 'cut', enabled: params.editFlags.canCut },
+      { role: 'copy', enabled: params.editFlags.canCopy },
+      { role: 'paste', enabled: params.editFlags.canPaste },
+      { role: 'delete', enabled: params.editFlags.canDelete },
+      { type: 'separator' },
+      { role: 'selectAll', enabled: params.editFlags.canSelectAll },
+    ]
+  }
+
+  const template: MenuItemConstructorOptions[] = []
+  if (params.selectionText.length > 0) {
+    template.push({ role: 'copy', enabled: params.editFlags.canCopy })
+  }
+  if (params.editFlags.canSelectAll) {
+    if (template.length > 0) template.push({ type: 'separator' })
+    template.push({ role: 'selectAll' })
+  }
+  return template
+}

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -16,6 +16,7 @@ import {
   type MenuItemConstructorOptions,
 } from 'electron'
 import { createHostSupervisor, spawnDshWeb, type HostSupervisor } from './host-supervisor.ts'
+import { createDesktopContextMenuTemplate } from './context-menu.ts'
 import { createDesktopLifecycle, type DesktopLifecycle } from './window-lifecycle.ts'
 
 const APP_NAME = 'DeepSeek Harness'
@@ -148,6 +149,15 @@ async function createMainWindow(): Promise<BrowserWindow> {
   window.webContents.setWindowOpenHandler(({ url }) => {
     if (isExternalUrl(url)) void shell.openExternal(url)
     return { action: 'deny' }
+  })
+  window.webContents.on('context-menu', (_event, params) => {
+    const template = createDesktopContextMenuTemplate(params)
+    if (template.length === 0) return
+    Menu.buildFromTemplate(template).popup({
+      window,
+      ...(params.frame === null ? {} : { frame: params.frame }),
+      sourceType: params.menuSourceType,
+    })
   })
   const rendererUrl = new URL(origin)
   rendererUrl.searchParams.set('dsh-desktop-platform', process.platform)

--- a/apps/desktop/tests/context-menu.spec.ts
+++ b/apps/desktop/tests/context-menu.spec.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from 'vitest'
+import {
+  createDesktopContextMenuTemplate,
+  type DesktopContextMenuParams,
+} from '../src/context-menu.ts'
+
+function context(
+  overrides: Partial<DesktopContextMenuParams> = {},
+): DesktopContextMenuParams {
+  return {
+    isEditable: false,
+    selectionText: '',
+    editFlags: {
+      canUndo: false,
+      canRedo: false,
+      canCut: false,
+      canCopy: false,
+      canPaste: false,
+      canDelete: false,
+      canSelectAll: false,
+      canEditRichly: false,
+    },
+    ...overrides,
+  }
+}
+
+describe('desktop context menu', () => {
+  it('exposes native edit roles with renderer-provided availability', () => {
+    const template = createDesktopContextMenuTemplate(context({
+      isEditable: true,
+      editFlags: {
+        canUndo: true,
+        canRedo: false,
+        canCut: true,
+        canCopy: true,
+        canPaste: true,
+        canDelete: true,
+        canSelectAll: true,
+        canEditRichly: false,
+      },
+    }))
+
+    expect(template).toEqual([
+      { role: 'undo', enabled: true },
+      { role: 'redo', enabled: false },
+      { type: 'separator' },
+      { role: 'cut', enabled: true },
+      { role: 'copy', enabled: true },
+      { role: 'paste', enabled: true },
+      { role: 'delete', enabled: true },
+      { type: 'separator' },
+      { role: 'selectAll', enabled: true },
+    ])
+  })
+
+  it('offers copy and select-all for selected read-only text', () => {
+    const template = createDesktopContextMenuTemplate(context({
+      selectionText: 'selected output',
+      editFlags: {
+        canUndo: false,
+        canRedo: false,
+        canCut: false,
+        canCopy: true,
+        canPaste: false,
+        canDelete: false,
+        canSelectAll: true,
+        canEditRichly: false,
+      },
+    }))
+
+    expect(template).toEqual([
+      { role: 'copy', enabled: true },
+      { type: 'separator' },
+      { role: 'selectAll' },
+    ])
+  })
+
+  it('keeps a read-only copy action disabled when the renderer rejects it', () => {
+    const template = createDesktopContextMenuTemplate(context({
+      selectionText: 'selected output',
+    }))
+
+    expect(template).toEqual([{ role: 'copy', enabled: false }])
+  })
+
+  it('offers select-all without a leading separator', () => {
+    const template = createDesktopContextMenuTemplate(context({
+      editFlags: {
+        canUndo: false,
+        canRedo: false,
+        canCut: false,
+        canCopy: false,
+        canPaste: false,
+        canDelete: false,
+        canSelectAll: true,
+        canEditRichly: false,
+      },
+    }))
+
+    expect(template).toEqual([{ role: 'selectAll' }])
+  })
+
+  it('stays silent when read-only content has no text action', () => {
+    expect(createDesktopContextMenuTemplate(context())).toEqual([])
+  })
+})


### PR DESCRIPTION
Fixes #12

<details>
<summary>变更与验证</summary>

* 根因：Desktop 隐藏应用菜单，复用的 Web renderer 也没有处理右键菜单，因此输入框只能通过键盘快捷键执行粘贴等编辑操作。
* 变更：Electron 主进程监听 `context-menu`，为可编辑字段提供系统原生的撤销、重做、剪切、复制、粘贴、删除和全选；只读文本选区提供复制与全选。
* 安全：菜单使用 Electron role 作用于当前 renderer frame，不增加 preload bridge，不放宽 `contextIsolation`、sandbox 或剪贴板权限策略。
* 验证：`pnpm exec vitest run apps/desktop/tests/context-menu.spec.ts --coverage --coverage.include='apps/desktop/src/context-menu.ts'`，5 个用例通过，语句/分支/函数/行覆盖率均为 100%。
* 验证：Desktop typecheck、全仓 oxlint、Agent Note/Markdown/本次双语配对检查与 `git diff --check` 均通过。
* 环境说明：全量 `doc-sync` 在当前 Linux checkout 被缺失的 `node-pty` 原生模块阻断；全量双语扫描另会命中 `master` 已存在的根目录 `README.md` 伴随记录失配，本 PR 未修改该组文件。

</details>
