### PR TITLE
fix(desktop): recover from unexpected pnpm runtime entries

### DIFF
--- a/dsh-plugin-desktop/src/desktop-runtime-environment.ts
+++ b/dsh-plugin-desktop/src/desktop-runtime-environment.ts
@@ -135,6 +135,34 @@ function assertOwnedDirectoryEntries(directory: string, allowed: readonly string
   }
 }
 
+/** Remove one stray command-directory entry, refusing only unsafe directories. */
+function removeUnexpectedEntry(directory: string, entry: string): void {
+  const filename = join(directory, entry)
+  const stat = lstatSync(filename)
+  if (stat.isDirectory()) {
+    throw new Error(
+      `dsh-plugin-desktop: command runtime directory contains an unexpected directory: ${entry}`,
+    )
+  }
+  process.stderr.write(
+    `dsh-plugin-desktop: removing unexpected command runtime entry ${JSON.stringify(entry)}\n`,
+  )
+  unlinkSync(filename)
+}
+
+/**
+ * Recover the app-owned command directory to this generation's exact contents.
+ * Stray files left by crashes or external tools must not brick startup: they
+ * are removed instead of failing. An unexpected directory is still refused
+ * because it cannot be removed safely without recursion.
+ */
+function reconcileOwnedDirectoryEntries(directory: string, allowed: readonly string[]): void {
+  for (const entry of readdirSync(directory)) {
+    if (allowed.includes(entry)) continue
+    removeUnexpectedEntry(directory, entry)
+  }
+}
+
 /** Remove only stale atomic-write files generated for one exact target name. */
 function removeStaleTemporaryFiles(directory: string, targetName: string): void {
   const prefix = `.${targetName}.`
@@ -388,8 +416,8 @@ export function installDesktopPnpmRuntime(options: DesktopPnpmRuntimeOptions): D
   removeStaleTemporaryFiles(pathDir, pnpmShimName)
   removeStaleTemporaryFiles(nodeBinDir, nodeShimName)
   removeStaleTemporaryFiles(privateDir, 'clear-env.mjs')
-  assertOwnedDirectoryEntries(pathDir, [pnpmShimName])
-  assertOwnedDirectoryEntries(nodeBinDir, [nodeShimName])
+  reconcileOwnedDirectoryEntries(pathDir, [pnpmShimName])
+  reconcileOwnedDirectoryEntries(nodeBinDir, [nodeShimName])
   const pnpmShimPath = join(pathDir, pnpmShimName)
   const nodeShimPath = join(nodeBinDir, nodeShimName)
   const clearEnvironmentPath = join(privateDir, 'clear-env.mjs')

--- a/dsh-plugin-desktop/tests/desktop-runtime-environment.spec.ts
+++ b/dsh-plugin-desktop/tests/desktop-runtime-environment.spec.ts
@@ -299,16 +299,53 @@ describe('desktop Host pnpm runtime', () => {
     expect(environment).toEqual({ PATH: '/usr/bin' })
   })
 
-  it('rejects unexpected public commands before changing PATH', () => {
+  it('recovers from stray command files instead of failing startup', () => {
+    const root = temporaryDirectory()
+    const stateDir = join(root, 'runtime')
+    const pathDir = join(stateDir, 'bin')
+    const privateDir = join(stateDir, 'private')
+    const nodeBinDir = join(privateDir, 'node-bin')
+    mkdirSync(pathDir, { recursive: true })
+    mkdirSync(nodeBinDir, { recursive: true })
+    writeFileSync(join(pathDir, 'dsh'), 'stray')
+    writeFileSync(join(nodeBinDir, 'dsh'), 'stray')
+    const environment: NodeJS.ProcessEnv = { PATH: '/usr/bin' }
+
+    const installation = installDesktopPnpmRuntime(options(stateDir, 'linux', environment))
+
+    expect(readdirSync(pathDir)).toEqual(['pnpm'])
+    expect(readdirSync(nodeBinDir)).toEqual(['node'])
+    expect(environment.PATH).toBe(`${pathDir}:/usr/bin`)
+    installation.dispose()
+  })
+
+  it('removes stray symlinks without touching their targets', () => {
     const root = temporaryDirectory()
     const stateDir = join(root, 'runtime')
     const pathDir = join(stateDir, 'bin')
     mkdirSync(pathDir, { recursive: true })
-    writeFileSync(join(pathDir, 'node'), 'unexpected')
+    const target = join(root, 'outside')
+    writeFileSync(target, 'outside')
+    symlinkSync(target, join(pathDir, 'dsh'))
+    const environment: NodeJS.ProcessEnv = { PATH: '/usr/bin' }
+
+    const installation = installDesktopPnpmRuntime(options(stateDir, 'linux', environment))
+
+    expect(readdirSync(pathDir)).toEqual(['pnpm'])
+    expect(readFileSync(target, 'utf8')).toBe('outside')
+    installation.dispose()
+  })
+
+  it('refuses an unexpected directory in the public command directory', () => {
+    const root = temporaryDirectory()
+    const stateDir = join(root, 'runtime')
+    const pathDir = join(stateDir, 'bin')
+    mkdirSync(pathDir, { recursive: true })
+    mkdirSync(join(pathDir, 'dsh'))
     const environment: NodeJS.ProcessEnv = { PATH: '/usr/bin' }
 
     expect(() => installDesktopPnpmRuntime(options(stateDir, 'linux', environment)))
-      .toThrow('directory contains unexpected entries: node')
+      .toThrow('contains an unexpected directory: dsh')
     expect(environment).toEqual({ PATH: '/usr/bin' })
   })
 


### PR DESCRIPTION
Fixes #103

## Summary

`installDesktopPnpmRuntime` previously failed **hard at startup** whenever the app-owned pnpm runtime command directory contained any entry it did not own:

```
dsh-plugin-desktop: pnpm runtime directory contains unexpected entries: dsh
```

A single stray file (e.g. a `dsh` shim left behind) made the packaged app exit silently with no window, no dialog, and no recovery path — the exact crash reported in #103.

This PR makes the runtime directory **self-healing**: before regenerating the shims, unexpected non-directory entries in `runtime-commands/bin` and `runtime-commands/private/node-bin` are removed (with a stderr warning), so leftover files no longer brick the app. The directory invariant is unchanged — after install it still contains exactly `pnpm` (public) and `node` (private).

**Security posture is preserved:**
- Symlinked state directories and symlinked shim targets are still rejected (`replacePrivateFile` / `preparePrivateDirectory` unchanged).
- An unexpected **directory** is still refused — removing it safely would require recursion, so it keeps failing loud with a clear message.

## Reproduction investigation (why the fix is shaped this way)

I reproduced on macOS 26.5 arm64 with the official v2.0.0 dmg. The **symptom** reproduces exactly: any stray file in `runtime-commands/bin` (e.g. `dsh`) crashes the next cold start with the error above.

The **mechanism described in #103** ("the built-in terminal writes its `dsh`/`pnpm`/`node` shims into `runtime-commands/bin`, colliding with the pnpm runtime") does **not** match the code: the terminal writes its shims to `userData/cli/<sha256(profile)>/bin`, which has never shared a directory with `runtime-commands` (verified against the v2.0.0 tag and the installed build). No code path writes `dsh` into `runtime-commands/bin` — the stray file comes from external interference (manual copy, crash leftovers, other tools).

The real product defect is therefore the **fail-loud assertion with no recovery**: any stray file bricks startup. This PR fixes that defect directly.

## Verification

`yarn run check` in `dsh-plugin-desktop` passes end-to-end (build + typecheck + 262 vitest tests + runtime-closure / packaged-CLI / Loader / profile boot verifications).

New tests cover:
- stray regular files in both the public and private command directories are removed and install succeeds (the #103 scenario)
- stray symlinks are removed without touching their targets
- an unexpected directory is still refused with a clear error
