### PR TITLE
fix(desktop): pin koffi to 3.1.5 to fix Windows ACL sandbox segfault (workspace-select crash)

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "dsh-plugin-desktop"
   ],
   "resolutions": {
+    "koffi": "3.1.5",
     "app-builder-lib@npm:26.15.3": "patch:app-builder-lib@npm%3A26.15.3#./patches/app-builder-lib@26.15.3.patch",
     "@deepseek-ai/dsh-sandbox-windows-acl@npm:0.1.0-rc.6": "patch:@deepseek-ai/dsh-sandbox-windows-acl@npm%3A0.1.0-rc.6#./patches/dsh-sandbox-windows-acl@0.1.0-rc.6.patch",
     "@deepseek-ai/dsh-sandbox-windows-acl@npm:^0.1.0-rc.6": "patch:@deepseek-ai/dsh-sandbox-windows-acl@npm%3A0.1.0-rc.6#./patches/dsh-sandbox-windows-acl@0.1.0-rc.6.patch"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4338,107 +4338,107 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@koromix/koffi-darwin-arm64@npm:3.1.4":
-  version: 3.1.4
-  resolution: "@koromix/koffi-darwin-arm64@npm:3.1.4"
+"@koromix/koffi-darwin-arm64@npm:3.1.5":
+  version: 3.1.5
+  resolution: "@koromix/koffi-darwin-arm64@npm:3.1.5"
   conditions: os=darwin & cpu=arm64
   languageName: node
   linkType: hard
 
-"@koromix/koffi-darwin-x64@npm:3.1.4":
-  version: 3.1.4
-  resolution: "@koromix/koffi-darwin-x64@npm:3.1.4"
+"@koromix/koffi-darwin-x64@npm:3.1.5":
+  version: 3.1.5
+  resolution: "@koromix/koffi-darwin-x64@npm:3.1.5"
   conditions: os=darwin & cpu=x64
   languageName: node
   linkType: hard
 
-"@koromix/koffi-freebsd-arm64@npm:3.1.4":
-  version: 3.1.4
-  resolution: "@koromix/koffi-freebsd-arm64@npm:3.1.4"
+"@koromix/koffi-freebsd-arm64@npm:3.1.5":
+  version: 3.1.5
+  resolution: "@koromix/koffi-freebsd-arm64@npm:3.1.5"
   conditions: os=freebsd & cpu=arm64
   languageName: node
   linkType: hard
 
-"@koromix/koffi-freebsd-ia32@npm:3.1.4":
-  version: 3.1.4
-  resolution: "@koromix/koffi-freebsd-ia32@npm:3.1.4"
+"@koromix/koffi-freebsd-ia32@npm:3.1.5":
+  version: 3.1.5
+  resolution: "@koromix/koffi-freebsd-ia32@npm:3.1.5"
   conditions: os=freebsd & cpu=ia32
   languageName: node
   linkType: hard
 
-"@koromix/koffi-freebsd-x64@npm:3.1.4":
-  version: 3.1.4
-  resolution: "@koromix/koffi-freebsd-x64@npm:3.1.4"
+"@koromix/koffi-freebsd-x64@npm:3.1.5":
+  version: 3.1.5
+  resolution: "@koromix/koffi-freebsd-x64@npm:3.1.5"
   conditions: os=freebsd & cpu=x64
   languageName: node
   linkType: hard
 
-"@koromix/koffi-linux-arm64@npm:3.1.4":
-  version: 3.1.4
-  resolution: "@koromix/koffi-linux-arm64@npm:3.1.4"
+"@koromix/koffi-linux-arm64@npm:3.1.5":
+  version: 3.1.5
+  resolution: "@koromix/koffi-linux-arm64@npm:3.1.5"
   conditions: os=linux & cpu=arm64
   languageName: node
   linkType: hard
 
-"@koromix/koffi-linux-ia32@npm:3.1.4":
-  version: 3.1.4
-  resolution: "@koromix/koffi-linux-ia32@npm:3.1.4"
+"@koromix/koffi-linux-ia32@npm:3.1.5":
+  version: 3.1.5
+  resolution: "@koromix/koffi-linux-ia32@npm:3.1.5"
   conditions: os=linux & cpu=ia32
   languageName: node
   linkType: hard
 
-"@koromix/koffi-linux-loong64@npm:3.1.4":
-  version: 3.1.4
-  resolution: "@koromix/koffi-linux-loong64@npm:3.1.4"
+"@koromix/koffi-linux-loong64@npm:3.1.5":
+  version: 3.1.5
+  resolution: "@koromix/koffi-linux-loong64@npm:3.1.5"
   conditions: os=linux & cpu=loong64
   languageName: node
   linkType: hard
 
-"@koromix/koffi-linux-riscv64@npm:3.1.4":
-  version: 3.1.4
-  resolution: "@koromix/koffi-linux-riscv64@npm:3.1.4"
+"@koromix/koffi-linux-riscv64@npm:3.1.5":
+  version: 3.1.5
+  resolution: "@koromix/koffi-linux-riscv64@npm:3.1.5"
   conditions: os=linux & cpu=riscv64
   languageName: node
   linkType: hard
 
-"@koromix/koffi-linux-x64@npm:3.1.4":
-  version: 3.1.4
-  resolution: "@koromix/koffi-linux-x64@npm:3.1.4"
+"@koromix/koffi-linux-x64@npm:3.1.5":
+  version: 3.1.5
+  resolution: "@koromix/koffi-linux-x64@npm:3.1.5"
   conditions: os=linux & cpu=x64
   languageName: node
   linkType: hard
 
-"@koromix/koffi-openbsd-ia32@npm:3.1.4":
-  version: 3.1.4
-  resolution: "@koromix/koffi-openbsd-ia32@npm:3.1.4"
+"@koromix/koffi-openbsd-ia32@npm:3.1.5":
+  version: 3.1.5
+  resolution: "@koromix/koffi-openbsd-ia32@npm:3.1.5"
   conditions: os=openbsd & cpu=ia32
   languageName: node
   linkType: hard
 
-"@koromix/koffi-openbsd-x64@npm:3.1.4":
-  version: 3.1.4
-  resolution: "@koromix/koffi-openbsd-x64@npm:3.1.4"
+"@koromix/koffi-openbsd-x64@npm:3.1.5":
+  version: 3.1.5
+  resolution: "@koromix/koffi-openbsd-x64@npm:3.1.5"
   conditions: os=openbsd & cpu=x64
   languageName: node
   linkType: hard
 
-"@koromix/koffi-win32-arm64@npm:3.1.4":
-  version: 3.1.4
-  resolution: "@koromix/koffi-win32-arm64@npm:3.1.4"
+"@koromix/koffi-win32-arm64@npm:3.1.5":
+  version: 3.1.5
+  resolution: "@koromix/koffi-win32-arm64@npm:3.1.5"
   conditions: os=win32 & cpu=arm64
   languageName: node
   linkType: hard
 
-"@koromix/koffi-win32-ia32@npm:3.1.4":
-  version: 3.1.4
-  resolution: "@koromix/koffi-win32-ia32@npm:3.1.4"
+"@koromix/koffi-win32-ia32@npm:3.1.5":
+  version: 3.1.5
+  resolution: "@koromix/koffi-win32-ia32@npm:3.1.5"
   conditions: os=win32 & cpu=ia32
   languageName: node
   linkType: hard
 
-"@koromix/koffi-win32-x64@npm:3.1.4":
-  version: 3.1.4
-  resolution: "@koromix/koffi-win32-x64@npm:3.1.4"
+"@koromix/koffi-win32-x64@npm:3.1.5":
+  version: 3.1.5
+  resolution: "@koromix/koffi-win32-x64@npm:3.1.5"
   conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
@@ -7911,25 +7911,25 @@ __metadata:
   languageName: node
   linkType: hard
 
-"koffi@npm:^3.1.0":
-  version: 3.1.4
-  resolution: "koffi@npm:3.1.4"
+"koffi@npm:3.1.5":
+  version: 3.1.5
+  resolution: "koffi@npm:3.1.5"
   dependencies:
-    "@koromix/koffi-darwin-arm64": "npm:3.1.4"
-    "@koromix/koffi-darwin-x64": "npm:3.1.4"
-    "@koromix/koffi-freebsd-arm64": "npm:3.1.4"
-    "@koromix/koffi-freebsd-ia32": "npm:3.1.4"
-    "@koromix/koffi-freebsd-x64": "npm:3.1.4"
-    "@koromix/koffi-linux-arm64": "npm:3.1.4"
-    "@koromix/koffi-linux-ia32": "npm:3.1.4"
-    "@koromix/koffi-linux-loong64": "npm:3.1.4"
-    "@koromix/koffi-linux-riscv64": "npm:3.1.4"
-    "@koromix/koffi-linux-x64": "npm:3.1.4"
-    "@koromix/koffi-openbsd-ia32": "npm:3.1.4"
-    "@koromix/koffi-openbsd-x64": "npm:3.1.4"
-    "@koromix/koffi-win32-arm64": "npm:3.1.4"
-    "@koromix/koffi-win32-ia32": "npm:3.1.4"
-    "@koromix/koffi-win32-x64": "npm:3.1.4"
+    "@koromix/koffi-darwin-arm64": "npm:3.1.5"
+    "@koromix/koffi-darwin-x64": "npm:3.1.5"
+    "@koromix/koffi-freebsd-arm64": "npm:3.1.5"
+    "@koromix/koffi-freebsd-ia32": "npm:3.1.5"
+    "@koromix/koffi-freebsd-x64": "npm:3.1.5"
+    "@koromix/koffi-linux-arm64": "npm:3.1.5"
+    "@koromix/koffi-linux-ia32": "npm:3.1.5"
+    "@koromix/koffi-linux-loong64": "npm:3.1.5"
+    "@koromix/koffi-linux-riscv64": "npm:3.1.5"
+    "@koromix/koffi-linux-x64": "npm:3.1.5"
+    "@koromix/koffi-openbsd-ia32": "npm:3.1.5"
+    "@koromix/koffi-openbsd-x64": "npm:3.1.5"
+    "@koromix/koffi-win32-arm64": "npm:3.1.5"
+    "@koromix/koffi-win32-ia32": "npm:3.1.5"
+    "@koromix/koffi-win32-x64": "npm:3.1.5"
   dependenciesMeta:
     "@koromix/koffi-darwin-arm64":
       optional: true
@@ -7961,7 +7961,7 @@ __metadata:
       optional: true
     "@koromix/koffi-win32-x64":
       optional: true
-  checksum: 10c0/5f705d33275aa6215b7659765df32c5031674c8a0e147bb5647e8b0523b1eedf3e6fe0315b57f6a36400782a283c881b8c92c62309400705c71112674c38a38c
+  checksum: 10c0/2941703da4b733c6aa92696dd41780194682389058a3ad4a6fed5634959a245dd8ecb3faa257804e965ca2ca6abc1523b784536d40f073c41c5950bc5118fc78
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Problem

DSH Desktop (v2.0.0) hard-crashes — no JS stack, abnormal exit code — immediately after the user selects a workspace on Windows. The desktop launches fine on a clean profile; the crash happens once a workspace is chosen.

## Root cause

Selecting a workspace initializes the `workspace-write` sandbox, which on Windows is the desktop-owned `desktop-windows-pwsh-sandbox` provider (`dsh-plugin-desktop/src/profile.ts:326-346`) backed by `@deepseek-ai/dsh-sandbox-windows-acl`. That runner uses **koffi** for Win32 FFI (the only koffi usage; loaded lazily in the runner child spawned via the desktop trampoline under `ELECTRON_RUN_AS_NODE`).

**koffi 3.1.4 segfaults during an FFI call** on Windows x64, under both system Node and the packaged Electron's bundled Node. koffi 3.1.5 fixes the segfault and is API-compatible. Verified with the exact upstream API form:

```
lib.func('__stdcall', name, result, args)
# koffi 3.1.4 -> Segmentation fault (exit 139), the FFI call never returns
# koffi 3.1.5 -> GetTickCount() returns, no segfault (exit 0)
```

Secondary issue (not fixed here): the desktop main process dies when the sandbox runner child segfaults, instead of surfacing "sandbox init failed". koffi is confined to the runner child; the main process should not be taken down by a child crash. A follow-up could handle that in `windows-pwsh-sandbox.ts`/`windows-acl-runner.ts`.

> Note: the upstream CLI `npx @deepseek-ai/dsh web` fails separately on a missing sharp win32-x64 binary (`npm install --os=win32 --cpu=x64 sharp` fixes the CLI). That is a distinct issue and is **not** what crashes the desktop — the desktop ships its own working sharp (verified: it loads + renders under the packaged Electron node).

## Fix

Add Yarn `resolutions` forcing `koffi` and `@koromix/koffi-win32-x64` to **3.1.5** across the workspace. The root koffi pin lives in upstream `dsh-sandbox-windows-acl`; this is a desktop-owned workaround until upstream bumps koffi.

koffi's JS version-gates the binary (`index.cjs` throws `Mismatched native Koffi modules` if the binary version differs), so a binary-only swap is rejected — hence pinning via resolution + reinstall.

## Verification

- `yarn typecheck` — passes (koffi 3.1.5 types compatible, including `import("koffi").TypeObject` usage in the patched `dsh-sandbox-windows-acl`).
- `yarn check:win-package` — green: build + 8 Windows-relevant test files (101 tests passed), incl. `windows-pwsh-sandbox.spec.ts` and `verify-packaged-runtime.spec.ts`, plus a closed runtime-closure graph (197 first-party nodes).
- koffi 3.1.5 FFI confirmed working under the packaged Electron's bundled Node (vs 3.1.4 segfault), using the upstream's real `lib.func('__stdcall', ...)` form.

## Repository note

`v2.0.0` is the installed build; `HEAD` on `master` is docs-only commits ahead with zero source changes, so this fix is not present in any released version.
