### PR TITLE
fix(desktop): preserve Host runtime logs

### DIFF
--- a/.agents/notes/implemented/bug-fix/2026-08-15-preserve-desktop-host-runtime-output.i18n.yaml
+++ b/.agents/notes/implemented/bug-fix/2026-08-15-preserve-desktop-host-runtime-output.i18n.yaml
@@ -1,0 +1,6 @@
+# Bilingual-pair consistency record (docs/i18n/README.md): the git blob hash of each
+# side as of the last confirmed-consistent state. Both languages carry equal authority;
+# after editing either side, bring the other along and re-record with:
+#   pnpm run verify-translation-pairing --write .agents/notes/implemented/bug-fix/2026-08-15-preserve-desktop-host-runtime-output.md
+2026-08-15-preserve-desktop-host-runtime-output.md: 0e3f8871a7d4a5f5c3ced490bd06f2bcea47c0d5
+2026-08-15-preserve-desktop-host-runtime-output.zh.md: a235e2d12f6b00fc87616464c7e225f46c0dc510

--- a/.agents/notes/implemented/bug-fix/2026-08-15-preserve-desktop-host-runtime-output.md
+++ b/.agents/notes/implemented/bug-fix/2026-08-15-preserve-desktop-host-runtime-output.md
@@ -1,0 +1,25 @@
+# Agent Note: Preserve desktop Host runtime output
+
+Status: implemented
+
+English | [中文](2026-08-15-preserve-desktop-host-runtime-output.zh.md)
+
+## Problem
+
+The desktop supervisor recognizes the loopback URL from a canonical Host stdout line, then resolves startup. The same readiness cleanup also detached the stdout and stderr data subscriptions. Node readable streams remain flowing when their data listeners are removed, so every later Host chunk was discarded instead of reaching desktop diagnostics. Runtime warnings and failure details became invisible after startup, leaving only an eventual exit code and signal.
+
+## Decision
+
+The supervisor keeps both Host output subscriptions for the lifetime of their streams. Every stdout and stderr chunk reaches the configured diagnostic callback. The stdout handler consults the readiness parser only until startup settles, and readiness cleanup owns only the timeout. The bounded recent-output tail remains available for startup-failure messages.
+
+## Alternatives considered
+
+**Stop consuming output after readiness.** Rejected because the Host is a desktop-owned child process and its warnings and errors are the primary diagnostics for failures that occur after startup.
+
+**Keep forwarding stdout through the readiness parser.** Rejected because a later log line that resembles a different readiness URL must not turn ordinary runtime output into a conflicting-startup failure or terminate an already-ready Host.
+
+**Persist Host output to a dedicated log file.** Deferred because persistence requires retention, rotation, and privacy decisions. Preserving the existing diagnostic callback fixes the loss without adding a durable artifact.
+
+## Consequences
+
+Host output remains observable through the desktop process for the entire run, while readiness still accepts exactly the first valid loopback URL. High-volume Host output reaches the existing diagnostic sink, but the supervisor's retained startup-failure context stays bounded. Unit coverage pins stdout and stderr forwarding after readiness and proves that later readiness-shaped output is logged without being parsed again.

--- a/.agents/notes/implemented/bug-fix/2026-08-15-preserve-desktop-host-runtime-output.zh.md
+++ b/.agents/notes/implemented/bug-fix/2026-08-15-preserve-desktop-host-runtime-output.zh.md
@@ -1,0 +1,25 @@
+# Agent Note: 保留桌面 Host 运行期输出
+
+Status: implemented
+
+[English](2026-08-15-preserve-desktop-host-runtime-output.md) | 中文
+
+## Problem
+
+桌面端 supervisor 从 Host 的规范 stdout 行识别回环 URL，随后完成启动。相同的就绪清理还会解除 stdout 与 stderr 的数据订阅。移除数据监听器后，Node 可读流仍保持流动，因此此后的每个 Host 分片都会被丢弃，无法进入桌面端诊断。运行时警告和失败详情在启动后不可见，最终只剩退出码与信号。
+
+## Decision
+
+supervisor 在两条 Host 输出流的整个生命周期内保留订阅。每个 stdout 和 stderr 分片都会进入已配置的诊断回调。stdout 处理器只在启动结算前查询就绪解析器，就绪清理只负责超时计时器。有界的近期输出尾段继续用于启动失败消息。
+
+## Alternatives considered
+
+**就绪后停止消费输出。** 拒绝，因为 Host 是桌面端自有子进程，其警告与错误是诊断启动后故障的主要信息。
+
+**继续让 stdout 经过就绪解析器。** 拒绝，因为此后类似另一个就绪 URL 的日志行不能把普通运行时输出变成启动冲突，也不能终止已经就绪的 Host。
+
+**把 Host 输出持久化到专用日志文件。** 暂缓，因为持久化需要确定保留、轮转与隐私策略。保留现有诊断回调即可修复输出丢失，同时不增加持久产物。
+
+## Consequences
+
+Host 输出在整个运行期间都可通过桌面进程观察，而就绪流程仍只接受第一个有效回环 URL。高吞吐 Host 输出会进入现有诊断接收端，但 supervisor 为启动失败保留的上下文仍有界。单元覆盖固定了就绪后的 stdout 与 stderr 转发，并证明后续形似就绪信息的输出只会被记录，不会再次解析。

