### PR TITLE
fix(desktop): prevent node-pty from rewriting unpacked asar paths twice

### DIFF
--- a/dsh-plugin-desktop/scripts/verify-mac-smoke.ts
+++ b/dsh-plugin-desktop/scripts/verify-mac-smoke.ts
@@ -7,6 +7,17 @@ import { basename, dirname, join, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { MACOS_UNIVERSAL_NATIVE_ENTRIES } from './mac-universal.ts'
 
+const NODE_PTY_SMOKE_TIMEOUT_MS = 5_000
+
+function nodePtySmokeScript(nodePtyRoot: string): string {
+  return [
+    `const pty = require(${JSON.stringify(nodePtyRoot)})`,
+    "const terminal = pty.spawn('/usr/bin/true', [], { name: 'xterm-256color', cols: 80, rows: 24, cwd: '/', env: process.env })",
+    `const timeout = setTimeout(() => { terminal.kill(); process.exit(124) }, ${String(NODE_PTY_SMOKE_TIMEOUT_MS)})`,
+    'terminal.onExit(({ exitCode }) => { clearTimeout(timeout); process.exit(exitCode === 0 ? 0 : 1) })',
+  ].join(';')
+}
+
 /** Injectable filesystem and command boundaries for smoke verification. */
 export interface MacSmokeVerificationOptions {
   /** Directory containing exactly one smoke DMG. */
@@ -141,6 +152,22 @@ export function verifyMacSmoke(
       }
       options.run('lipo', [nativePath, '-verify_arch', entry.arch])
     }
+
+    const nodePtyRoot = join(unpackedRoot, 'node_modules', 'node-pty')
+    const nodePtyManifest = join(nodePtyRoot, 'package.json')
+    if (!options.exists(nodePtyManifest)) {
+      throw new Error(`universal application is missing node-pty package: ${nodePtyManifest}`)
+    }
+
+    // Exercise the node-pty instance sealed inside the Universal application.
+    // Without the asar rewrite guard, helper resolution becomes
+    // app.asar.unpacked.unpacked and this spawn fails with posix_spawnp.
+    options.run('/usr/bin/env', [
+      'ELECTRON_RUN_AS_NODE=1',
+      executablePath,
+      '-e',
+      nodePtySmokeScript(nodePtyRoot),
+    ])
   } catch (cause) {
     failure = cause
   }

--- a/dsh-plugin-desktop/tests/package.spec.ts
+++ b/dsh-plugin-desktop/tests/package.spec.ts
@@ -652,3 +652,23 @@ describe('published package surface', () => {
     expect(installedRuntime).not.toContain('134217728')
   })
 })
+
+describe('node-pty packaged runtime', () => {
+  it('does not rewrite an already-unpacked spawn helper path twice', () => {
+    const unixTerminal = readFileSync(
+      new URL('node_modules/node-pty/lib/unixTerminal.js', packageRoot),
+      'utf8',
+    )
+
+    expect(unixTerminal).toContain([
+      "if (helperPath.indexOf('app.asar.unpacked') === -1) {",
+      "    helperPath = helperPath.replace('app.asar', 'app.asar.unpacked');",
+      '}',
+      "if (helperPath.indexOf('node_modules.asar.unpacked') === -1) {",
+      "    helperPath = helperPath.replace('node_modules.asar', 'node_modules.asar.unpacked');",
+      '}',
+    ].join('\n'))
+    expect(unixTerminal.match(/helperPath = helperPath\.replace\('app\.asar'/gu)).toHaveLength(1)
+    expect(unixTerminal.match(/helperPath = helperPath\.replace\('node_modules\.asar'/gu)).toHaveLength(1)
+  })
+})

--- a/dsh-plugin-desktop/tests/verify-mac-smoke.spec.ts
+++ b/dsh-plugin-desktop/tests/verify-mac-smoke.spec.ts
@@ -15,6 +15,7 @@ interface AppFixture {
   readonly infoPlist: string
   readonly executable: string
   readonly appAsar: string
+  readonly nodePtyRoot: string
   readonly modeOverrides: Map<string, number>
 }
 
@@ -44,7 +45,10 @@ function fixture(): AppFixture {
       modeOverrides.set(path, 0o755)
     }
   }
-  return { root, infoPlist, executable, appAsar, modeOverrides }
+  const nodePtyRoot = join(`${appAsar}.unpacked`, 'node_modules', 'node-pty')
+  mkdirSync(nodePtyRoot, { recursive: true })
+  writeFileSync(join(nodePtyRoot, 'package.json'), '{"main":"lib/index.js"}')
+  return { root, infoPlist, executable, appAsar, nodePtyRoot, modeOverrides }
 }
 
 function options(
@@ -123,8 +127,19 @@ describe('macOS DMG smoke artifact verification', () => {
         command: 'lipo',
         args: [join(`${value.appAsar}.unpacked`, entry.path), '-verify_arch', entry.arch],
       })),
