### PR TITLE
fix(desktop): make built-in copy buttons work in the desktop app

### DIFF
--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -91,7 +91,18 @@ function hasOrigin(raw: string, expected: string): boolean {
 function hardenSession(): void {
   const desktopSession = session.defaultSession
   desktopSession.setPermissionCheckHandler(() => false)
-  desktopSession.setPermissionRequestHandler((_webContents, _permission, callback) => { callback(false) })
+  // The Web GUI's copy controls use `navigator.clipboard.writeText`, which
+  // Electron gates through the permission REQUEST handler under the
+  // `clipboard-sanitized-write` permission. Auto-denying it (as this policy
+  // does for everything else) silently breaks every built-in copy button:
+  // the write is rejected with NotAllowedError and no fallback runs. Only the
+  // app's own loopback origin can ever load in this session (will-navigate
+  // blocks every other origin), so granting this one benign, user-gesture-bound
+  // clipboard write cannot be reached by third-party content; everything else
+  // stays denied.
+  desktopSession.setPermissionRequestHandler((_webContents, permission, callback) => {
+    callback(permission === 'clipboard-sanitized-write')
+  })
 }
 
 async function createMainWindow(): Promise<BrowserWindow> {

--- a/packages/client/ui-primitives/src/clipboard.ts
+++ b/packages/client/ui-primitives/src/clipboard.ts
@@ -3,8 +3,9 @@
 
 /**
  * Write text to the host clipboard, preferring the async Clipboard API and
- * falling back to `execCommand('copy')` on hosts (jsdom, insecure contexts)
- * that omit it.
+ * falling back to `execCommand('copy')` on hosts that omit it (jsdom,
+ * insecure contexts) or that keep it but refuse the write (Electron sessions
+ * that deny the `clipboard-sanitized-write` permission).
  * @param text - the exact text to place on the clipboard.
  * @returns true only when the host accepted the write.
  */
@@ -17,13 +18,15 @@ export async function writeClipboard(text: string): Promise<boolean> {
       await navigator.clipboard.writeText(text)
       return true
     } catch {
-      // Denied permissions / iframe policy — do not claim success.
-      return false
+      // Denied permissions / iframe policy — do not give up yet: the
+      // synchronous path below is still honored on a user gesture by hosts
+      // (like hardened Electron sessions) whose async API is denied.
     }
   }
-  // jsdom and older hosts: best-effort execCommand path when present.
-  // execCommand('copy') is the only clipboard fallback where the async API
-  // is missing; deprecated but deliberately retained.
+  // jsdom, older hosts and permission-denied sessions: best-effort execCommand
+  // path when present. execCommand('copy') is the only clipboard fallback
+  // where the async API is missing or refused; deprecated but deliberately
+  // retained.
   /* oxlint-disable typescript/no-deprecated */
   const exec = typeof document.execCommand === 'function'
     ? document.execCommand.bind(document)

--- a/packages/client/ui-primitives/tests/terminal-block.client.spec.tsx
+++ b/packages/client/ui-primitives/tests/terminal-block.client.spec.tsx
@@ -384,6 +384,26 @@ describe('writeClipboard', () => {
     await expect(writeClipboard('payload')).resolves.toBe(false)
   })
 
+  it('falls back to execCommand when the Clipboard API rejects but execCommand accepts', async () => {
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: { writeText: vi.fn().mockRejectedValue(new Error('denied')) },
+    })
+    Object.defineProperty(document, 'execCommand', { configurable: true, value: vi.fn(() => true) })
+    await expect(writeClipboard('payload')).resolves.toBe(true)
+    expect(document.execCommand).toHaveBeenCalledWith('copy')
+  })
+
+  it('reports false when both the Clipboard API and execCommand refuse', async () => {
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: { writeText: vi.fn().mockRejectedValue(new Error('denied')) },
+    })
+    Object.defineProperty(document, 'execCommand', { configurable: true, value: vi.fn(() => false) })
+    await expect(writeClipboard('payload')).resolves.toBe(false)
+    expect(document.querySelector('textarea')).toBeNull()
+  })
+
   it('selects a detached textarea for the execCommand fallback and removes it after', async () => {
     Object.defineProperty(navigator, 'clipboard', { configurable: true, value: undefined })
     let selected: string | undefined


### PR DESCRIPTION
## Summary

The packaged desktop app (Electron 43) silently breaks **every** built-in copy button in the Web GUI (code blocks, terminal blocks, read blocks, JSON tree, search blocks). Clicking "复制" does nothing — no clipboard write, no "复制成功" feedback.

## Root cause

`apps/desktop/src/main.ts` `hardenSession()` auto-denies **all** permissions through `setPermissionRequestHandler`, including `clipboard-sanitized-write`. `navigator.clipboard.writeText` (used by all copy controls via `writeClipboard`) is gated through that request handler in Electron, so the write is rejected with `NotAllowedError` and the copy silently fails.

Verified with Electron 43.4.0 (the packaged version): with `callback(false)` for every permission, `navigator.clipboard.writeText` → `ERR NotAllowedError: Write permission denied`; the same call succeeds once `clipboard-sanitized-write` is granted in the request handler.

## Fix (two layers)

1. **`apps/desktop/src/main.ts`** — grant only `clipboard-sanitized-write` in the permission request handler. Only the app's own loopback origin can ever load in this session (`will-navigate` blocks every other origin), so the grant cannot be reached by third-party content; all other permissions stay denied.
2. **`packages/client/ui-primitives/src/clipboard.ts`** — when the async Clipboard API exists but rejects the write, fall through to the `execCommand('copy')` path instead of giving up. `execCommand('copy')` on a user gesture is still honored by hardened Electron sessions whose async API is denied, so the copy controls keep working even in shells that haven't shipped the shell-side change yet.

Tests: added cases pinning the new fallback contract in `terminal-block.client.spec.tsx`.

## Verification

- `navigator.clipboard.writeText` succeeds under the new permission policy.
- With the old deny-everything policy + the new `writeClipboard`, the copy control still copies via the `execCommand` fallback.
- Native selection copy (Cmd+C / Edit menu Copy) is unaffected and works in both policies.