### PR TITLE
fix(ci): guard upstream issue lifecycle automation

### DIFF
--- a/.github/workflows/issue-lifecycle.yml
+++ b/.github/workflows/issue-lifecycle.yml
@@ -45,6 +45,7 @@ jobs:
           ref: ${{ github.event.repository.default_branch }}
           persist-credentials: false
       - name: Create project token
+        if: ${{ github.repository == 'deepseek-harness/deepseek-harness' }}
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1
         with:
@@ -53,6 +54,7 @@ jobs:
           owner: deepseek-harness
           repositories: deepseek-harness
       - name: Handle repository event
+        if: ${{ github.repository == 'deepseek-harness/deepseek-harness' }}
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: node .github/issue-management/policy.mjs lifecycle


### PR DESCRIPTION
## Summary

Guard the upstream-only issue lifecycle steps so they only run in `deepseek-harness/deepseek-harness`.

The desktop repository inherits this workflow, but the token creation and lifecycle handling target the upstream repository and its GitHub App configuration. As a result, issue events here can trigger a workflow that cannot complete successfully.

## Change

Add a repository check to:

- `Create project token`
- `Handle repository event`

Upstream behavior remains unchanged; downstream forks/repos simply skip these upstream-specific steps.