### PR TITLE
feat(desktop): expose model image capability

### DIFF
--- a/.agents/notes/implemented/architecture/2026-08-16-desktop-model-image-capability.md
+++ b/.agents/notes/implemented/architecture/2026-08-16-desktop-model-image-capability.md
@@ -1,0 +1,25 @@
+# Agent Note: Desktop model image capability control
+
+Status: implemented
+
+[中文](2026-08-16-desktop-model-image-capability.zh.md)
+
+## Problem
+
+The Desktop runtime consumes the published `@deepseek-ai/dsh-client-ui-settings-models` bundle. Hand-declared third-party models default to text input, but the published model editor does not expose the existing `input` modality declaration. Users must otherwise edit `settings.yaml` to enable a provider model that accepts images.
+
+## Decision
+
+Desktop applies a Yarn patch to the pinned rc.6 model settings bundle. Each model row's expanded capability section gains an Image input checkbox. The control writes `input: [text, image]` when enabled and `input: [text]` when disabled. The default remains text-only, and the Host's existing image admission check remains authoritative.
+
+The patch is scoped to the published client bundle consumed by Desktop. It does not modify the pinned upstream submodule or introduce a second settings service. The resolution is version-pinned so a future upstream package change requires an explicit patch refresh.
+
+## Consequences
+
+Desktop users can configure third-party vision models without leaving the application. The Desktop image picker and the model capability control are independent: the picker supplies image content, while the model setting declares whether the selected route may receive it.
+
+A declaration remains an explicit claim about the endpoint. If the endpoint rejects images, the provider error remains possible and the user must disable the capability.
+
+## Verification
+
+The package surface test asserts the patch resolution and its image capability mutation. The image picker and package tests pass, and the Desktop package builds with the patch installed.

--- a/.agents/notes/implemented/architecture/2026-08-16-desktop-model-image-capability.zh.md
+++ b/.agents/notes/implemented/architecture/2026-08-16-desktop-model-image-capability.zh.md
@@ -1,0 +1,25 @@
+# Agent Note：Desktop 模型图片能力开关
+
+状态：已实现
+
+[English](2026-08-16-desktop-model-image-capability.md)
+
+## 问题
+
+Desktop runtime 使用已发布的 `@deepseek-ai/dsh-client-ui-settings-models` bundle。手动声明的第三方模型默认接受文本，但已发布的模型编辑器没有暴露现有的 `input` 模态声明。否则，用户必须编辑 `settings.yaml`，才能启用实际接受图片的提供方模型。
+
+## 决策
+
+Desktop 对固定的 rc.6 模型设置 bundle 应用 Yarn patch。每个模型行展开的能力区域增加“图片输入”复选框。启用时控件写入 `input: [text, image]`，停用时写入 `input: [text]`。默认值仍然是纯文本，Host 现有的图片 admission 检查继续作为权威校验。
+
+补丁只作用于 Desktop 消费的已发布 Client bundle，不修改固定的 upstream submodule，也不引入第二个 settings service。resolution 固定版本，因此上游 package 发生变化时必须显式刷新补丁。
+
+## 结果
+
+Desktop 用户可以直接在应用内配置第三方视觉模型。Desktop 图片选择器与模型能力开关相互独立：选择器提供图片内容，模型设置声明选中的路由是否可以接收图片。
+
+该声明仍然是用户对端点的明确断言。如果端点拒绝图片，提供方仍可能返回错误，用户需要关闭该能力。
+
+## 验证
+
+Package surface 测试断言 patch resolution 和图片能力 mutation。图片选择器与 package 测试通过，Desktop package 在应用补丁后构建成功。

