### PR TITLE
feat: add multi-platform build automation with GitHub Actions

### DIFF
--- a/.github/workflows/build-all.yml
+++ b/.github/workflows/build-all.yml
@@ -1,0 +1,135 @@
+name: Build All Platforms
+
+on:
+  push:
+    branches: [master, main]
+    tags:
+      - 'v*'
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+env:
+  DSH_TELEMETRY_DISABLED: '1'
+
+jobs:
+  build-linux:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+          submodules: recursive
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+
+      - name: Enable Corepack
+        run: corepack enable
+
+      - name: Install dependencies
+        run: yarn install --immutable
+
+      - name: Build Linux AppImage
+        run: yarn dist:linux
+
+      - name: Upload Linux AppImage
+        uses: actions/upload-artifact@v4
+        with:
+          name: DSH-Desktop-Linux
+          path: dsh-plugin-desktop/dist/*.AppImage
+          retention-days: 90
+
+      - name: Upload to Release (on tag)
+        if: startsWith(github.ref, 'refs/tags/v')
+        uses: softprops/action-gh-release@v1
+        with:
+          files: dsh-plugin-desktop/dist/*.AppImage
+          draft: false
+          prerelease: false
+
+  build-windows:
+    runs-on: windows-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+          submodules: recursive
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+
+      - name: Enable Corepack
+        run: corepack enable
+
+      - name: Install dependencies
+        run: yarn install --immutable
+
+      - name: Build Windows
+        run: yarn dist:win
+
+      - name: Upload Windows Installer
+        uses: actions/upload-artifact@v4
+        with:
+          name: DSH-Desktop-Windows
+          path: dsh-plugin-desktop/dist/*.exe
+          retention-days: 90
+
+      - name: Upload to Release (on tag)
+        if: startsWith(github.ref, 'refs/tags/v')
+        uses: softprops/action-gh-release@v1
+        with:
+          files: dsh-plugin-desktop/dist/*.exe
+          draft: false
+          prerelease: false
+
+  build-macos:
+    runs-on: macos-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+          submodules: recursive
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+
+      - name: Enable Corepack
+        run: corepack enable
+
+      - name: Install dependencies
+        run: yarn install --immutable
+
+      - name: Build macOS
+        run: |
+          yarn workspace dsh-plugin-desktop build
+          cd dsh-plugin-desktop
+          npx electron-builder --mac dmg --publish never
+        env:
+          CSC_IDENTITY_AUTO_DISCOVERY: false
+
+      - name: Upload macOS DMG
+        uses: actions/upload-artifact@v4
+        with:
+          name: DSH-Desktop-macOS
+          path: dsh-plugin-desktop/dist/*.dmg
+          retention-days: 90
+
+      - name: Upload to Release (on tag)
+        if: startsWith(github.ref, 'refs/tags/v')
+        uses: softprops/action-gh-release@v1
+        with:
+          files: dsh-plugin-desktop/dist/*.dmg
+          draft: false
+          prerelease: false

--- a/README.en.md
+++ b/README.en.md
@@ -7,7 +7,7 @@
   <img src="https://img.shields.io/badge/Desktop-App-47848F?style=flat" alt="Desktop application">
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-2EA44F?style=flat" alt="MIT License"></a>
   <a href="https://discord.gg/TJeGqKRNM"><img src="https://img.shields.io/badge/Discord-5865F2?style=flat&amp;logo=discord&amp;logoColor=white" alt="Join Discord"></a>
-  <img src="https://img.shields.io/badge/macOS%20%7C%20Windows-4493F8?style=flat-square" alt="Supported platforms: macOS and Windows">
+  <img src="https://img.shields.io/badge/macOS%20%7C%20Windows%20%7C%20Linux-4493F8?style=flat-square" alt="Supported platforms: macOS, Windows and Linux">
 </p>
 
 <p align="center"><sub><a href="README.md">中文</a> · English</sub></p>
@@ -16,7 +16,7 @@
 
 <a id="run"></a>
 
-<h3 align="center"><a href="https://www.deepseekdesktop.com"><ins>Download Desktop</ins></a></h3>
+<h3 align="center"><a href="https://www.deepseekdesktop.com"><ins>Download Desktop</ins></a> · <a href="https://github.com/ziyuliu258/deepseek-harness-desktop-extended-for-linux/releases"><ins>Linux AppImage</ins></a></h3>
 
 <p align="center">
   <img src="assets/desktop-preview.png" alt="DeepSeek Harness Desktop preview" width="100%">
@@ -80,7 +80,7 @@ The official project provides the core agent capabilities, plugin system, and We
 - Desktop application packaging
 - Starting, stopping, and recovering the local service
 - Desktop window and system tray integration
-- macOS and Windows installer builds and releases
+- macOS, Windows, and Linux installer builds and releases
 - An interface designed for desktop use
 
 If you prefer to run Harness from the command line or contribute to its core functionality, refer to the official repository first.

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
   <img src="https://img.shields.io/badge/Desktop-App-47848F?style=flat" alt="Desktop application">
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-2EA44F?style=flat" alt="MIT License"></a>
   <a href="https://discord.gg/TJeGqKRNM"><img src="https://img.shields.io/badge/Discord-5865F2?style=flat&amp;logo=discord&amp;logoColor=white" alt="Join Discord"></a>
-  <img src="https://img.shields.io/badge/macOS%20%7C%20Windows-4493F8?style=flat-square" alt="Supported platforms: macOS and Windows">
+  <img src="https://img.shields.io/badge/macOS%20%7C%20Windows%20%7C%20Linux-4493F8?style=flat-square" alt="Supported platforms: macOS, Windows and Linux">
 </p>
 
 <p align="center"><sub>中文 · <a href="README.en.md">English</a></sub></p>
@@ -16,7 +16,7 @@
 
 <a id="run"></a>
 
-<h3 align="center"><a href="https://www.deepseekdesktop.com"><ins>立刻下载 MacOS/Windows</ins></a></h3>
+<h3 align="center"><a href="https://www.deepseekdesktop.com"><ins>立刻下载 MacOS/Windows</ins></a> · <a href="https://github.com/ziyuliu258/deepseek-harness-desktop-extended-for-linux/releases"><ins>Linux AppImage</ins></a></h3>
 
 <p align="center">
   <img src="assets/desktop-preview.png" alt="DeepSeek Harness Desktop 界面预览" width="100%">
@@ -80,7 +80,7 @@ Desktop 的插件能力已经可以使用。开发者可以通过两个公开接
 - 桌面应用封装
 - 本地服务的启动、停止与恢复
 - 桌面窗口和系统托盘集成
-- macOS、Windows 安装包构建与发布
+- macOS、Windows、Linux 安装包构建与发布
 - 更适合桌面使用的界面体验
 
 如果你希望通过命令行运行 Harness，或者参与核心功能开发，请优先查看官方仓库。

--- a/dsh-plugin-desktop/package.json
+++ b/dsh-plugin-desktop/package.json
@@ -98,6 +98,7 @@
     "package:dir": "yarn run build && node scripts/package-dir.mjs",
     "dist:mac": "node scripts/release-mac.ts",
     "dist:win": "node scripts/package-win.ts",
+    "dist:linux": "node scripts/package-linux.ts",
     "prepack": "yarn run check"
   },
   "dependencies": {
@@ -283,9 +284,18 @@
     },
     "linux": {
       "target": [
-        "dir"
+        {
+          "target": "AppImage",
+          "arch": [
+            "x64"
+          ]
+        }
       ],
-      "icon": "build/app-icon.png"
+      "icon": "build/app-icon.png",
+      "category": "Development"
+    },
+    "appImage": {
+      "artifactName": "DSH-Desktop-${version}-${arch}.${ext}"
     }
   }
 }

--- a/dsh-plugin-desktop/scripts/package-linux.ts
+++ b/dsh-plugin-desktop/scripts/package-linux.ts
@@ -1,0 +1,50 @@
+/** Build a Linux AppImage package. */
+
+import { spawnSync } from 'node:child_process'
+import { createRequire } from 'node:module'
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+function run(command: string, args: readonly string[], cwd: string, env: NodeJS.ProcessEnv): void {
+  console.log(`Running: ${command} ${args.join(' ')}`)
+  const result = spawnSync(command, args, { cwd, env, stdio: 'inherit' })
+  if (result.error !== undefined) throw result.error
+  if (result.status !== 0) {
+    throw new Error(`${command} ${args.join(' ')} exited with ${result.status}`)
+  }
+}
+
+function packageLinux(): void {
+  const desktopRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..')
+  const workspaceRoot = resolve(desktopRoot, '..')
+  const require = createRequire(import.meta.url)
+  const builderCli = require.resolve('electron-builder/cli.js')
+
+  console.log('Building Linux AppImage package...')
+
+  // Run build first
+  console.log('Building application...')
+  run('yarn', ['workspace', 'dsh-plugin-desktop', 'build'], workspaceRoot, process.env)
+
+  // Package Linux AppImage
+  console.log('Packaging Linux AppImage...')
+  run(
+    process.execPath,
+    [builderCli, '--linux', 'AppImage', '--x64', '--publish', 'never', '--config.npmRebuild=false'],
+    desktopRoot,
+    process.env,
+  )
+
+  console.log('✓ Linux AppImage built successfully')
+  console.log('Output: dsh-plugin-desktop/dist/')
+}
+
+const invokedPath = process.argv[1]
+if (invokedPath !== undefined && resolve(invokedPath) === fileURLToPath(import.meta.url)) {
+  try {
+    packageLinux()
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error))
+    process.exitCode = 1
+  }
+}

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "package:dir": "yarn workspace dsh-plugin-desktop package:dir",
     "dist:mac": "yarn workspace dsh-plugin-desktop dist:mac",
     "dist:win": "yarn workspace dsh-plugin-desktop dist:win",
+    "dist:linux": "yarn workspace dsh-plugin-desktop dist:linux",
     "upstream:version": "cd deepseek-harness && corepack pnpm --version",
     "upstream:install": "cd deepseek-harness && corepack pnpm install --frozen-lockfile",
     "upstream:build": "cd deepseek-harness && corepack pnpm run build"


### PR DESCRIPTION
## Summary
This PR adds automated builds for Linux, Windows, and macOS using GitHub Actions, enabling releases for all three platforms.

## Changes
- ✅ Add GitHub Actions workflow for automated builds
- ✅ Linux AppImage packaging support
- ✅ Windows EXE builds (reusing existing scripts)
- ✅ macOS DMG builds (unsigned for CI)
- ✅ Automated releases on version tags
- ✅ Update README to reflect multi-platform support

## Benefits
- Automated CI builds for all platforms
- One-click releases via git tags
- Consistent build environment
- No manual packaging needed

## Testing
Successfully built and tested all three platforms in my fork.
