### PR TITLE
desktop: allow overriding local Host entry / 允许覆盖本地 Host 入口

### DIFF
--- a/apps/desktop/README.i18n.yaml
+++ b/apps/desktop/README.i18n.yaml
@@ -2,5 +2,5 @@
 # side as of the last confirmed-consistent state. Both languages carry equal authority;
 # after editing either side, bring the other along and re-record with:
 #   pnpm run verify-translation-pairing --write apps/desktop/README.md
-README.md: aa83348f84b2282dfad6e3f8dafe4c152f2a6078
-README.zh.md: 3e797b0d477aa164443032a1720939bea76a7457
+README.md: 0faed028e371eaecf0dcc10dce768eb489c6b3df
+README.zh.md: ea0dae241f20c37686e3f16c3fbd5e322d1e7b14

--- a/apps/desktop/README.md
+++ b/apps/desktop/README.md
@@ -16,6 +16,8 @@ Closing the window hides it. Use the tray menu to restore the window or quit the
 
 The desktop app accepts only the readiness URL emitted by `dsh web` for `127.0.0.1` or `localhost`. Navigation stays on that origin; HTTP and HTTPS links open in the system browser.
 
+Set `DSH_DESKTOP_HOST_ENTRY` to the path of a Node-compatible CLI entry when the desktop shell must launch a local Host wrapper or alternative implementation. The desktop shell still appends `web --host 127.0.0.1 --port 0`, validates the emitted loopback URL, and owns the child process lifecycle; without the variable, it launches the built-in DSH CLI.
+
 Native chrome follows the host platform. macOS uses a frameless inset title bar, traffic lights, and sidebar vibrancy; its collapsed sidebar is 90px wide, with centered controls whose top edge aligns with the expanded logo row below the traffic lights. Windows retains its system frame, shadow, resize and Snap behavior, and Windows 11 rounded corners while a hidden title bar places the native caption buttons in the Session header's first row; the Windows sidebar has no traffic-light inset. The empty part of that row remains draggable, its controls remain clickable, and a resident drag band covers the same row when no Session header is visible. Windows acrylic and macOS vibrancy reach only the sidebar, while conversation and details stay opaque. Linux keeps a frameless window and an opaque sidebar fallback.
 
 ## Packaging

--- a/apps/desktop/README.zh.md
+++ b/apps/desktop/README.zh.md
@@ -16,6 +16,8 @@ pnpm run dev:desktop
 
 桌面应用只接受 `dsh web` 为 `127.0.0.1` 或 `localhost` 输出的就绪 URL。页面导航限制在该来源；HTTP 和 HTTPS 链接交给系统浏览器打开。
 
+如果桌面壳需要启动本地 Host 包装器或替代实现，将 `DSH_DESKTOP_HOST_ENTRY` 设为一个兼容 Node 的 CLI 入口路径。桌面壳仍会追加 `web --host 127.0.0.1 --port 0`、校验输出的回环 URL，并持有子进程生命周期；未设置该变量时，应用启动内置 DSH CLI。
+
 原生窗口外观按宿主平台区分。macOS 使用无边框内嵌标题栏、交通灯和侧栏 vibrancy；收起侧栏宽 90px，其中的控件水平居中，最上方控件在交通灯下方与展开态 logo 行对齐。Windows 保留系统边框、阴影、缩放与 Snap 行为以及 Windows 11 圆角，同时用隐藏标题栏把原生窗口按钮放入 Session header 首行；Windows 侧栏不预留交通灯区域。该行的空白部分可拖动，控件仍可点击；没有 Session header 时，常驻拖拽带覆盖同一行。Windows acrylic 和 macOS vibrancy 只透过侧栏，会话区与详情区保持不透明。Linux 使用无边框窗口和不透明侧栏降级样式。
 
 ## 打包

--- a/apps/desktop/src/host-entry.ts
+++ b/apps/desktop/src/host-entry.ts
@@ -1,0 +1,13 @@
+/** Resolve the Node CLI entry launched by the desktop Host supervisor. */
+
+import { resolve } from 'node:path'
+
+/**
+ * Select the built-in Host entry unless deployment configures another path.
+ * @param builtinEntry - Checkout or packaged DSH CLI entry.
+ * @param configuredEntry - Optional Node-compatible CLI entry path.
+ * @returns The absolute configured path or the built-in entry.
+ */
+export function resolveHostEntry(builtinEntry: string, configuredEntry: string | undefined): string {
+  return configuredEntry === undefined ? builtinEntry : resolve(configuredEntry)
+}

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -15,6 +15,7 @@ import {
   type Event,
   type MenuItemConstructorOptions,
 } from 'electron'
+import { resolveHostEntry } from './host-entry.ts'
 import { createHostSupervisor, spawnDshWeb, type HostSupervisor } from './host-supervisor.ts'
 import { createDesktopLifecycle, type DesktopLifecycle } from './window-lifecycle.ts'
 
@@ -32,19 +33,23 @@ let hostOrigin: string | undefined
 let bootQuitPromise: Promise<void> | undefined
 let quitReleased = false
 