--- a/apps/desktop/README.i18n.yaml
+++ b/apps/desktop/README.i18n.yaml
@@ -2,5 +2,5 @@
 # side as of the last confirmed-consistent state. Both languages carry equal authority;
 # after editing either side, bring the other along and re-record with:
 #   pnpm run verify-translation-pairing --write apps/desktop/README.md
-README.md: aa83348f84b2282dfad6e3f8dafe4c152f2a6078
-README.zh.md: 3e797b0d477aa164443032a1720939bea76a7457
+README.md: aac56570c63a789314802548c629473b3fd835ed
+README.zh.md: 20ca4e2f5669fd9efd469c8d237b1d8f4e6f585f

--- a/apps/desktop/README.md
+++ b/apps/desktop/README.md
@@ -14,6 +14,8 @@ pnpm run dev:desktop
 
 Closing the window hides it. Use the tray menu to restore the window or quit the application. Explicit quit waits for the Host process to stop and escalates termination after the bounded Host grace period.
 
+Host stdout and stderr remain connected to desktop diagnostics after readiness, so runtime warnings and failure details stay visible. The supervisor retains only a bounded recent output tail for startup failures.
+
 The desktop app accepts only the readiness URL emitted by `dsh web` for `127.0.0.1` or `localhost`. Navigation stays on that origin; HTTP and HTTPS links open in the system browser.
 
 Native chrome follows the host platform. macOS uses a frameless inset title bar, traffic lights, and sidebar vibrancy; its collapsed sidebar is 90px wide, with centered controls whose top edge aligns with the expanded logo row below the traffic lights. Windows retains its system frame, shadow, resize and Snap behavior, and Windows 11 rounded corners while a hidden title bar places the native caption buttons in the Session header's first row; the Windows sidebar has no traffic-light inset. The empty part of that row remains draggable, its controls remain clickable, and a resident drag band covers the same row when no Session header is visible. Windows acrylic and macOS vibrancy reach only the sidebar, while conversation and details stay opaque. Linux keeps a frameless window and an opaque sidebar fallback.

--- a/apps/desktop/README.zh.md
+++ b/apps/desktop/README.zh.md
@@ -14,6 +14,8 @@ pnpm run dev:desktop
 
 关闭窗口会隐藏窗口。通过托盘菜单恢复窗口或退出应用。显式退出会等待 Host 进程停止，并在 Host 的有界宽限期结束后升级终止行为。
 
+Host 就绪后，stdout 与 stderr 仍会接入桌面端诊断，因此运行时警告和失败详情保持可见。supervisor 只为启动失败保留有界的近期输出尾段。
+
 桌面应用只接受 `dsh web` 为 `127.0.0.1` 或 `localhost` 输出的就绪 URL。页面导航限制在该来源；HTTP 和 HTTPS 链接交给系统浏览器打开。
 
 原生窗口外观按宿主平台区分。macOS 使用无边框内嵌标题栏、交通灯和侧栏 vibrancy；收起侧栏宽 90px，其中的控件水平居中，最上方控件在交通灯下方与展开态 logo 行对齐。Windows 保留系统边框、阴影、缩放与 Snap 行为以及 Windows 11 圆角，同时用隐藏标题栏把原生窗口按钮放入 Session header 首行；Windows 侧栏不预留交通灯区域。该行的空白部分可拖动，控件仍可点击；没有 Session header 时，常驻拖拽带覆盖同一行。Windows acrylic 和 macOS vibrancy 只透过侧栏，会话区与详情区保持不透明。Linux 使用无边框窗口和不透明侧栏降级样式。