+      {
+        command: '/usr/bin/env',
+        args: [
+          'ELECTRON_RUN_AS_NODE=1',
+          value.executable,
+          '-e',
+          expect.stringContaining(`require(${JSON.stringify(value.nodePtyRoot)})`),
+        ],
+      },
       { command: 'hdiutil', args: ['detach', value.root] },
     ])
+    const nodePtySmoke = harness.calls.find(call => call.command === '/usr/bin/env')
+    expect(nodePtySmoke?.args.at(-1)).toContain("pty.spawn('/usr/bin/true'")
     expect(harness.removeMountPoint).toHaveBeenCalledWith(value.root)
   })
 
@@ -177,6 +192,16 @@ describe('macOS DMG smoke artifact verification', () => {
     const harness = options({ makeMountPoint: () => value.root }, value.modeOverrides)
 
     expectSmokeFailure(harness, 'app.asar')
+    expect(harness.removeMountPoint).toHaveBeenCalledWith(value.root)
+  })
+
+  it('rejects an application without its unpacked node-pty runtime', () => {
+    const value = fixture()
+    rmSync(join(value.nodePtyRoot, 'package.json'))
+    const harness = options({ makeMountPoint: () => value.root }, value.modeOverrides)
+
+    expectSmokeFailure(harness, 'node-pty package')
+    expect(harness.calls.some(call => call.command === '/usr/bin/env')).toBe(false)
     expect(harness.removeMountPoint).toHaveBeenCalledWith(value.root)
   })
 })

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   ],
   "resolutions": {
     "app-builder-lib@npm:26.15.7": "patch:app-builder-lib@npm%3A26.15.7#./patches/app-builder-lib@26.15.7.patch",
+    "node-pty": "patch:node-pty@npm%3A1.1.0#./patches/node-pty@1.1.0.patch",
     "@deepseek-ai/dsh-app-boot@npm:0.1.0-rc.7": "patch:@deepseek-ai/dsh-app-boot@npm%3A0.1.0-rc.7#./patches/dsh-app-boot@0.1.0-rc.7.patch",
     "@deepseek-ai/dsh-app-boot@npm:^0.1.0-rc.7": "patch:@deepseek-ai/dsh-app-boot@npm%3A0.1.0-rc.7#./patches/dsh-app-boot@0.1.0-rc.7.patch",
     "@deepseek-ai/dsh-llm-deepseek@npm:^0.1.0-rc.7": "patch:@deepseek-ai/dsh-llm-deepseek@npm%3A0.1.0-rc.7#./patches/dsh-llm-deepseek@0.1.0-rc.7.patch",

--- a/patches/node-pty@1.1.0.patch
+++ b/patches/node-pty@1.1.0.patch
@@ -1,0 +1,20 @@
+diff --git a/lib/unixTerminal.js b/lib/unixTerminal.js
+--- a/lib/unixTerminal.js
++++ b/lib/unixTerminal.js
+@@ -26,10 +26,14 @@ var terminal_1 = require("./terminal");
+ var utils_1 = require("./utils");
+ var native = utils_1.loadNativeModule('pty');
+ var pty = native.module;
+ var helperPath = native.dir + '/spawn-helper';
+ helperPath = path.resolve(__dirname, helperPath);
+-helperPath = helperPath.replace('app.asar', 'app.asar.unpacked');
+-helperPath = helperPath.replace('node_modules.asar', 'node_modules.asar.unpacked');
++if (helperPath.indexOf('app.asar.unpacked') === -1) {
++    helperPath = helperPath.replace('app.asar', 'app.asar.unpacked');
++}
++if (helperPath.indexOf('node_modules.asar.unpacked') === -1) {
++    helperPath = helperPath.replace('node_modules.asar', 'node_modules.asar.unpacked');
++}
+ var DEFAULT_FILE = 'sh';
+ var DEFAULT_NAME = 'xterm';
+ var DESTROY_SOCKET_TIMEOUT_MS = 200;

--- a/yarn.lock
+++ b/yarn.lock
@@ -9667,13 +9667,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"node-pty@npm:1.2.0-beta.15":
-  version: 1.2.0-beta.15
-  resolution: "node-pty@npm:1.2.0-beta.15"
+"node-pty@npm:1.1.0":
+  version: 1.1.0
+  resolution: "node-pty@npm:1.1.0"
   dependencies:
     node-addon-api: "npm:^7.1.0"
     node-gyp: "npm:latest"
-  checksum: 10c0/2f2bcca18efe94f56fd5c9fc9611164f63af912b96286ea4d858f4886e3b25aa9c529e3d7680d47e5ddefc6c3e799786ed11dc4b80947e40438e00a67dbc2fbf
+  checksum: 10c0/e527305263da36d554b7d2116aee6430b898675fc50e7bd82fbd762f14cb6b948fb8d997736af1f70d76bf9ffd4f5179bc1ed1d8002567dfcf3b29f039291798
+  languageName: node
+  linkType: hard
+
+"node-pty@patch:node-pty@npm%3A1.1.0#./patches/node-pty@1.1.0.patch::locator=deepseek-harness-desktop%40workspace%3A.":
+  version: 1.1.0
+  resolution: "node-pty@patch:node-pty@npm%3A1.1.0#./patches/node-pty@1.1.0.patch::version=1.1.0&hash=1e7fd1&locator=deepseek-harness-desktop%40workspace%3A."
+  dependencies:
+    node-addon-api: "npm:^7.1.0"
+    node-gyp: "npm:latest"
+  checksum: 10c0/8d4df6bdfc0a8860b8a96632c40a0dd389831f38f19e9f8ca84c6e75c27a4b5684248ce38c38ed65da37bc86e874ea9c459f5d84c5a520ac7a6353e618c69c7b
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Fixes #91

## Summary

- patch `node-pty@1.1.0` to avoid rewriting an already-unpacked asar path
- add a regression test for the `app.asar.unpacked.unpacked` case
- keep the existing spawn-helper executable-bit workaround unchanged

## Root cause

In the packaged app, node-pty resolves its helper under:

`app.asar.unpacked/node_modules/node-pty/.../spawn-helper`

node-pty 1.1.0 rewrites `app.asar` unconditionally, producing:

`app.asar.unpacked.unpacked/...`

The helper cannot be found, so PTY creation fails with `posix_spawnp failed`.

This patch backports microsoft/node-pty#924.

## Verification

- `corepack yarn workspace dsh-plugin-desktop typecheck`
- `corepack yarn workspace dsh-plugin-desktop test` — 273 tests passed
- `corepack yarn check`
- `corepack yarn install --immutable`
- `corepack yarn workspace dsh-plugin-desktop package:dir`
- packaged Electron smoke:
  - `/usr/bin/true` exits successfully
  - `/bin/bash` → `echo ping` → `ping`