### PR TITLE
fix(desktop): reject truncated installer downloads

### DIFF
--- a/dsh-plugin-desktop/src/update-download.ts
+++ b/dsh-plugin-desktop/src/update-download.ts
@@ -120,11 +120,11 @@ export async function downloadDesktopUpdate(options: DownloadDesktopUpdateOption
   if (response.body === null) {
     throw new UpdateDownloadError('empty-body', 'The update download service returned an empty body.')
   }
-  assertDeclaredSize(response)
+  const declaredSize = assertDeclaredSize(response)
 
   let failure: unknown
   try {
-    await writeResponseBody(paths.temporary, response.body, options.signal)
+    await writeResponseBody(paths.temporary, response.body, options.signal, declaredSize)
     throwIfAborted(options.signal)
     await validateArtifact(paths.temporary, platform)
     throwIfAborted(options.signal)
@@ -220,21 +220,24 @@ async function lstatOptional(filename: string): Promise<Awaited<ReturnType<typeo
   }
 }
 
-function assertDeclaredSize(response: Response): void {
+function assertDeclaredSize(response: Response): bigint | undefined {
   const declared = response.headers.get('content-length')
-  if (declared === null || !DECIMAL_BYTES.test(declared)) return
-  if (BigInt(declared) > BigInt(MAX_UPDATE_DOWNLOAD_BYTES)) {
+  if (declared === null || !DECIMAL_BYTES.test(declared)) return undefined
+  const bytes = BigInt(declared)
+  if (bytes > BigInt(MAX_UPDATE_DOWNLOAD_BYTES)) {
     throw new UpdateDownloadError(
       'response-too-large',
       `The update installer exceeds ${String(MAX_UPDATE_DOWNLOAD_BYTES)} bytes.`,
     )
   }
+  return bytes
 }
 
 async function writeResponseBody(
   filename: string,
   body: ReadableStream<Uint8Array>,
   signal: AbortSignal | undefined,
+  declaredSize: bigint | undefined,
 ): Promise<void> {
   const handle = await open(filename, 'wx', PRIVATE_FILE_MODE)
   const reader = body.getReader()
@@ -256,6 +259,12 @@ async function writeResponseBody(
     }
     if (bytesWritten === 0) {
       throw new UpdateDownloadError('empty-body', 'The update download service returned an empty body.')
+    }
+    if (declaredSize !== undefined && BigInt(bytesWritten) !== declaredSize) {
+      throw new UpdateDownloadError(
+        'invalid-artifact',
+        'The update installer download was truncated before it completed.',
+      )
     }
     await handle.sync()
   } catch (cause) {

--- a/dsh-plugin-desktop/tests/update-download.spec.ts
+++ b/dsh-plugin-desktop/tests/update-download.spec.ts
@@ -111,6 +111,39 @@ describe('desktop update installer download', () => {
     await expectNoPartialFiles(userDataPath, '2.2.0')
   })
 
+  it('rejects a truncated Windows executable whose delivered size falls short of the declared length', async () => {
+    const userDataPath = await temporaryUserData()
+    const artifact = windowsArtifact()
+    await expectFailure(downloadDesktopUpdate({
+      platform: 'win32',
+      version: '2.2.1',
+      userDataPath,
+      request: async () => chunkedResponse(
+        [artifact],
+        { 'content-length': String(artifact.byteLength + 512) },
+      ),
+    }), 'invalid-artifact')
+    await expectNoPartialFiles(userDataPath, '2.2.1')
+  })
+
+  it('accepts a Windows executable whose delivered size matches the declared length', async () => {
+    const userDataPath = await temporaryUserData()
+    const artifact = windowsArtifact()
+    const result = await downloadDesktopUpdate({
+      platform: 'win32',
+      version: '2.2.2',
+      userDataPath,
+      request: async () => chunkedResponse(
+        [artifact],
+        { 'content-length': String(artifact.byteLength) },
+      ),
+    })
+
+    expect(result).toBe(join(userDataPath, 'updates', '2.2.2', 'DSH-Desktop-2.2.2-windows.exe'))
+    expect(await readFile(result)).toEqual(Buffer.from(artifact))
+    await expectNoPartialFiles(userDataPath, '2.2.2')
+  })
+
   it('accepts canonical stable SemVer build metadata in the private artifact path', async () => {
     const userDataPath = await temporaryUserData()
     const result = await downloadDesktopUpdate({


### PR DESCRIPTION
## 问题
`downloadDesktopUpdate` 从不校验声明的 `content-length` 与实际写入字节数是否一致，Windows 安装包校验只检查文件头的 MZ/PE 魔数。连接中断导致的**截断 exe 会被当作完整安装包接受并执行**（macOS 分支校验文件尾 koly trailer，可抓住截断；Windows 分支不对称）。
仓库现有测试甚至把 512 字节的 MZ+PE 空壳断言为合法安装包（`windowsArtifact()`），固化了该行为。
## 复现
vitest 用例：声明 `content-length: 2048`、实际只送达 512 字节合法头的安装包，当前代码直接通过校验并返回路径。
## 修复
- `assertDeclaredSize` 返回声明的字节数（无声明时返回 undefined）
- `writeResponseBody` 完成后比对实收字节数与声明值，不一致抛 `invalid-artifact`（截断）
- 新增回归测试：截断被拒绝；声明与实收一致仍被接受
## 验证
- `vitest run tests/update-download.spec.ts`：20 通过 / 1 跳过（win32 符号链接用例）
- `tsc --noEmit`（typecheck）通过