### PR TITLE
fix(desktop): resolve profile switch after restart disposal

### DIFF
--- a/dsh-plugin-desktop/src/profile-service.ts
+++ b/dsh-plugin-desktop/src/profile-service.ts
@@ -112,7 +112,6 @@ export class DesktopProfileService extends Service implements DesktopProfiles {
         return this.runExclusive(name, async () => {
           this.assertActive()
           await this.bootstrap.requestRestart()
-          this.assertActive()
           this.restartCompleted = true
         })
       }
@@ -122,7 +121,6 @@ export class DesktopProfileService extends Service implements DesktopProfiles {
         this.committedName = name
         this.assertActive()
         await this.bootstrap.requestRestart()
-        this.assertActive()
         this.restartCompleted = true
       })
     } catch (cause) {

--- a/dsh-plugin-desktop/tests/profile-service.spec.ts
+++ b/dsh-plugin-desktop/tests/profile-service.spec.ts
@@ -176,6 +176,19 @@ describe('desktop profile service', () => {
     expect(requestRestart).toHaveBeenCalledTimes(2)
   })
 
+  it('resolves after restart disposes the service fiber, matching the launcher restart timing', async () => {
+    // main.ts 的真实链：requestRestart → shutdown.request → fiber.dispose()，
+    // 销毁本服务的 fiber（disposed=true）后才 resolve。
+    let disposeFiber!: () => Promise<unknown>
+    const bootstrap = createBootstrap({
+      requestRestart: async () => { await disposeFiber() },
+    })
+    const mounted = await mount(bootstrap)
+    disposeFiber = mounted.dispose
+
+    await expect(mounted.service.select('work')).resolves.toBeUndefined()
+  })
+
   it('unregisters with its fiber and rejects retained calls after disposal', async () => {
     const pending = deferred<void>()
     const requestRestart = vi.fn(async () => {})


### PR DESCRIPTION
## 问题
`DesktopProfileService.select()` 在 `await requestRestart()` 之后调用 `assertActive()`。真实链路（`main.ts`）里 `requestRestart` → `shutdown.request(0)` → `fiber.dispose()`，会在 resolve 之前把本服务的 fiber 销毁（`disposed = true`），因此**每次切换 profile 都必然以 `desktopProfiles service disposed` 拒绝**，`restartCompleted` 成为不可达死代码，依赖 `select()` 的调用方收到假失败。
## 复现
vitest 用例：`requestRestart` 模拟真实时序（销毁服务自身 fiber），`select('work')` 当前代码以 `desktopProfiles service disposed` 拒绝（堆栈指向 `profile-service.ts:125`）。
## 修复
- 删除 `await requestRestart()` 之后的 `assertActive()`（两处：committed 分支与首次选择分支）——重启按设计会销毁本服务，之后不应再访问服务状态
- 新增回归测试：重启销毁 fiber 后 `select()` 正常 resolve
## 验证
- `vitest run tests/profile-service.spec.ts`：10 通过
- `tsc --noEmit`（typecheck）通过