### PR TITLE
fix: Copy button broken in Electron desktop — execCommand fallback missing focus()

### DIFF
--- a/packages/client/ui-primitives/src/clipboard.ts
+++ b/packages/client/ui-primitives/src/clipboard.ts
@@ -3,7 +3,7 @@
 
 /**
  * Write text to the host clipboard, preferring the async Clipboard API and
- * falling back to `execCommand('copy')` on hosts (jsdom, insecure contexts)
+ * falling back to \execCommand('copy')\ on hosts (jsdom, insecure contexts)
  * that omit it.
  * @param text - the exact text to place on the clipboard.
  * @returns true only when the host accepted the write.
@@ -35,6 +35,7 @@ export async function writeClipboard(text: string): Promise<boolean> {
   el.style.position = 'fixed'
   el.style.left = '-9999px'
   document.body.appendChild(el)
+  el.focus() // oxlint-disable-line oxc/no-useless-call — focus required for execCommand('copy') in Electron/insecure contexts
   el.select()
   try {
     return exec('copy')


### PR DESCRIPTION
﻿## Problem

In DeepSeek Harness Desktop (Electron), the copy button on messages does nothing when clicked — no visual feedback at all.

**Symptoms**:
- Hover over a message → copy icon appears
- Click copy icon → nothing happens
- Neither "Copied" confirmation nor error is shown

**Impact**: All Electron desktop users (Windows / macOS / Linux)

## Root Cause

The `writeClipboard` function in `dsh-client-ui-primitives` has two clipboard implementations:

1. `navigator.clipboard.writeText` — unavailable in Electron renderer, fails silently
2. `execCommand('copy')` fallback — missing `focus()` before `select()`, so the selection fails silently

Both paths fail → function returns `false` → no feedback to user.

## Fix

Add `el.focus() before `el.select()` in the `execCommand('copy')` fallback:

`diff
   document.body.appendChild(el)
+  el.focus() // focus required for execCommand('copy') in Electron/insecure contexts
   el.select()
`

## Files Changed

- `packages/client/ui-primitives/src/clipboard.ts`

## Verification

| Environment | Before | After |
|---|---|---|
| Win11 + DSH Desktop | Click no response, paste empty | Shows "Copied", paste correct |
| Chrome browser | Normal (Strategy 1) | Normal (unaffected) |

## Notes

- Does not affect environments where `navigator.clipboard` is available — Strategy 1 still takes priority
- `focus()` is a necessary prerequisite for `execCommand('copy')` in certain contexts
