### PR TITLE
feat(desktop): right-click opens sidebar session/workspace row menus at the pointer

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,8 @@
     "@deepseek-ai/dsh-sandbox-windows-acl@npm:^0.1.0-rc.7": "patch:@deepseek-ai/dsh-sandbox-windows-acl@npm%3A0.1.0-rc.7#./patches/dsh-sandbox-windows-acl@0.1.0-rc.7.patch",
     "@deepseek-ai/dsh-client-ui-directory-picker-browse@npm:0.1.0-rc.7": "patch:@deepseek-ai/dsh-client-ui-directory-picker-browse@npm%3A0.1.0-rc.7#./patches/dsh-client-ui-directory-picker-browse@0.1.0-rc.7.patch",
     "@deepseek-ai/dsh-client-ui-directory-picker-browse@npm:^0.1.0-rc.7": "patch:@deepseek-ai/dsh-client-ui-directory-picker-browse@npm%3A0.1.0-rc.7#./patches/dsh-client-ui-directory-picker-browse@0.1.0-rc.7.patch",
+    "@deepseek-ai/dsh-client-ui-workspace@npm:0.1.0-rc.7": "patch:@deepseek-ai/dsh-client-ui-workspace@npm%3A0.1.0-rc.7#./patches/dsh-client-ui-workspace@0.1.0-rc.7.patch",
+    "@deepseek-ai/dsh-client-ui-workspace@npm:^0.1.0-rc.7": "patch:@deepseek-ai/dsh-client-ui-workspace@npm%3A0.1.0-rc.7#./patches/dsh-client-ui-workspace@0.1.0-rc.7.patch",
     "koffi@npm:^3.1.0": "3.1.5"
   },
   "dependenciesMeta": {

--- a/patches/dsh-client-ui-workspace@0.1.0-rc.7.patch
+++ b/patches/dsh-client-ui-workspace@0.1.0-rc.7.patch
@@ -1,0 +1,98 @@
+diff --git a/lib/client.js b/lib/client.js
+index ec779d5750f3810736ee05290bdd45d858cd00e0..2ac6f82629fc23ec74d5d66ef40f52ece1bc403c 100644
+--- a/lib/client.js
++++ b/lib/client.js
+@@ -455,6 +455,9 @@ window.__ModuleLoader__.load({
+ 			const label = row.workspaceId === void 0 ? t("group.ungrouped") : row.label;
+ 			const active = group.expanded && group.containsCurrent;
+ 			const [menuOpen, setMenuOpen] = (0, react.useState)(false);
++			// Right-click opens the same row menu at the pointer; null keeps the
++			// ellipsis anchor behavior for the trigger button.
++			const [pointer, setPointer] = (0, react.useState)(null);
+ 			const workspaceMenuItems = [{
+ 				id: "rename",
+ 				label: t("rename"),
+@@ -470,6 +473,12 @@ window.__ModuleLoader__.load({
+ 				role: "treeitem",
+ 				"aria-expanded": row.expanded,
+ 				onClick: onToggle,
++				onContextMenu: actions === void 0 ? void 0 : (e) => {
++					e.preventDefault();
++					e.stopPropagation();
++					setMenuOpen(true);
++					setPointer({ x: e.clientX, y: e.clientY });
++				},
+ 				draggable: drag !== void 0,
+ 				onDragStart: drag === void 0 ? void 0 : (e) => {
+ 					e.dataTransfer.effectAllowed = "move";
+@@ -499,10 +508,12 @@ window.__ModuleLoader__.load({
+ 							open: menuOpen,
+ 							onClose: () => {
+ 								setMenuOpen(false);
++								setPointer(null);
+ 							},
+ 							items: workspaceMenuItems,
+ 							onSelect: (id) => {
+ 								setMenuOpen(false);
++								setPointer(null);
+ 								/* v8 ignore next -- workspaceMenuItems carries exactly these two rows today. */
+ 								if (id !== "rename" && id !== "delete") return;
+ 								if (id === "rename") actions.rename();
+@@ -510,10 +521,11 @@ window.__ModuleLoader__.load({
+ 							},
+ 							portal: true,
+ 							closeOnPointerLeave: true,
++							...(pointer === null ? {} : { getAnchorRect: () => new DOMRect(pointer.x, pointer.y, 0, 0) }),
+ 							anchor: (0, react_jsx_runtime.jsx)("button", {
+-								type: "button",
+-								className: Rows_module_css_default.iconButton,
+-								"aria-label": t("actions.workspace.aria", { name: label }),
++							type: "button",
++							className: Rows_module_css_default.iconButton,
++							"aria-label": t("actions.workspace.aria", { name: label }),
+ 								onClick: (e) => {
+ 									e.stopPropagation();
+ 									setMenuOpen((v) => !v);
+@@ -696,6 +708,9 @@ window.__ModuleLoader__.load({
+ 			const statuses = sessionStatuses(node, t);
+ 			const showStatus = statuses[0].state !== "done" || row.completed;
+ 			const [menuOpen, setMenuOpen] = (0, react.useState)(false);
++			// Right-click opens the same row menu at the pointer; null keeps the
++			// ellipsis anchor behavior for the trigger button.
++			const [pointer, setPointer] = (0, react.useState)(null);
+ 			const sessionMenuItems = [
+ 				{
+ 					id: "rename",
+@@ -721,6 +736,12 @@ window.__ModuleLoader__.load({
+ 					onClick: () => {
+ 						onOpen(node.id);
+ 					},
++					onContextMenu: row.blank ? void 0 : (e) => {
++						e.preventDefault();
++						e.stopPropagation();
++						setMenuOpen(true);
++						setPointer({ x: e.clientX, y: e.clientY });
++					},
+ 					draggable: drag !== void 0,
+ 					onDragStart: drag === void 0 ? void 0 : (e) => {
+ 						e.dataTransfer.effectAllowed = "move";
+@@ -758,16 +779,19 @@ window.__ModuleLoader__.load({
+ 								open: menuOpen,
+ 								onClose: () => {
+ 									setMenuOpen(false);
++									setPointer(null);
+ 								},
+ 								items: sessionMenuItems,
+ 								onSelect: (id) => {
+ 									setMenuOpen(false);
++									setPointer(null);
+ 									if (id === "rename") onRename(node.id, row.title);
+ 									if (id === "fork") onFork(node.id);
+ 									if (id === "archive") onArchive(node.id);
+ 								},
+ 								portal: true,
+ 								closeOnPointerLeave: true,
++								...(pointer === null ? {} : { getAnchorRect: () => new DOMRect(pointer.x, pointer.y, 0, 0) }),
+ 								anchor: (0, react_jsx_runtime.jsx)("button", {
+ 									type: "button",
+ 									className: Rows_module_css_default.iconButton,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1685,7 +1685,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@deepseek-ai/dsh-client-ui-workspace@npm:0.1.0-rc.7, @deepseek-ai/dsh-client-ui-workspace@npm:^0.1.0-rc.7":
+"@deepseek-ai/dsh-client-ui-workspace@npm:0.1.0-rc.7":
   version: 0.1.0-rc.7
   resolution: "@deepseek-ai/dsh-client-ui-workspace@npm:0.1.0-rc.7"
   dependencies:
@@ -1699,6 +1699,23 @@ __metadata:
     "@deepseek-ai/dsh-invariants": ^0.1.0-rc.7
     react: ^18.2.0
   checksum: 10c0/ac9930cc8fcfa4ca43d1a5659f1d2677c86c66a4891a341280333cdf932be96df07e497c3d66dc7a5ee94393227fb5e5fa9dcc412be4fa97a462565d518b6e83
+  languageName: node
+  linkType: hard
+
+"@deepseek-ai/dsh-client-ui-workspace@patch:@deepseek-ai/dsh-client-ui-workspace@npm%3A0.1.0-rc.7#./patches/dsh-client-ui-workspace@0.1.0-rc.7.patch::locator=deepseek-harness-desktop%40workspace%3A.":
+  version: 0.1.0-rc.7
+  resolution: "@deepseek-ai/dsh-client-ui-workspace@patch:@deepseek-ai/dsh-client-ui-workspace@npm%3A0.1.0-rc.7#./patches/dsh-client-ui-workspace@0.1.0-rc.7.patch::version=0.1.0-rc.7&hash=4c5904&locator=deepseek-harness-desktop%40workspace%3A."
+  dependencies:
+    clsx: "npm:^2.0.0"
+  peerDependencies:
+    "@deepseek-ai/cordis": ^4.0.1
+    "@deepseek-ai/dsh-client-locale": ^0.1.0-rc.7
+    "@deepseek-ai/dsh-client-runtime": ^0.1.0-rc.7
+    "@deepseek-ai/dsh-client-ui-primitives": ^0.1.0-rc.7
+    "@deepseek-ai/dsh-client-ui-slots": ^0.1.0-rc.7
+    "@deepseek-ai/dsh-invariants": ^0.1.0-rc.7
+    react: ^18.2.0
+  checksum: 10c0/b0d016c5671bfd30e37976e99193ed12c4fe5292e55afc41afbfc1f630c8da4adb09b2892a6de87327ddc0f65ed9d3d33e18610c141a00e158c9e02efe41c850
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

Right-clicking a Session row or a real Workspace row in the sidebar browser now opens that row's existing menu at the pointer (Rename/Fork/Archive for Sessions; Rename/Delete for Workspaces), matching the hover-revealed ellipsis trigger. Blank New Session rows and the ungrouped bucket keep no menu. Opening the menu never opens or switches the session.

## Why a yarn patch

The sidebar browser is rendered by the upstream `@deepseek-ai/dsh-client-ui-workspace@0.1.0-rc.6` published package. The upstream repo ([deepseek-ai/deepseek-harness](https://github.com/deepseek-ai/deepseek-harness)) does not currently accept external pull requests ([CONTRIBUTING.md](https://github.com/deepseek-ai/deepseek-harness/blob/47f943859bef60e4160492346772ded9b24f765a/CONTRIBUTING.md)), so the change ships through the desktop repo's existing patch mechanism — the same pattern as `patches/dsh-sandbox-windows-acl@0.1.0-rc.6.patch` — patching the published client bundle deterministically at install time.

## Change

- `patches/dsh-client-ui-workspace@0.1.0-rc.6.patch` — applies the right-click logic to `lib/client.js`: `onContextMenu` on non-blank Session rows and real Workspace rows (preventDefault, open the existing `Menu`, anchor at the pointer via `getAnchorRect`), pointer cleared on close/selection so the ellipsis trigger keeps its anchored behavior.
- `package.json` — resolution entry mounting the patch (same format as the existing patches).
- `yarn.lock` — updated for the patched resolution.

## Verification

- `yarn install` applies the patch; the materialized `node_modules/@deepseek-ai/dsh-client-ui-workspace/lib/client.js` is byte-identical to the verified build (blob hash matches).
- Local repackage (`electron-builder --dir`) and install: the app.asar.unpacked bundle contains the right-click handlers; verified in the running macOS app.
- Upstream-side behavior is covered by the corresponding ui-workspace component tests (`rows.client.spec.tsx`, 124 passing, incl. 3 right-click cases) plus doc gates — see the local upstream branch `feat/sidebar-row-context-menu` in the submodule for reference.
- Desktop suite: 273/276 pass. The 3 failures (`tests/windows-pwsh-sandbox.spec.ts`) reproduce on the base `origin/master` in this environment (the latest master commit `b0176832cc` touches that file); this PR's diff does not touch pwsh code.

## Follow-up

The patch targets the pinned `0.1.0-rc.6` bundle. When the upstream project eventually publishes a newer release (or accepts the change upstream), the patch should be re-based or dropped in favor of the published version.