-/** Resolve artifacts from the checkout in development and resourcesPath when packaged. */
+/** Resolve artifacts from the checkout or package, with an optional Host entry override. */
 function hostPaths(): { nodeExecutable: string; cliEntry: string; cwd: string; electronRunAsNode: boolean } {
+  const configuredCliEntry = process.env.DSH_DESKTOP_HOST_ENTRY
   if (!app.isPackaged) {
     return {
       nodeExecutable: process.env.DSH_DESKTOP_NODE_EXECUTABLE ?? 'node',
-      cliEntry: join(REPOSITORY_ROOT, 'apps/cli/lib/bin.js'),
+      cliEntry: resolveHostEntry(join(REPOSITORY_ROOT, 'apps/cli/lib/bin.js'), configuredCliEntry),
       cwd: process.cwd(),
       electronRunAsNode: false,
     }
   }
   return {
     nodeExecutable: process.execPath,
-    cliEntry: join(process.resourcesPath, 'host/node_modules/@deepseek-ai/dsh/lib/bin.js'),
+    cliEntry: resolveHostEntry(
+      join(process.resourcesPath, 'host/node_modules/@deepseek-ai/dsh/lib/bin.js'),
+      configuredCliEntry,
+    ),
     cwd: app.getPath('home'),
     electronRunAsNode: true,
   }
@@ -55,7 +60,7 @@ function assertHostArtifacts(paths: ReturnType<typeof hostPaths>): void {
     throw new Error(`desktop Node runtime is missing: ${paths.nodeExecutable}`)
   }
   if (!existsSync(paths.cliEntry)) {
-    throw new Error(`desktop Host entry is missing: ${paths.cliEntry}; run pnpm run build first`)
+    throw new Error(`desktop Host entry is missing: ${paths.cliEntry}`)
   }
 }
 

--- a/apps/desktop/tests/host-entry.spec.ts
+++ b/apps/desktop/tests/host-entry.spec.ts
@@ -1,0 +1,13 @@
+import { resolve } from 'node:path'
+import { describe, expect, it } from 'vitest'
+import { resolveHostEntry } from '../src/host-entry.ts'
+
+describe('desktop Host entry', () => {
+  it('uses the built-in entry by default', () => {
+    expect(resolveHostEntry('/app/dsh/lib/bin.js', undefined)).toBe('/app/dsh/lib/bin.js')
+  })
+
+  it('resolves the configured entry against the launch directory', () => {
+    expect(resolveHostEntry('/app/dsh/lib/bin.js', 'wrappers/dsh.js')).toBe(resolve('wrappers/dsh.js'))
+  })
+})


### PR DESCRIPTION
## English

### What changed

- Add `DSH_DESKTOP_HOST_ENTRY` so the desktop shell can launch a Node-compatible local Host wrapper or alternative CLI entry.
- Keep the bundled `@deepseek-ai/dsh` CLI as the default.
- Keep `web --host 127.0.0.1 --port 0`, readiness validation, BrowserWindow origin policy, and child-process lifecycle under Desktop ownership.
- Resolve a configured relative path against the Desktop launch directory and report a missing entry before spawning.
- Document the option in both Desktop READMEs and cover default/configured entry selection with unit tests.

### Why

Desktop currently selects the bundled DSH CLI directly in `hostPaths()`. The lower-level Host supervisor already accepts an explicit `cliEntry`, so local wrappers such as instrumentation or compatibility launchers can participate without changing the network or lifecycle model.

This is intentionally not a remote backend URL, a configurable shell command, or a change to the loopback security policy.

### Validation

- `pnpm exec vitest run apps/desktop/tests/host-entry.spec.ts apps/desktop/tests/host-supervisor.spec.ts` - 22 tests passed
- `pnpm --filter @deepseek-ai/dsh-desktop run typecheck`
- `pnpm --filter @deepseek-ai/dsh-desktop run build`
- `pnpm run lint`
- `pnpm run verify-translation-pairing apps/desktop/README.md`
- Pre-commit and pre-push hooks passed

`pnpm run doc-sync` completed 27 of 28 gates. Its only failure is the existing root `README.md` translation-pairing mismatch on `master`; this branch does not modify `README.md`, `README.zh.md`, or `README.i18n.yaml`.

---

## 中文

### 改动内容

- 增加 `DSH_DESKTOP_HOST_ENTRY`，允许桌面壳启动兼容 Node 的本地 Host 包装器或替代 CLI 入口。
- 默认行为不变，仍然启动内置的 `@deepseek-ai/dsh` CLI。
- `web --host 127.0.0.1 --port 0`、就绪 URL 校验、BrowserWindow 同源策略和子进程生命周期仍由 Desktop 统一持有。
- 自定义相对路径会基于 Desktop 启动目录解析；入口不存在时会在创建子进程前明确报错。
- 同步更新 Desktop 中英文 README，并用单元测试覆盖默认入口和自定义入口。

### 原因

Desktop 当前在 `hostPaths()` 中直接选择内置 DSH CLI，而下层 Host supervisor 已经接受独立的 `cliEntry`。这个小型配置点让检测工具或兼容启动器等本地包装器可以接入，同时不改变现有网络模型和生命周期。

这不是远程后端 URL、可配置 shell command，也不会放宽回环地址安全策略。

### 验证

- `pnpm exec vitest run apps/desktop/tests/host-entry.spec.ts apps/desktop/tests/host-supervisor.spec.ts` - 22 项测试通过
- `pnpm --filter @deepseek-ai/dsh-desktop run typecheck`
- `pnpm --filter @deepseek-ai/dsh-desktop run build`
- `pnpm run lint`
- `pnpm run verify-translation-pairing apps/desktop/README.md`
- pre-commit 和 pre-push hooks 通过

`pnpm run doc-sync` 的 28 项检查中有 27 项通过。唯一失败是 `master` 已存在的根目录 `README.md` 双语配对记录不同步；本分支没有修改 `README.md`、`README.zh.md` 或 `README.i18n.yaml`。
