### PR TITLE
fix(desktop): leave fullscreen before hiding macOS window on close

### DIFF
--- a/dsh-plugin-desktop/src/electron-runtime.ts
+++ b/dsh-plugin-desktop/src/electron-runtime.ts
@@ -495,10 +495,20 @@ export class ElectronDesktopRuntime implements DesktopRuntime {
     this.window = window
 
     const show = (): void => { this.show() }
+    const hide = (): void => {
+      if (!window.isDestroyed()) window.hide()
+    }
     const close = (event: Electron.Event): void => {
       if (this.quitting) return
       event.preventDefault()
-      window.hide()
+      if (this.platform === 'darwin' && window.isFullScreen()) {
+        // Hiding a fullscreen window on macOS leaves a black fullscreen space
+        // behind (electron/electron#20263); leave fullscreen before hiding.
+        window.once('leave-full-screen', hide)
+        window.setFullScreen(false)
+      } else {
+        window.hide()
+      }
     }
     const preserveBlankTitle = (event: Electron.Event): void => { event.preventDefault() }
     const navigate = (event: Electron.Event<{ url: string }>): void => {
@@ -562,6 +572,7 @@ export class ElectronDesktopRuntime implements DesktopRuntime {
       released = true
       app.off('activate', show)
       window.off('close', close)
+      window.removeListener('leave-full-screen', hide)
       window.off('page-title-updated', preserveBlankTitle)
       window.webContents.off('will-frame-navigate', navigate)
       window.webContents.off('will-redirect', navigate)

--- a/dsh-plugin-desktop/tests/electron-runtime.spec.ts
+++ b/dsh-plugin-desktop/tests/electron-runtime.spec.ts
@@ -84,11 +84,15 @@ const electron = vi.hoisted(() => {
 
     readonly isDestroyed = vi.fn(() => false)
     readonly isMinimized = vi.fn(() => false)
+    readonly isFullScreen = vi.fn(() => false)
     readonly restore = vi.fn()
     readonly show = vi.fn()
+    readonly hide = vi.fn()
     readonly focus = vi.fn()
+    readonly setFullScreen = vi.fn()
     readonly on = browserWindowOn
     readonly off = browserWindowOff
+    readonly removeListener = vi.fn()
     readonly once = vi.fn()
     readonly destroy = vi.fn()
     readonly loadURL = loadURL
@@ -280,6 +284,55 @@ describe('Electron compatibility runtime', () => {
     await release()
     expect(electron.browserWindowOff).toHaveBeenCalledWith('page-title-updated', titleListener)
     expect(electron.trays[0]?.off).toHaveBeenCalledWith('click', expect.any(Function))
+  })
+
+  it('hides a fullscreen macOS window only after leaving fullscreen', async () => {
+    vi.spyOn(process, 'platform', 'get').mockReturnValue('darwin')
+    const { ElectronDesktopRuntime } = await import('../src/electron-runtime.ts')
+    const runtime = new ElectronDesktopRuntime(async () => {})
+    const release = runtime.schedule(spec)
+
+    await runtime.mountScheduled()
+    const window = electron.browserWindows[0]!
+    window.isFullScreen.mockReturnValue(true)
+
+    const closeListener = electron.browserWindowOn.mock.calls.find(([event]) => event === 'close')?.[1]
+    expect(closeListener).toEqual(expect.any(Function))
+    const closeEvent = { preventDefault: vi.fn() }
+    closeListener(closeEvent)
+
+    expect(closeEvent.preventDefault).toHaveBeenCalledOnce()
+    expect(window.hide).not.toHaveBeenCalled()
+    expect(window.setFullScreen).toHaveBeenCalledWith(false)
+
+    const leaveFullscreen = window.once.mock.calls.find(([event]) => event === 'leave-full-screen')?.[1]
+    expect(leaveFullscreen).toEqual(expect.any(Function))
+    leaveFullscreen()
+    expect(window.hide).toHaveBeenCalledOnce()
+
+    await release()
+    expect(window.removeListener).toHaveBeenCalledWith('leave-full-screen', expect.any(Function))
+  })
+
+  it('hides a non-fullscreen window directly on close', async () => {
+    vi.spyOn(process, 'platform', 'get').mockReturnValue('darwin')
+    const { ElectronDesktopRuntime } = await import('../src/electron-runtime.ts')
+    const runtime = new ElectronDesktopRuntime(async () => {})
+    const release = runtime.schedule(spec)
+
+    await runtime.mountScheduled()
+    const window = electron.browserWindows[0]!
+
+    const closeListener = electron.browserWindowOn.mock.calls.find(([event]) => event === 'close')?.[1]
+    const closeEvent = { preventDefault: vi.fn() }
+    closeListener(closeEvent)
+
+    expect(closeEvent.preventDefault).toHaveBeenCalledOnce()
+    expect(window.hide).toHaveBeenCalledOnce()
+    expect(window.setFullScreen).not.toHaveBeenCalled()
+    expect(window.once).not.toHaveBeenCalledWith('leave-full-screen', expect.any(Function))
+
+    await release()
   })
 
   it('uses the Windows caption, hidden menu bar, removed menu, and fixed blue tray image', async () => {


### PR DESCRIPTION
## Problem

Closes #49 — on macOS, entering fullscreen and then clicking the red close button leaves the app stuck: the window is hidden while still in its fullscreen space, the space stays black, and only the system menu bar remains. After exiting fullscreen, the window can come back with a corrupted frame (native titlebar shown together with the desktop-drawn caption strip).

## Root cause

The close handler in `dsh-plugin-desktop/src/electron-runtime.ts` hides to the Dock on close (`event.preventDefault()` + `window.hide()`). Hiding a fullscreen macOS window is broken in Electron (electron/electron#20263): the fullscreen space goes black and the renderer is never shown again. The duplicated titlebar in the issue is a downstream symptom of that stuck fullscreen state.

## Fix

When the window is fullscreen on macOS, the close handler now exits fullscreen first and hides the window only after the `leave-full-screen` transition completes, so closing behaves exactly like the non-fullscreen path (hide to Dock, app keeps running in the tray, re-open works). The one-shot listener is removed when the shell generation releases.

## Verification
![Uploading 20260816-161311.gif…]()

- New unit tests in `dsh-plugin-desktop/tests/electron-runtime.spec.ts` cover both the fullscreen close path (exit fullscreen, then hide on `leave-full-screen`) and the unchanged non-fullscreen path (hide directly).
- `tsc --noEmit` (main + tests) and the full `vitest run` suite (274 tests) pass; `tsdown` build succeeds.

## Verification recording (macOS)

本地重新打包验证录屏：全屏 → 红色关闭 → 窗口先退出全屏并隐藏到 Dock → 从 Dock 唤起内容正常，无黑屏残留。

![修复验证录屏](https://github.com/user-attachments/assets/b3e66506-ca25-4767-a043-2a4f8d59411a)