### PR TITLE
fix(desktop): recover from cross-profile web clients

### DIFF
--- a/dsh-plugin-desktop/src/main.ts
+++ b/dsh-plugin-desktop/src/main.ts
@@ -26,7 +26,7 @@ import {
   type DesktopProfileStartup,
 } from './profile-manager.ts'
 import { DesktopProfileService } from './profile-service.ts'
-import { prepareDesktopProfile } from './profile.ts'
+import { prepareDesktopProfile, type SkippedOptionalEntry } from './profile.ts'
 import type { DesktopPnpmBootstrap } from './pnpm.ts'
 import {
   createDesktopExitCoordinator,
@@ -45,6 +45,26 @@ function notifyProfileRecovery(runtime: ElectronDesktopRuntime, body: string): v
   } catch (cause) {
     process.stderr.write(
       `${BIN_NAME}: failed to show profile recovery notification: ${cause instanceof Error ? cause.message : String(cause)}\n`,
+    )
+  }
+}
+
+/** Report optional user UI plugins skipped to keep startup recoverable. */
+function notifySkippedOptionalEntries(
+  runtime: ElectronDesktopRuntime,
+  entries: readonly SkippedOptionalEntry[],
+): void {
+  if (entries.length === 0) return
+  const names = entries.map(entry => entry.name)
+  const suffix = names.length > 1 ? ` and ${names.length - 1} more` : ''
+  try {
+    runtime.updates.notify({
+      title: 'Skipped Unavailable UI Plugin',
+      body: `${names[0]} is not installed in this profile${suffix}.`,
+    })
+  } catch (cause) {
+    process.stderr.write(
+      `${BIN_NAME}: failed to show skipped plugin notification: ${cause instanceof Error ? cause.message : String(cause)}\n`,
     )
   }
 }