--- a/.yarn/patches/@deepseek-ai-dsh-client-ui-settings-models-npm-0.1.0-rc.6-3766bee0bd.patch
+++ b/.yarn/patches/@deepseek-ai-dsh-client-ui-settings-models-npm-0.1.0-rc.6-3766bee0bd.patch
@@ -1,0 +1,71 @@
+diff --git a/lib/client.js b/lib/client.js
+index 644a0f2edecdb363a0157d63a67ad4a6af45b638..e8df90fccd240a6e8e1c03e6bc2bbd37f44f87e7 100644
+--- a/lib/client.js
++++ b/lib/client.js
+@@ -666,6 +666,10 @@ window.__ModuleLoader__.load({
+ 			const value = model[key];
+ 			return typeof value === "number" ? value : void 0;
+ 		}
++		/** Whether the model explicitly declares image input among its modalities. */
++		function acceptsImages(model) {
++			return Array.isArray(model.input) && model.input.includes("image");
++		}
+ 		/** Disclosure chevron; rotates to point down while its row is open. */
+ 		function IconChevron({ open }) {
+ 			return (0, react_jsx_runtime.jsx)("svg", {
+@@ -971,6 +975,33 @@ window.__ModuleLoader__.load({
+ 										editCapacity(index, "maxTokens", event.target.value);
+ 									}
+ 								})]
++							}), (0, react_jsx_runtime.jsxs)("label", {
++								style: {
++									display: "flex",
++									gridColumn: "1 / -1",
++									alignItems: "flex-start",
++									gap: "8px",
++									paddingTop: "4px",
++									cursor: "pointer"
++								},
++								children: [(0, react_jsx_runtime.jsx)("input", {
++									type: "checkbox",
++									checked: acceptsImages(model),
++									"aria-label": `${t("modelImageInput")} ${index + 1}`,
++									disabled,
++									onChange: (event) => {
++										patch(index, { input: event.target.checked ? ["text", "image"] : ["text"] });
++									}
++								}), (0, react_jsx_runtime.jsxs)("span", {
++									style: { fontSize: "12px", lineHeight: "18px" },
++									children: [(0, react_jsx_runtime.jsx)("span", {
++										style: { display: "block" },
++										children: t("modelImageInput")
++									}), (0, react_jsx_runtime.jsx)("span", {
++										style: { display: "block", color: "var(--dsw-alias-label-tertiary)" },
++										children: t("modelImageInputHint")
++									})]
++								})]
+ 							})]
+ 						}) : null]
+ 					}, index)),
+@@ -2488,7 +2519,9 @@ window.__ModuleLoader__.load({
+ 			contextWindowPlaceholder: "Uses the provider default",
+ 			maxTokens: "Max output tokens",
+ 			maxTokensPlaceholder: "Uses the provider default",
+-			modelAdvanced: "Capacities",
++			modelAdvanced: "Model capabilities",
++			modelImageInput: "Image input",
++			modelImageInputHint: "Enable only when this model accepts images.",
+ 			addModel: "Add model",
+ 			removeModel: "Delete model",
+ 			modelsEmpty: "No models will be shown in the selector. Unlisted IDs can still be sent directly.",
+@@ -2584,7 +2617,9 @@ window.__ModuleLoader__.load({
+ 			contextWindowPlaceholder: "使用提供方默认值",
+ 			maxTokens: "最大输出 token 数",
+ 			maxTokensPlaceholder: "使用提供方默认值",
+-			modelAdvanced: "容量",
++			modelAdvanced: "模型能力",
++			modelImageInput: "图片输入",
++			modelImageInputHint: "仅在该模型可以接收图片时启用。",
+ 			addModel: "添加模型",
+ 			removeModel: "删除模型",
+ 			modelsEmpty: "模型选择器中将不显示任何模型；目录外 ID 仍可直接发送。",

--- a/dsh-plugin-desktop/tests/package.spec.ts
+++ b/dsh-plugin-desktop/tests/package.spec.ts
@@ -286,6 +286,16 @@ describe('published package surface', () => {
     expect(installedCodeSign).toContain('"-k", keychainPassword, keychainFile')
   })
 
+  it('patches the model settings editor with explicit image input capability', () => {
+    const patchResolution = 'patch:@deepseek-ai/dsh-client-ui-settings-models@npm%3A0.1.0-rc.6#./.yarn/patches/@deepseek-ai-dsh-client-ui-settings-models-npm-0.1.0-rc.6-3766bee0bd.patch'
+    const patch = readFileSync(new URL('.yarn/patches/@deepseek-ai-dsh-client-ui-settings-models-npm-0.1.0-rc.6-3766bee0bd.patch', workspaceRoot), 'utf8')
+    expect(workspaceManifest.resolutions).toMatchObject({
+      '@deepseek-ai/dsh-client-ui-settings-models@npm:^0.1.0-rc.6': patchResolution,
+    })
+    expect(patch).toContain('modelImageInput')
+    expect(patch).toContain('input: event.target.checked ? ["text", "image"] : ["text"]')
+  })
+
   it('starts restricted Windows shells with a hidden console show state', () => {
     const patchResolution = 'patch:@deepseek-ai/dsh-sandbox-windows-acl@npm%3A0.1.0-rc.6#./patches/dsh-sandbox-windows-acl@0.1.0-rc.6.patch'
     const lockfile = readFileSync(new URL('yarn.lock', workspaceRoot), 'utf8')

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
   "resolutions": {
     "app-builder-lib@npm:26.15.3": "patch:app-builder-lib@npm%3A26.15.3#./patches/app-builder-lib@26.15.3.patch",
     "@deepseek-ai/dsh-sandbox-windows-acl@npm:0.1.0-rc.6": "patch:@deepseek-ai/dsh-sandbox-windows-acl@npm%3A0.1.0-rc.6#./patches/dsh-sandbox-windows-acl@0.1.0-rc.6.patch",
-    "@deepseek-ai/dsh-sandbox-windows-acl@npm:^0.1.0-rc.6": "patch:@deepseek-ai/dsh-sandbox-windows-acl@npm%3A0.1.0-rc.6#./patches/dsh-sandbox-windows-acl@0.1.0-rc.6.patch"
+    "@deepseek-ai/dsh-sandbox-windows-acl@npm:^0.1.0-rc.6": "patch:@deepseek-ai/dsh-sandbox-windows-acl@npm%3A0.1.0-rc.6#./patches/dsh-sandbox-windows-acl@0.1.0-rc.6.patch",
+    "@deepseek-ai/dsh-client-ui-settings-models@npm:^0.1.0-rc.6": "patch:@deepseek-ai/dsh-client-ui-settings-models@npm%3A0.1.0-rc.6#./.yarn/patches/@deepseek-ai-dsh-client-ui-settings-models-npm-0.1.0-rc.6-3766bee0bd.patch"
   },
   "dependenciesMeta": {
     "@deepseek-ai/dsh-subprocess-local": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1355,7 +1355,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@deepseek-ai/dsh-client-ui-settings-models@npm:^0.1.0-rc.6":
+"@deepseek-ai/dsh-client-ui-settings-models@npm:0.1.0-rc.6":
   version: 0.1.0-rc.6
   resolution: "@deepseek-ai/dsh-client-ui-settings-models@npm:0.1.0-rc.6"
   peerDependencies:
@@ -1370,6 +1370,24 @@ __metadata:
     "@deepseek-ai/dsh-invariants": ^0.1.0-rc.6
     react: ^18.2.0
   checksum: 10c0/006e90f314aa70641c236fe0f8fa807430e7503fbf418dd8521d206b81e156c17532385b83c620ca05dad86db36562fe276f47be1f3bdd5327cd6b12ab0a5735
+  languageName: node
+  linkType: hard
+
+"@deepseek-ai/dsh-client-ui-settings-models@patch:@deepseek-ai/dsh-client-ui-settings-models@npm%3A0.1.0-rc.6#./.yarn/patches/@deepseek-ai-dsh-client-ui-settings-models-npm-0.1.0-rc.6-3766bee0bd.patch::locator=deepseek-harness-desktop%40workspace%3A.":
+  version: 0.1.0-rc.6
+  resolution: "@deepseek-ai/dsh-client-ui-settings-models@patch:@deepseek-ai/dsh-client-ui-settings-models@npm%3A0.1.0-rc.6#./.yarn/patches/@deepseek-ai-dsh-client-ui-settings-models-npm-0.1.0-rc.6-3766bee0bd.patch::version=0.1.0-rc.6&hash=4e1910&locator=deepseek-harness-desktop%40workspace%3A."
+  peerDependencies:
+    "@deepseek-ai/cordis": ^4.0.1
+    "@deepseek-ai/dsh-api-remotes": ^0.1.0-rc.6
+    "@deepseek-ai/dsh-client-connection": ^0.1.0-rc.6
+    "@deepseek-ai/dsh-client-runtime": ^0.1.0-rc.6
+    "@deepseek-ai/dsh-client-schema-form": ^0.1.0-rc.6
+    "@deepseek-ai/dsh-client-ui-primitives": ^0.1.0-rc.6
+    "@deepseek-ai/dsh-client-ui-slots": ^0.1.0-rc.6
+    "@deepseek-ai/dsh-client-web-react": ^0.1.0-rc.6
+    "@deepseek-ai/dsh-invariants": ^0.1.0-rc.6
+    react: ^18.2.0
+  checksum: 10c0/e5ba436696e1481b9ab1c6e55f933f4a306e580de2102200d9fb4f529e0d18123524f202fdae0e3a827a4a37e553299668243a0fb5bab366fd34287b96fbf05e
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

- add a Desktop-scoped Yarn patch for the published rc.6 model settings bundle
- expose an Image input checkbox in each custom model's expanded Model capabilities section
- persist `input: [text, image]` when enabled and `input: [text]` when disabled
- keep text-only as the safe default and leave Host image admission authoritative

## Why Desktop owns this patch

The Desktop runtime consumes the published `@deepseek-ai/dsh-client-ui-settings-models` bundle and does not edit the pinned upstream submodule. This patch makes the existing `input` modality declaration available in the packaged Desktop UI without introducing a parallel settings service. The resolution is pinned to rc.6 and must be refreshed when the upstream bundle changes.

## Verification

- `yarn workspace dsh-plugin-desktop exec vitest run tests/package.spec.ts tests/attachment-picker.client.spec.ts` — 18 passed
- `yarn workspace dsh-plugin-desktop run build` — passed
- `yarn workspace dsh-plugin-desktop run verify:loader` — passed
- installed bundle contains `Image input` / `图片输入` and writes the expected modality arrays

The working tree contains an unrelated pre-existing untracked `docs/design/` directory; it is not included in this PR.