--- a/apps/desktop/src/host-supervisor.ts
+++ b/apps/desktop/src/host-supervisor.ts
@@ -105,7 +105,7 @@ export interface HostSupervisorOptions {
   readonly readinessTimeoutMs?: number
   /** Grace after SIGTERM before SIGKILL. */
   readonly shutdownTimeoutMs?: number
-  /** Receives bounded Host output for desktop diagnostics. */
+  /** Receives Host output throughout the child process lifetime. */
   readonly log?: (line: string) => void
   /** Called when a ready Host exits outside an application-owned shutdown. */
   readonly onUnexpectedExit?: (detail: { code: number | null; signal: NodeJS.Signals | null }) => void
@@ -168,27 +168,26 @@ export function createHostSupervisor(options: HostSupervisorOptions): HostSuperv
       exitResult = deferred<void>()
       exited = exitResult.promise
       let settled = false
-      const startupCleanups: Array<() => void> = []
 
-      const cleanupStartup = (): void => {
+      const cleanupReadiness = (): void => {
         clearTimeout(timer)
-        for (const dispose of startupCleanups.splice(0)) dispose()
       }
       const fail = (error: unknown): void => {
         if (settled) return
         settled = true
-        cleanupStartup()
+        cleanupReadiness()
         const diagnostic = output === '' ? '' : `\nHost output:\n${output}`
         reject(new Error(`${error instanceof Error ? error.message : String(error)}${diagnostic}`))
       }
       const acceptChunk = (chunk: string): void => {
         appendOutput(chunk)
+        if (settled) return
         try {
           const url = parser.push(chunk)
-          if (url === undefined || settled) return
+          if (url === undefined) return
           settled = true
           ready = true
-          cleanupStartup()
+          cleanupReadiness()
           resolve(url)
         } catch (error) {
           fail(error)
@@ -200,8 +199,9 @@ export function createHostSupervisor(options: HostSupervisorOptions): HostSuperv
         fail(new Error(`desktop Host readiness timed out after ${String(readinessTimeoutMs)}ms`))
         spawned.kill('SIGTERM')
       }, readinessTimeoutMs)
-      startupCleanups.push(spawned.stdout.onData(acceptChunk))
-      startupCleanups.push(spawned.stderr.onData(appendOutput))
+      // Keep both streams subscribed until they close so runtime diagnostics are not discarded.
+      spawned.stdout.onData(acceptChunk)
+      spawned.stderr.onData(appendOutput)
       spawned.onError((error) => {
         fail(new Error(`desktop Host failed to spawn: ${error.message}`))
         exitResult?.resolve()

--- a/apps/desktop/tests/host-supervisor.spec.ts
+++ b/apps/desktop/tests/host-supervisor.spec.ts
@@ -128,6 +128,28 @@ describe('desktop Host supervisor', () => {
     expect(child.signals).toEqual([])
   })
 
+  it('keeps forwarding Host output after readiness without parsing another readiness URL', async () => {
+    const child = new FakeHostChild()
+    const log = vi.fn<(chunk: string) => void>()
+    const supervisor = createHostSupervisor({ spawnHost: () => child, log })
+    const starting = supervisor.start()
+
+    child.stdout.emit('dsh web: http://127.0.0.1:4567\n')
+    await expect(starting).resolves.toBe('http://127.0.0.1:4567')
+
+    child.stdout.emit('runtime warning\n')
+    child.stderr.emit('runtime failure\n')
+    child.stdout.emit('dsh web: http://127.0.0.1:9999\n')
+
+    expect(log.mock.calls.map(([chunk]) => chunk)).toEqual([
+      'dsh web: http://127.0.0.1:4567\n',
+      'runtime warning\n',
+      'runtime failure\n',
+      'dsh web: http://127.0.0.1:9999\n',
+    ])
+    expect(child.signals).toEqual([])
+  })
+
   it('does not combine stderr and stdout fragments into a readiness line', async () => {
     const child = new FakeHostChild()
     const supervisor = createHostSupervisor({ spawnHost: () => child })


### PR DESCRIPTION
关联 Issue：无（本 PR 由 Desktop 代码审计独立发现）

<details>
<summary>变更与验证</summary>

* 变更：Host supervisor 在 readiness 完成后继续转发 stdout/stderr，让运行期警告与失败详情保持可见；readiness 解析器在首次成功后停止消费协议，避免后续形似 readiness 的日志被误判。同步补充 Desktop 中英 README、Agent Note 三联记录与回归测试。
* 根因：readiness cleanup 同时移除了 stdout/stderr 的 data listener。Node 流继续流动，但后续分片没有消费者，因此桌面诊断只看到启动输出和最终退出码。
* 影响：Desktop 启动后的 Host 日志不再静默丢失；输出继续使用既有诊断回调，不新增持久日志文件。
* 验证：`pnpm run lint`；`pnpm run typecheck:desktop`；`pnpm exec vitest run apps/desktop/tests`（5 files / 45 tests）；两组 scoped translation pairing 与 Agent Note format 均通过。
* 环境基线：`pnpm run doc-sync` 通过 26/28 gates；剩余 tool catalog 因当前环境缺少 `node-pty` 原生模块失败，translation pairing 因 fork 的根 `README.md` 在 master 上已与遗留 `README.zh.md` 记录不同步而失败。本分支未修改这两个失败源。

</details>