@@ -201,6 +221,7 @@ async function start(): Promise<void> {
     await runtime.mountScheduled(() => {
       markDesktopProfileHealthy(selectionStatePath, activeProfileName)
     })
+    notifySkippedOptionalEntries(runtime, prepared.skippedOptionalEntries)
     if (profileStartup.rolledBackFrom !== undefined) {
       notifyProfileRecovery(
         runtime,

--- a/dsh-plugin-desktop/src/profile.ts
+++ b/dsh-plugin-desktop/src/profile.ts
@@ -1,7 +1,7 @@
 /** Compatibility profile composition over the official Web bundle and user plugins. */
 
-import { createRequire } from 'node:module'
-import { existsSync, readFileSync, writeFileSync } from 'node:fs'
+import { createRequire, findPackageJSON } from 'node:module'
+import { existsSync, readFileSync, readdirSync, writeFileSync } from 'node:fs'
 import { dirname, join } from 'node:path'
 import { fileURLToPath, pathToFileURL } from 'node:url'
 import { evaluate, isJsExpr, type EntryOptions } from '@deepseek-ai/cordis-plugin-loader'
@@ -135,8 +135,18 @@ export interface PreparedDesktopProfile {
   bareModuleBaseUrl: string
   /** Complete ordered patch list for this desktop generation. */
   patches: PatchOptions[]
+  /** Optional Client UI entries skipped because this profile cannot resolve them. */
+  skippedOptionalEntries: SkippedOptionalEntry[]
   /** Persisted shell mode applied after every user-owned patch. */
   mode: DesktopShellMode
+}
+
+/** User patch entry skipped to keep a profile bootable. */
+export interface SkippedOptionalEntry {
+  /** Loader row id from the skipped entry. */
+  id?: string
+  /** Package name from the skipped entry. */
+  name: string
 }
 
 /**
@@ -212,6 +222,82 @@ function rowDisabledOnPlatform(row: EntryOptions, platform: NodeJS.Platform): bo
   return Boolean(evaluate({ process: scopedProcess }, row.disabled.__jsExpr))
 }
 
+/** Find one package manifest using the selected profile's dependency graph. */
+function packageManifestFromProfile(name: string, profilePackageUrl: string): string | undefined {
+  try {
+    return findPackageJSON(name, profilePackageUrl)
+  } catch (cause) {
+    if ((cause as NodeJS.ErrnoException).code === 'ERR_MODULE_NOT_FOUND') return undefined
+    throw cause
+  }
+}
+
+/** Return whether a Loader specifier names an npm package. */
+function isBarePackageSpecifier(name: string): boolean {
+  return !name.startsWith('.')
+    && !name.startsWith('/')
+    && !name.startsWith('#')
+    && !URL.canParse(name)
+}
+
+/** Return whether another profile owns this unavailable Web Client package. */
+function isWebClientPackageInAnotherProfile(
+  name: string,
+  home: string,
+  activeProfilePackageUrl: string,
+): boolean {
+  const profilesDir = join(home, 'profiles')
+  for (const entry of readdirSync(profilesDir, { withFileTypes: true })) {
+    if (!entry.isDirectory() || entry.name === 'node_modules') continue
+    const profilePackageUrl = pathToFileURL(join(profilesDir, entry.name, 'package.json')).href
+    if (profilePackageUrl === activeProfilePackageUrl) continue
+    const manifestPath = packageManifestFromProfile(name, profilePackageUrl)
+    if (manifestPath === undefined) continue
+    const manifest = JSON.parse(readFileSync(manifestPath, 'utf8')) as {
+      dsh?: { client?: { platform?: unknown } }
+    }
+    if (manifest.dsh?.client?.platform === 'web') return true
+  }
+  return false
+}
+
+/** Drop unresolved optional Client UI rows from the machine-wide patch only. */
+function omitUnresolvedOptionalEntries(
+  patches: PatchOptions[],
+  profilePackageUrl: string,
+  home: string,
+): { patches: PatchOptions[], skipped: SkippedOptionalEntry[] } {
+  const skipped: SkippedOptionalEntry[] = []
+
+  const filterRows = (rows: EntryOptions[]): EntryOptions[] => {
+    const filtered: EntryOptions[] = []
+    for (const row of rows) {
+      if (typeof row.name === 'string'
+        && isBarePackageSpecifier(row.name)
+        && packageManifestFromProfile(row.name, profilePackageUrl) === undefined
+        && isWebClientPackageInAnotherProfile(row.name, home, profilePackageUrl)) {
+        skipped.push({
+          ...(typeof row.id === 'string' ? { id: row.id } : {}),
+          name: row.name,
+        })
+        continue
+      }
+      const config = row.group === true && Array.isArray(row.config) ? filterRows(row.config) : undefined
+      filtered.push(config === undefined ? row : { ...row, config })
+    }
+    return filtered
+  }
+
+  return {
+    patches: patches.flatMap((patch) => {
+      if (!Array.isArray(patch.insert)) return [patch]
+      const insert = filterRows(patch.insert)
+      return [{ ...patch, insert }]
+    }),
+    skipped,
+  }
+}
+
 /**
  * Load and compose one desktop profile generation.
  * @param telemetryDisabled - inherited DSH telemetry opt-out value.
@@ -248,7 +334,12 @@ export function prepareDesktopProfile(
     throw new Error(`${BIN_NAME}: desktop profile is missing @deepseek-ai/dsh-web-app`)
   }
 
-  const homePatches = loadOptionalPatches(BIN_NAME, join(home, PROFILE_PATCH_FILENAME)) ?? []
+  const loadedHomePatches = loadOptionalPatches(BIN_NAME, join(home, PROFILE_PATCH_FILENAME)) ?? []
+  const { patches: homePatches, skipped: skippedOptionalEntries } = omitUnresolvedOptionalEntries(
+    loadedHomePatches,
+    bareModuleBaseUrl,
+    home,
+  )
   const patches: PatchOptions[] = [
     ...bundlePatches,
     ...profile.patches,
@@ -372,6 +463,7 @@ export function prepareDesktopProfile(
     rootConfig,
     bareModuleBaseUrl,
     patches: structuredClone(patches),
+    skippedOptionalEntries,
     mode,
   }
 }

--- a/dsh-plugin-desktop/src/profile.ts
+++ b/dsh-plugin-desktop/src/profile.ts
@@ -1,7 +1,7 @@
 /** Compatibility profile composition over the official Web bundle and user plugins. */
 
 import { createRequire, findPackageJSON } from 'node:module'
-import { existsSync, readFileSync, readdirSync, writeFileSync } from 'node:fs'
+import { existsSync, readFileSync, writeFileSync } from 'node:fs'
 import { dirname, join } from 'node:path'
 import { fileURLToPath, pathToFileURL } from 'node:url'
 import { evaluate, isJsExpr, type EntryOptions } from '@deepseek-ai/cordis-plugin-loader'
@@ -240,32 +240,15 @@ function isBarePackageSpecifier(name: string): boolean {
     && !URL.canParse(name)
 }
 
-/** Return whether another profile owns this unavailable Web Client package. */
-function isWebClientPackageInAnotherProfile(
-  name: string,
-  home: string,
-  activeProfilePackageUrl: string,
-): boolean {
-  const profilesDir = join(home, 'profiles')
-  for (const entry of readdirSync(profilesDir, { withFileTypes: true })) {
-    if (!entry.isDirectory() || entry.name === 'node_modules') continue
-    const profilePackageUrl = pathToFileURL(join(profilesDir, entry.name, 'package.json')).href
-    if (profilePackageUrl === activeProfilePackageUrl) continue
-    const manifestPath = packageManifestFromProfile(name, profilePackageUrl)
-    if (manifestPath === undefined) continue
-    const manifest = JSON.parse(readFileSync(manifestPath, 'utf8')) as {
-      dsh?: { client?: { platform?: unknown } }
-    }
-    if (manifest.dsh?.client?.platform === 'web') return true
-  }
-  return false
+/** Return whether a package is a user-facing Client UI extension, not a Host provider. */
+function isOptionalClientPackage(name: string): boolean {
+  return /^(@[^/]+\/)?dsh-client-ui-/u.test(name)
 }
 
 /** Drop unresolved optional Client UI rows from the machine-wide patch only. */
 function omitUnresolvedOptionalEntries(
   patches: PatchOptions[],
   profilePackageUrl: string,
-  home: string,
 ): { patches: PatchOptions[], skipped: SkippedOptionalEntry[] } {
   const skipped: SkippedOptionalEntry[] = []
 
@@ -274,8 +257,8 @@ function omitUnresolvedOptionalEntries(
     for (const row of rows) {
       if (typeof row.name === 'string'
         && isBarePackageSpecifier(row.name)
-        && packageManifestFromProfile(row.name, profilePackageUrl) === undefined
-        && isWebClientPackageInAnotherProfile(row.name, home, profilePackageUrl)) {
+        && isOptionalClientPackage(row.name)
+        && packageManifestFromProfile(row.name, profilePackageUrl) === undefined) {
         skipped.push({
           ...(typeof row.id === 'string' ? { id: row.id } : {}),
           name: row.name,
@@ -338,7 +321,6 @@ export function prepareDesktopProfile(
   const { patches: homePatches, skipped: skippedOptionalEntries } = omitUnresolvedOptionalEntries(
     loadedHomePatches,
     bareModuleBaseUrl,
-    home,
   )
   const patches: PatchOptions[] = [
     ...bundlePatches,

--- a/dsh-plugin-desktop/tests/profile.spec.ts
+++ b/dsh-plugin-desktop/tests/profile.spec.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { fileURLToPath } from 'node:url'
@@ -19,6 +19,27 @@ function temporaryHome(): string {
   const home = mkdtempSync(join(tmpdir(), 'dsh-desktop-profile-'))
   homes.push(home)
   return home
+}
+
+function installWebClient(
+  home: string,
+  packageName: string,
+  manifest: Record<string, unknown> = {},
+): string {
+  const webDir = join(home, 'profiles', 'web')
+  const bundles = PROFILE_TEMPLATES.web
+  if (bundles === undefined) throw new Error('test requires the shipped Web template')
+  initProfile(webDir, bundles)
+  const packageDir = join(webDir, 'node_modules', ...packageName.split('/'))
+  mkdirSync(packageDir, { recursive: true })
+  writeFileSync(join(packageDir, 'package.json'), JSON.stringify({
+    name: packageName,
+    type: 'module',
+    dsh: { client: { platform: 'web' } },
+    ...manifest,
+  }) + '\n')
+  writeFileSync(join(packageDir, 'index.js'), 'export default {}\n')
+  return webDir
 }
 
 afterEach(() => {
@@ -267,6 +288,98 @@ describe('desktop profile composition', () => {
       disabled: { __jsExpr: "process.platform !== 'win32'" },
       config: { cwd: 'C:\\workspace' },
     }))
+  })
+
+  it('keeps a Web Client in its owning profile and omits it from desktop', () => {
+    const home = temporaryHome()
+    const packageName = '@linxin666/dsh-client-ui-skin-whale-song'
+    installWebClient(home, packageName, { exports: { '.': { import: './index.js' } } })
+    writeFileSync(join(home, 'cordis.patch.yml'), [
+      '- insert:',
+      '    - id: missing-skin',
+      `      name: '${packageName}'`,
+      '    - id: third-party-host',
+      "      name: 'third-party-host-plugin'",
+      '',
+    ].join('\n'))
+
+    const desktop = prepareDesktopProfile(undefined, home, 'darwin')
+    const desktopRows = composeEntries([desktop.patches])
+
+    expect(desktopRows.map(row => row.id)).not.toContain('missing-skin')
+    expect(desktopRows).toContainEqual({
+      id: 'third-party-host',
+      name: 'third-party-host-plugin',
+    })
+    expect(desktop.skippedOptionalEntries).toEqual([{
+      id: 'missing-skin',
+      name: packageName,
+    }])
+
+    const web = prepareDesktopProfile(undefined, home, 'darwin', 'web')
+    const webRows = composeEntries([web.patches])
+    expect(webRows).toContainEqual({ id: 'missing-skin', name: packageName })
+    expect(web.skippedOptionalEntries).toEqual([])
+  })
+
+  it('identifies optional Web Clients from package metadata instead of their name', () => {
+    const home = temporaryHome()
+    const packageName = '@example/whale-song-theme'
+    installWebClient(home, packageName, { exports: { '.': './index.js' } })
+    writeFileSync(join(home, 'cordis.patch.yml'), [
+      '- insert:',
+      '    - id: optional-theme',
+      `      name: '${packageName}'`,
+      '',
+    ].join('\n'))
+
+    const desktop = prepareDesktopProfile(undefined, home, 'darwin')
+    expect(composeEntries([desktop.patches]).map(row => row.id)).not.toContain('optional-theme')
+    expect(desktop.skippedOptionalEntries).toEqual([{ id: 'optional-theme', name: packageName }])
+
+    const web = prepareDesktopProfile(undefined, home, 'darwin', 'web')
+    expect(composeEntries([web.patches])).toContainEqual({ id: 'optional-theme', name: packageName })
+    expect(web.skippedOptionalEntries).toEqual([])
+  })
+
+  it('does not treat ordinary array config as nested Loader entries', () => {
+    const home = temporaryHome()
+    const packageName = '@example/whale-song-theme'
+    installWebClient(home, packageName)
+    writeFileSync(join(home, 'cordis.patch.yml'), [
+      '- insert:',
+      '    - id: config-holder',
+      "      name: 'third-party-host-plugin'",
+      '      config:',
+      `        - name: '${packageName}'`,
+      '          enabled: true',
+      '',
+    ].join('\n'))
+
+    const prepared = prepareDesktopProfile(undefined, home, 'darwin')
+    expect(composeEntries([prepared.patches])).toContainEqual({
+      id: 'config-holder',
+      name: 'third-party-host-plugin',
+      config: [{ name: packageName, enabled: true }],
+    })
+    expect(prepared.skippedOptionalEntries).toEqual([])
+  })
+
+  it('leaves non-package Loader specifiers unchanged', () => {
+    const home = temporaryHome()
+    writeFileSync(join(home, 'cordis.patch.yml'), [
+      '- insert:',
+      '    - id: builtin-plugin',
+      "      name: 'cordis:example'",
+      '',
+    ].join('\n'))
+
+    const prepared = prepareDesktopProfile(undefined, home, 'darwin')
+    expect(composeEntries([prepared.patches])).toContainEqual({
+      id: 'builtin-plugin',
+      name: 'cordis:example',
+    })
+    expect(prepared.skippedOptionalEntries).toEqual([])
   })
 
   it('preserves an explicitly disabled upstream pwsh provider and a third-party replacement', () => {

--- a/dsh-plugin-desktop/tests/profile.spec.ts
+++ b/dsh-plugin-desktop/tests/profile.spec.ts
@@ -322,10 +322,9 @@ describe('desktop profile composition', () => {
     expect(web.skippedOptionalEntries).toEqual([])
   })
 
-  it('identifies optional Web Clients from package metadata instead of their name', () => {
+  it('keeps unresolved non-UI package entries fail-loud', () => {
     const home = temporaryHome()
     const packageName = '@example/whale-song-theme'
-    installWebClient(home, packageName, { exports: { '.': './index.js' } })
     writeFileSync(join(home, 'cordis.patch.yml'), [
       '- insert:',
       '    - id: optional-theme',
@@ -334,12 +333,8 @@ describe('desktop profile composition', () => {
     ].join('\n'))
 
     const desktop = prepareDesktopProfile(undefined, home, 'darwin')
-    expect(composeEntries([desktop.patches]).map(row => row.id)).not.toContain('optional-theme')
-    expect(desktop.skippedOptionalEntries).toEqual([{ id: 'optional-theme', name: packageName }])
-
-    const web = prepareDesktopProfile(undefined, home, 'darwin', 'web')
-    expect(composeEntries([web.patches])).toContainEqual({ id: 'optional-theme', name: packageName })
-    expect(web.skippedOptionalEntries).toEqual([])
+    expect(composeEntries([desktop.patches])).toContainEqual({ id: 'optional-theme', name: packageName })
+    expect(desktop.skippedOptionalEntries).toEqual([])
   })
 
   it('does not treat ordinary array config as nested Loader entries', () => {


### PR DESCRIPTION
## Summary

- skip machine-wide Web Client patch entries only when the active profile cannot resolve them and another profile owns a package declaring `dsh.client.platform: web`
- preserve Host plugins, non-package Loader specifiers, ordinary array config, and ESM-only package exports
- notify users after successful window mount when optional Web Client entries were skipped

## Validation

- `corepack yarn workspace dsh-plugin-desktop build`
- `corepack yarn workspace dsh-plugin-desktop typecheck`
- `corepack yarn workspace dsh-plugin-desktop vitest run tests/profile.spec.ts` (14 passed)
- full Vitest run: 240 passed, 19 failed, 1 skipped; the 19 existing Windows failures are unchanged from baseline and remain confined to POSIX/macOS path and permission assertions