### PR TITLE
fix(dsh-plugin-desktop): tolerate plain-browser loads of the Web UI

### DIFF
--- a/dsh-plugin-desktop/src/client/environment.ts
+++ b/dsh-plugin-desktop/src/client/environment.ts
@@ -16,19 +16,25 @@ const MODES = new Set<DesktopClientMode>(['compatibility', 'advanced'])
 const PLATFORMS = new Set<DesktopClientPlatform>(['darwin', 'win32', 'linux'])
 
 /**
- * Validate the Electron-owned query marker before any desktop client effects run.
+ * Resolve the desktop renderer environment from the Electron-owned query markers.
+ *
+ * Returns `null` when either marker is absent: the page is not a desktop shell
+ * window (e.g. the same Web UI opened directly in a plain browser), so no
+ * desktop client effects should run. A marker that is present but holds an
+ * unknown value still fails loud — that indicates a malformed desktop page.
  * @param search - URL search string, including or omitting the leading question mark.
- * @returns the validated desktop renderer environment.
+ * @returns the validated desktop renderer environment, or `null` outside the desktop shell.
  */
-export function parseDesktopClientEnvironment(search: string): DesktopClientEnvironment {
+export function parseDesktopClientEnvironment(search: string): DesktopClientEnvironment | null {
   const params = new URLSearchParams(search)
   const mode = params.get('dsh-desktop-mode')
   const platform = params.get('dsh-desktop-platform')
+  if (mode === null || platform === null) return null
   if (!MODES.has(mode as DesktopClientMode)) {
-    throw new Error(`dsh-plugin-desktop: invalid or missing dsh-desktop-mode ${JSON.stringify(mode)}`)
+    throw new Error(`dsh-plugin-desktop: invalid dsh-desktop-mode ${JSON.stringify(mode)}`)
   }
   if (!PLATFORMS.has(platform as DesktopClientPlatform)) {
-    throw new Error(`dsh-plugin-desktop: invalid or missing dsh-desktop-platform ${JSON.stringify(platform)}`)
+    throw new Error(`dsh-plugin-desktop: invalid dsh-desktop-platform ${JSON.stringify(platform)}`)
   }
   return { mode: mode as DesktopClientMode, platform: platform as DesktopClientPlatform }
 }

--- a/dsh-plugin-desktop/src/client/index.ts
+++ b/dsh-plugin-desktop/src/client/index.ts
@@ -21,5 +21,6 @@ export const inject = [
 /** Register desktop-owned client surfaces for the current BrowserWindow mode. @param ctx - browser Cordis context. */
 export function apply(ctx: ClientContext): void {
   const environment = parseDesktopClientEnvironment(window.location.search)
+  if (environment === null) return
   if (environment.mode === 'advanced') applyAdvancedShell(ctx, environment)
 }

--- a/dsh-plugin-desktop/tests/client-environment.spec.ts
+++ b/dsh-plugin-desktop/tests/client-environment.spec.ts
@@ -23,12 +23,18 @@ describe('desktop client environment', () => {
   })
 
   it.each([
-    ['', 'dsh-desktop-mode'],
     ['?dsh-desktop-mode=glass&dsh-desktop-platform=darwin', 'dsh-desktop-mode'],
-    ['?dsh-desktop-mode=advanced', 'dsh-desktop-platform'],
     ['?dsh-desktop-mode=advanced&dsh-desktop-platform=android', 'dsh-desktop-platform'],
-  ])('fails loud for malformed marker %s', (search, field) => {
+  ])('fails loud for an unknown marker value %s', (search, field) => {
     expect(() => parseDesktopClientEnvironment(search)).toThrow(field)
+  })
+
+  it.each([
+    ['', 'no markers'],
+    ['?dsh-desktop-mode=advanced', 'missing platform'],
+    ['?dsh-desktop-platform=darwin', 'missing mode'],
+  ])('resolves to null when the page is not served by the desktop shell (%s: %s)', (search) => {
+    expect(parseDesktopClientEnvironment(search)).toBeNull()
   })
 })
 


### PR DESCRIPTION
## 背景

DSH Desktop 的 Web UI 被普通浏览器直接打开（根地址不带 `dsh-desktop-mode` / `dsh-desktop-platform` query 参数）时，客户端插件加载失败并报错：

```
Failed to load plugins: dsh-plugin-desktop: invalid or missing dsh-desktop-mode null
```

详见 #88。

## 改动

**`dsh-plugin-desktop/src/client/environment.ts`**
- `parseDesktopClientEnvironment()` 返回类型改为 `DesktopClientEnvironment | null`：任一标记缺失 → 返回 `null`（页面不属于桌面壳窗口，例如浏览器直接访问根地址）；标记存在但取值非法 → 仍然抛错（malformed desktop page，兜底宿主配置错误）。
- 错误文案由 "invalid or missing" 收紧为 "invalid"（缺失不再视为错误）。

**`dsh-plugin-desktop/src/client/index.ts`**
- `apply()` 在解析结果为 `null` 时直接返回，不注入任何桌面客户端效果。

**`dsh-plugin-desktop/tests/client-environment.spec.ts`**
- "fails loud" 用例收敛为仅覆盖非法取值（glass / android）；
- 新增用例：无标记、缺 mode、缺 platform 均解析为 `null`。

## 兼容性

- DSH Desktop 自身 BrowserWindow 的 URL 始终携带两个标记，`compatibility` / `advanced` 行为完全不变。
- 浏览器直接访问不再报错，且不会注入桌面效果。

## 验证

- `yarn typecheck` 通过（4 个 tsconfig 全部无错误）。
- `yarn workspace dsh-plugin-desktop vitest run tests/client-environment.spec.ts`：11/11 通过。