### PR TITLE
fix(deps): force koffi ^3.1.5 to avoid Windows host crash on launch

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
   "resolutions": {
     "app-builder-lib@npm:26.15.3": "patch:app-builder-lib@npm%3A26.15.3#./patches/app-builder-lib@26.15.3.patch",
     "@deepseek-ai/dsh-sandbox-windows-acl@npm:0.1.0-rc.6": "patch:@deepseek-ai/dsh-sandbox-windows-acl@npm%3A0.1.0-rc.6#./patches/dsh-sandbox-windows-acl@0.1.0-rc.6.patch",
-    "@deepseek-ai/dsh-sandbox-windows-acl@npm:^0.1.0-rc.6": "patch:@deepseek-ai/dsh-sandbox-windows-acl@npm%3A0.1.0-rc.6#./patches/dsh-sandbox-windows-acl@0.1.0-rc.6.patch"
+    "@deepseek-ai/dsh-sandbox-windows-acl@npm:^0.1.0-rc.6": "patch:@deepseek-ai/dsh-sandbox-windows-acl@npm%3A0.1.0-rc.6#./patches/dsh-sandbox-windows-acl@0.1.0-rc.6.patch",
+    "koffi": "npm:^3.1.5"
   },
   "dependenciesMeta": {
     "@deepseek-ai/dsh-subprocess-local": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4338,107 +4338,107 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@koromix/koffi-darwin-arm64@npm:3.1.4":
-  version: 3.1.4
-  resolution: "@koromix/koffi-darwin-arm64@npm:3.1.4"
+"@koromix/koffi-darwin-arm64@npm:3.1.5":
+  version: 3.1.5
+  resolution: "@koromix/koffi-darwin-arm64@npm:3.1.5"
   conditions: os=darwin & cpu=arm64
   languageName: node
   linkType: hard
 
-"@koromix/koffi-darwin-x64@npm:3.1.4":
-  version: 3.1.4
-  resolution: "@koromix/koffi-darwin-x64@npm:3.1.4"
+"@koromix/koffi-darwin-x64@npm:3.1.5":
+  version: 3.1.5
+  resolution: "@koromix/koffi-darwin-x64@npm:3.1.5"
   conditions: os=darwin & cpu=x64
   languageName: node
   linkType: hard
 
-"@koromix/koffi-freebsd-arm64@npm:3.1.4":
-  version: 3.1.4
-  resolution: "@koromix/koffi-freebsd-arm64@npm:3.1.4"
+"@koromix/koffi-freebsd-arm64@npm:3.1.5":
+  version: 3.1.5
+  resolution: "@koromix/koffi-freebsd-arm64@npm:3.1.5"
   conditions: os=freebsd & cpu=arm64
   languageName: node
   linkType: hard
 
-"@koromix/koffi-freebsd-ia32@npm:3.1.4":
-  version: 3.1.4
-  resolution: "@koromix/koffi-freebsd-ia32@npm:3.1.4"
+"@koromix/koffi-freebsd-ia32@npm:3.1.5":
+  version: 3.1.5
+  resolution: "@koromix/koffi-freebsd-ia32@npm:3.1.5"
   conditions: os=freebsd & cpu=ia32
   languageName: node
   linkType: hard
 
-"@koromix/koffi-freebsd-x64@npm:3.1.4":
-  version: 3.1.4
-  resolution: "@koromix/koffi-freebsd-x64@npm:3.1.4"
+"@koromix/koffi-freebsd-x64@npm:3.1.5":
+  version: 3.1.5
+  resolution: "@koromix/koffi-freebsd-x64@npm:3.1.5"
   conditions: os=freebsd & cpu=x64
   languageName: node
   linkType: hard
 
-"@koromix/koffi-linux-arm64@npm:3.1.4":
-  version: 3.1.4
-  resolution: "@koromix/koffi-linux-arm64@npm:3.1.4"
+"@koromix/koffi-linux-arm64@npm:3.1.5":
+  version: 3.1.5
+  resolution: "@koromix/koffi-linux-arm64@npm:3.1.5"
   conditions: os=linux & cpu=arm64
   languageName: node
   linkType: hard
 
-"@koromix/koffi-linux-ia32@npm:3.1.4":
-  version: 3.1.4
-  resolution: "@koromix/koffi-linux-ia32@npm:3.1.4"
+"@koromix/koffi-linux-ia32@npm:3.1.5":
+  version: 3.1.5
+  resolution: "@koromix/koffi-linux-ia32@npm:3.1.5"
   conditions: os=linux & cpu=ia32
   languageName: node
   linkType: hard
 
-"@koromix/koffi-linux-loong64@npm:3.1.4":
-  version: 3.1.4
-  resolution: "@koromix/koffi-linux-loong64@npm:3.1.4"
+"@koromix/koffi-linux-loong64@npm:3.1.5":
+  version: 3.1.5
+  resolution: "@koromix/koffi-linux-loong64@npm:3.1.5"
   conditions: os=linux & cpu=loong64
   languageName: node
   linkType: hard
 
-"@koromix/koffi-linux-riscv64@npm:3.1.4":
-  version: 3.1.4
-  resolution: "@koromix/koffi-linux-riscv64@npm:3.1.4"
+"@koromix/koffi-linux-riscv64@npm:3.1.5":
+  version: 3.1.5
+  resolution: "@koromix/koffi-linux-riscv64@npm:3.1.5"
   conditions: os=linux & cpu=riscv64
   languageName: node
   linkType: hard
 
-"@koromix/koffi-linux-x64@npm:3.1.4":
-  version: 3.1.4
-  resolution: "@koromix/koffi-linux-x64@npm:3.1.4"
+"@koromix/koffi-linux-x64@npm:3.1.5":
+  version: 3.1.5
+  resolution: "@koromix/koffi-linux-x64@npm:3.1.5"
   conditions: os=linux & cpu=x64
   languageName: node
   linkType: hard
 
-"@koromix/koffi-openbsd-ia32@npm:3.1.4":
-  version: 3.1.4
-  resolution: "@koromix/koffi-openbsd-ia32@npm:3.1.4"
+"@koromix/koffi-openbsd-ia32@npm:3.1.5":
+  version: 3.1.5
+  resolution: "@koromix/koffi-openbsd-ia32@npm:3.1.5"
   conditions: os=openbsd & cpu=ia32
   languageName: node
   linkType: hard
 
-"@koromix/koffi-openbsd-x64@npm:3.1.4":
-  version: 3.1.4
-  resolution: "@koromix/koffi-openbsd-x64@npm:3.1.4"
+"@koromix/koffi-openbsd-x64@npm:3.1.5":
+  version: 3.1.5
+  resolution: "@koromix/koffi-openbsd-x64@npm:3.1.5"
   conditions: os=openbsd & cpu=x64
   languageName: node
   linkType: hard
 
-"@koromix/koffi-win32-arm64@npm:3.1.4":
-  version: 3.1.4
-  resolution: "@koromix/koffi-win32-arm64@npm:3.1.4"
+"@koromix/koffi-win32-arm64@npm:3.1.5":
+  version: 3.1.5
+  resolution: "@koromix/koffi-win32-arm64@npm:3.1.5"
   conditions: os=win32 & cpu=arm64
   languageName: node
   linkType: hard
 
-"@koromix/koffi-win32-ia32@npm:3.1.4":
-  version: 3.1.4
-  resolution: "@koromix/koffi-win32-ia32@npm:3.1.4"
+"@koromix/koffi-win32-ia32@npm:3.1.5":
+  version: 3.1.5
+  resolution: "@koromix/koffi-win32-ia32@npm:3.1.5"
   conditions: os=win32 & cpu=ia32
   languageName: node
   linkType: hard
 
-"@koromix/koffi-win32-x64@npm:3.1.4":
-  version: 3.1.4
-  resolution: "@koromix/koffi-win32-x64@npm:3.1.4"
+"@koromix/koffi-win32-x64@npm:3.1.5":
+  version: 3.1.5
+  resolution: "@koromix/koffi-win32-x64@npm:3.1.5"
   conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
@@ -7911,25 +7911,25 @@ __metadata:
   languageName: node
   linkType: hard
 
-"koffi@npm:^3.1.0":
-  version: 3.1.4
-  resolution: "koffi@npm:3.1.4"
+"koffi@npm:^3.1.5":
+  version: 3.1.5
+  resolution: "koffi@npm:3.1.5"
   dependencies:
-    "@koromix/koffi-darwin-arm64": "npm:3.1.4"
-    "@koromix/koffi-darwin-x64": "npm:3.1.4"
-    "@koromix/koffi-freebsd-arm64": "npm:3.1.4"
-    "@koromix/koffi-freebsd-ia32": "npm:3.1.4"
-    "@koromix/koffi-freebsd-x64": "npm:3.1.4"
-    "@koromix/koffi-linux-arm64": "npm:3.1.4"
-    "@koromix/koffi-linux-ia32": "npm:3.1.4"
-    "@koromix/koffi-linux-loong64": "npm:3.1.4"
-    "@koromix/koffi-linux-riscv64": "npm:3.1.4"
-    "@koromix/koffi-linux-x64": "npm:3.1.4"
-    "@koromix/koffi-openbsd-ia32": "npm:3.1.4"
-    "@koromix/koffi-openbsd-x64": "npm:3.1.4"
-    "@koromix/koffi-win32-arm64": "npm:3.1.4"
-    "@koromix/koffi-win32-ia32": "npm:3.1.4"
-    "@koromix/koffi-win32-x64": "npm:3.1.4"
+    "@koromix/koffi-darwin-arm64": "npm:3.1.5"
+    "@koromix/koffi-darwin-x64": "npm:3.1.5"
+    "@koromix/koffi-freebsd-arm64": "npm:3.1.5"
+    "@koromix/koffi-freebsd-ia32": "npm:3.1.5"
+    "@koromix/koffi-freebsd-x64": "npm:3.1.5"
+    "@koromix/koffi-linux-arm64": "npm:3.1.5"
+    "@koromix/koffi-linux-ia32": "npm:3.1.5"
+    "@koromix/koffi-linux-loong64": "npm:3.1.5"
+    "@koromix/koffi-linux-riscv64": "npm:3.1.5"
+    "@koromix/koffi-linux-x64": "npm:3.1.5"
+    "@koromix/koffi-openbsd-ia32": "npm:3.1.5"
+    "@koromix/koffi-openbsd-x64": "npm:3.1.5"
+    "@koromix/koffi-win32-arm64": "npm:3.1.5"
+    "@koromix/koffi-win32-ia32": "npm:3.1.5"
+    "@koromix/koffi-win32-x64": "npm:3.1.5"
   dependenciesMeta:
     "@koromix/koffi-darwin-arm64":
       optional: true
@@ -7961,7 +7961,7 @@ __metadata:
       optional: true
     "@koromix/koffi-win32-x64":
       optional: true
-  checksum: 10c0/5f705d33275aa6215b7659765df32c5031674c8a0e147bb5647e8b0523b1eedf3e6fe0315b57f6a36400782a283c881b8c92c62309400705c71112674c38a38c
+  checksum: 10c0/2941703da4b733c6aa92696dd41780194682389058a3ad4a6fed5634959a245dd8ecb3faa257804e965ca2ca6abc1523b784536d40f073c41c5950bc5118fc78
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Problem

On Windows, the desktop app crashes on startup: the shell exits with "Host exited unexpectedly" immediately after launch.

Root cause chain:

1. On launch, the frontend auto-creates a session (`session.create` RPC).
2. `@deepseek-ai/dsh-session-persistence-jsonl` calls `koffi.load("kernel32.dll")` to bind `MoveFileExW` (durable directory publishing via `MOVEFILE_WRITE_THROUGH`).
3. The workspace resolves koffi to **3.1.4**, whose Windows binaries are **Clang-cross-compiled** (koffi switched to Clang for Windows builds in 3.1.3).
4. `koffi.load()` segfaults with `0xC0000005` inside the host process (silent crash, no WER dump/log).
5. The host dies, the desktop shell sees "Host exited unexpectedly" and quits — appearing as a launch-time flash crash.

Upstream koffi confirmed the instability: [koffi 3.1.5 changelog](https://koffi.dev/changelog) — *"Revert to native compilation for Windows builds for stability"*.

## Fix

Pin koffi to `>=3.1.5` via Yarn `resolutions` in the root `package.json` and refresh `yarn.lock` so every consumer (`dsh-session-persistence-jsonl`, `dsh-fs-local`, `dsh-sandbox-windows-acl`, `dsh-host-directory-picker-native`, all declaring `koffi: ^3.1.0`) resolves the fixed native-compiled build.

## Verification

- Reproduced locally with the previously resolved koffi 3.1.4: `koffi.load("kernel32.dll")` → segfault (SIGSEGV / 0xC0000005).
- With koffi 3.1.5: `koffi.load("kernel32.dll")` + `MoveFileExW`/`GetLastError` bind and a real `MoveFileExW(..., MOVEFILE_WRITE_THROUGH)` file publish succeed.
- Launching the packaged app with the 3.1.5 binary: the Electron shell and host stay alive and sessions persist normally (previously exited within seconds).
- `yarn install --mode=update-lockfile` resolves cleanly; no 3.1.4 references remain in `yarn.lock`.
