### PR TITLE
feat(desktop): support building an Intel macOS release

### DIFF
--- a/dsh-plugin-desktop/README.md
+++ b/dsh-plugin-desktop/README.md
@@ -161,6 +161,19 @@ Python and Visual Studio C++ Build Tools are not required. The Windows command u
 
 This local command deliberately strips Windows certificate variables and sets `signExecutable=false`. Its output is installable for testing but has no Authenticode publisher, so Windows can display an Unknown publisher or SmartScreen warning. A signed Windows release, certificate verification, installer upgrade/uninstall testing, and native UI/sandbox smoke remain separate release gates.
 
+### Local macOS release
+
+`dist:mac` builds one signed and notarized macOS DMG from validated release credentials, then mounts, verifies, and detaches that DMG. One invocation produces exactly one architecture. The release architecture comes from the `DSH_MAC_ARCH` environment variable and defaults to `arm64`:
+
+```bash
+DSH_MAC_ARCH=x64 yarn dist:mac      # Intel DMG
+DSH_MAC_ARCH=arm64 yarn dist:mac    # Apple silicon DMG (default)
+```
+
+Electron Builder receives the matching `--x64` or `--arm64` flag, and the artifact name embeds the architecture (`DSH-Desktop-${version}-mac-x64.dmg` or `DSH-Desktop-${version}-mac-arm64.dmg`) so one distribution directory can hold both without a naming collision. `DSH_MAC_ARCH` is not a release secret, so it is forwarded to the verified `electron-builder` subprocess and to `verify-mac-release.ts`, whose error and success messages name the expected architecture. Build the Intel and arm64 artifacts on their native hosts (an Intel host for `x64`, an Apple silicon host for `arm64`) so Electron ships the correct binary per DMG.
+
+Supporting Intel macOS is a build capability. Distribution is a release-operator step: after both DMGs are published, the version service and the macOS download endpoint should route each running application to the DMG that matches its installed architecture. The update client opens whichever DMG the endpoint serves, so routing the Intel DMG to Intel installs is what makes the Intel build reachable in-app.
+
 ## Model Experience
 
 None. The desktop package changes application composition and native presentation; it does not add model-visible instructions, tools, events, or request fields.

--- a/dsh-plugin-desktop/README.zh.md
+++ b/dsh-plugin-desktop/README.zh.md
@@ -161,6 +161,20 @@ corepack.cmd yarn dist:win
 
 该本地命令会主动移除 Windows 证书变量，并设置 `signExecutable=false`。产物可以安装测试，但没有 Authenticode publisher，因此 Windows 可能显示 Unknown publisher 或 SmartScreen 警告。签名后的 Windows release、证书校验、安装器升级与卸载测试，以及原生 UI 和 sandbox smoke 仍是独立的发布 gate。
 
+### 本地 macOS 发布
+
+`dist:mac` 会根据已通过校验的发布凭据构建一个已签名并公证的 macOS DMG，然后挂载、校验其签名并卸载该 DMG。一次调用恰好产出一个架构。发布架构来自 `DSH_MAC_ARCH` 环境变量，未设置时默认为 `arm64`：
+
+```bash
+DSH_MAC_ARCH=x64 yarn dist:mac      # Intel DMG
+DSH_MAC_ARCH=arm64 yarn dist:mac    # Apple silicon DMG（默认）
+```
+
+Electron Builder 会收到对应的 `--x64` 或 `--arm64` flag，且产物名会内嵌架构（`DSH-Desktop-${version}-mac-x64.dmg` 或 `DSH-Desktop-${version}-mac-arm64.dmg`），因此同一个发布目录可以同时容纳两种架构而不发生命名冲突。`DSH_MAC_ARCH` 不是发布密钥，所以会转发给受校验的 `electron-builder` 子进程，以及 `verify-mac-release.ts`（其成功与失败信息都会标明期望的架构）。请分别在各自的原生宿主上构建 Intel 与 arm64 产物（`x64` 用 Intel 主机、`arm64` 用 Apple silicon 主机），让每个 DMG 带对应架构的正确 Electron 二进制。
+
+支持 Intel macOS 属于构建能力。分发是发布方职责：两种 DMG 都发布后，版本服务与 macOS 下载入口应按当前安装应用的架构把更新路由到匹配的 DMG。更新客户端打开的是入口下发的那个 DMG，因此把 Intel DMG 路由给 Intel 安装，才是让 Intel 构建在应用内可被更新的关键。
+
+
 ## 模型体验
 
 无。desktop package 只改变应用组合与原生呈现，不增加任何模型可见的指令、工具、事件或请求字段。

--- a/dsh-plugin-desktop/package.json
+++ b/dsh-plugin-desktop/package.json
@@ -257,6 +257,7 @@
         "dir"
       ],
       "category": "public.app-category.developer-tools",
+      "artifactName": "DSH-Desktop-${version}-mac-${arch}.${ext}",
       "hardenedRuntime": true,
       "icon": "build/app-icon-mac.png",
       "notarize": true

--- a/dsh-plugin-desktop/scripts/release-mac.ts
+++ b/dsh-plugin-desktop/scripts/release-mac.ts
@@ -9,6 +9,27 @@ import {
   withoutMacReleaseSecrets,
 } from './release-preflight.ts'
 
+/** Supported Electron architectures for one macOS release artifact. */
+export type MacReleaseArch = 'x64' | 'arm64'
+
+/** Environment variable that selects the macOS release architecture. */
+export const MAC_ARCH_ENV = 'DSH_MAC_ARCH'
+
+/**
+ * Resolve the architecture the release should build.
+ * @param env - Environment containing the optional architecture selector.
+ * @returns the requested architecture, defaulting to `arm64` when the selector is absent.
+ * @throws when the selector is present but not a supported architecture.
+ */
+export function readMacReleaseArch(env: NodeJS.ProcessEnv): MacReleaseArch {
+  const arch = env[MAC_ARCH_ENV]
+  if (arch === undefined || arch.length === 0) return 'arm64'
+  if (arch === 'x64' || arch === 'arm64') return arch
+  throw new Error(
+    `${MAC_ARCH_ENV} must be "x64", "arm64", or unset (defaults to arm64); received ${JSON.stringify(arch)}`,
+  )
+}
+
 /** Injectable release boundary used by focused tests. */
 export interface MacReleaseOptions {
   /** Environment containing the selected signing and notarization credentials. */
@@ -19,6 +40,8 @@ export interface MacReleaseOptions {
   readonly desktopRoot: string
   /** Read code-signing identities with a credential-free environment. */
   readonly listCodeSigningIdentities: (env: NodeJS.ProcessEnv) => string
+  /** Resolve the architecture the DMG builder must produce. */
+  readonly arch: (env: NodeJS.ProcessEnv) => MacReleaseArch
   /** Execute one release command. */
   readonly run: (
     command: string,
@@ -56,6 +79,7 @@ function defaultReleaseOptions(): MacReleaseOptions {
     platform: process.platform,
     desktopRoot: resolve(dirname(fileURLToPath(import.meta.url)), '..'),
     listCodeSigningIdentities,
+    arch: readMacReleaseArch,
     run,
     log: message => console.log(message),
   }
@@ -68,6 +92,7 @@ function defaultReleaseOptions(): MacReleaseOptions {
 export function releaseMac(options: MacReleaseOptions = defaultReleaseOptions()): void {
   const releaseEnvironment = adaptMacReleaseEnvironment(options.env)
   const buildEnvironment = withoutMacReleaseSecrets(releaseEnvironment)
+  const arch = options.arch(releaseEnvironment)
   const result = assertMacReleaseReady({
     env: releaseEnvironment,
     platform: options.platform,
@@ -81,10 +106,16 @@ export function releaseMac(options: MacReleaseOptions = defaultReleaseOptions())
   // material is withheld from every build, test, Loader smoke, and layout subprocess.
   options.run('yarn', ['run', 'check'], resolve(options.desktopRoot, '..'), buildEnvironment)
   options.run('yarn', [
-    'exec', 'electron-builder', '--mac', 'dmg',
+    'exec', 'electron-builder', '--mac', 'dmg', `--${arch}`,
     '--config.forceCodeSigning=true', '--config.mac.notarize=true',
-  ], options.desktopRoot, releaseEnvironment)
-  options.run(process.execPath, ['scripts/verify-mac-release.ts'], options.desktopRoot, buildEnvironment)
+  ], options.desktopRoot, {
+    ...releaseEnvironment,
+    [MAC_ARCH_ENV]: arch,
+  })
+  options.run(process.execPath, ['scripts/verify-mac-release.ts'], options.desktopRoot, {
+    ...buildEnvironment,
+    [MAC_ARCH_ENV]: arch,
+  })
 }
 
 const invokedPath = process.argv[1]

--- a/dsh-plugin-desktop/scripts/verify-mac-release.ts
+++ b/dsh-plugin-desktop/scripts/verify-mac-release.ts
@@ -12,6 +12,8 @@ export interface MacReleaseVerificationOptions {
   readonly distDir: string
   /** Installed application name inside the mounted image. */
   readonly productName: string
+  /** Architecture the release expected to seal into the DMG. */
+  readonly arch: 'x64' | 'arm64'
   /** Return regular DMG files in the distribution directory. */
   readonly listDmgs: (distDir: string) => readonly string[]
   /** Create a private empty mount point. */
@@ -42,6 +44,7 @@ function defaultOptions(): MacReleaseVerificationOptions {
   return {
     distDir: join(packageRoot, 'dist'),
     productName: 'DSH Desktop',
+    arch: process.env.DSH_MAC_ARCH === 'x64' ? 'x64' : 'arm64',
     listDmgs,
     makeMountPoint: () => mkdtempSync(join(tmpdir(), 'dsh-desktop-dmg-')),
     run,
@@ -60,7 +63,7 @@ export function verifyMacRelease(
   const dmgs = options.listDmgs(options.distDir)
   if (dmgs.length !== 1) {
     throw new Error(
-      `macOS release verification requires exactly one DMG in ${options.distDir}; found ${String(dmgs.length)}`,
+      `macOS release verification requires exactly one ${options.arch} DMG in ${options.distDir}; found ${String(dmgs.length)}`,
     )
   }
 
@@ -105,7 +108,7 @@ const invokedPath = process.argv[1]
 if (invokedPath !== undefined && resolve(invokedPath) === fileURLToPath(import.meta.url)) {
   try {
     const verified = verifyMacRelease()
-    console.log(`macOS release verification passed: ${verified.dmgPath}`)
+    console.log(`macOS release verification passed (${verified.dmgPath})`)
   } catch (error) {
     console.error(error instanceof Error ? error.message : String(error))
     process.exitCode = 1

--- a/dsh-plugin-desktop/tests/package.spec.ts
+++ b/dsh-plugin-desktop/tests/package.spec.ts
@@ -203,6 +203,7 @@ describe('published package surface', () => {
       hardenedRuntime: true,
       notarize: true,
       target: ['dir'],
+      artifactName: 'DSH-Desktop-${version}-mac-${arch}.${ext}',
     }))
     expect(manifest.devDependencies?.['@electron/asar']).toBe('3.4.1')
   })

--- a/dsh-plugin-desktop/tests/release-mac.spec.ts
+++ b/dsh-plugin-desktop/tests/release-mac.spec.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from 'vitest'
-import { releaseMac, type MacReleaseOptions } from '../scripts/release-mac.ts'
+import {
+  MAC_ARCH_ENV,
+  readMacReleaseArch,
+  releaseMac,
+  type MacReleaseOptions,
+} from '../scripts/release-mac.ts'
 
 const DEVELOPER_ID_OUTPUT = `
   1) 0123456789ABCDEF "Developer ID Application: Mengxin Yang (TEAM123456)"
@@ -27,6 +32,7 @@ function baseOptions(
       identityEnvironments.push({ ...identityEnv })
       return DEVELOPER_ID_OUTPUT
     },
+    arch: readMacReleaseArch,
     run: (command, args, cwd, commandEnv) => {
       calls.push({ command, args: [...args], cwd, env: { ...commandEnv } })
     },
@@ -60,7 +66,7 @@ describe('macOS release command boundary', () => {
     expect(calls[1]).toEqual({
       command: 'yarn',
       args: [
-        'exec', 'electron-builder', '--mac', 'dmg',
+        'exec', 'electron-builder', '--mac', 'dmg', '--arm64',
         '--config.forceCodeSigning=true', '--config.mac.notarize=true',
       ],
       cwd: '/repo/dsh-plugin-desktop',
@@ -70,13 +76,14 @@ describe('macOS release command boundary', () => {
         APPLE_ID: 'developer@example.test',
         APPLE_APP_SPECIFIC_PASSWORD: appPassword,
         APPLE_TEAM_ID: 'TEAM123456',
+        [MAC_ARCH_ENV]: 'arm64',
       },
     })
     expect(calls[2]).toEqual({
       command: process.execPath,
       args: ['scripts/verify-mac-release.ts'],
       cwd: '/repo/dsh-plugin-desktop',
-      env: { PATH: '/usr/bin', SAFE_BUILD_VALUE: 'kept' },
+      env: { PATH: '/usr/bin', SAFE_BUILD_VALUE: 'kept', [MAC_ARCH_ENV]: 'arm64' },
     })
     expect(logs).toHaveLength(1)
     expect(logs[0]).toContain('signing via keychain; notarization via apple-id')
@@ -111,7 +118,8 @@ describe('macOS release command boundary', () => {
     expect(calls[1]?.env.CSC_KEY_PASSWORD).toBe(p12Password)
     expect(calls[1]?.env.MAC_CERT_P12_BASE64).toBeUndefined()
     expect(calls[1]?.env.MACOS_SIGN_IDENTITY).toBeUndefined()
-    expect(calls[2]?.env).toEqual({ PATH: '/usr/bin' })
+    expect(calls[1]?.env[MAC_ARCH_ENV]).toBe('arm64')
+    expect(calls[2]?.env).toEqual({ PATH: '/usr/bin', [MAC_ARCH_ENV]: 'arm64' })
   })
 
   it('rejects development signing before running any command', () => {
@@ -141,5 +149,35 @@ describe('macOS release command boundary', () => {
     expect(calls).toHaveLength(1)
     expect(calls[0]?.args).toEqual(['run', 'check'])
     expect(calls[0]?.cwd).toBe('/repo')
+  })
+
+  it('builds an Intel DMG when the caller selects the x64 architecture', () => {
+    const calls: CommandCall[] = []
+    const options = baseOptions({
+      APPLE_KEYCHAIN_PROFILE: 'dsh-notary',
+      [MAC_ARCH_ENV]: 'x64',
+    }, calls)
+
+    releaseMac(options)
+
+    expect(calls).toHaveLength(3)
+    expect(calls[1]?.args).toEqual([
+      'exec', 'electron-builder', '--mac', 'dmg', '--x64',
+      '--config.forceCodeSigning=true', '--config.mac.notarize=true',
+    ])
+    expect(calls[1]?.env[MAC_ARCH_ENV]).toBe('x64')
+    expect(calls[2]?.env[MAC_ARCH_ENV]).toBe('x64')
+  })
+
+  it('reads the default arm64 architecture from a release environment', () => {
+    expect(readMacReleaseArch({ PATH: '/usr/bin', [MAC_ARCH_ENV]: 'arm64' })).toBe('arm64')
+    expect(readMacReleaseArch({})).toBe('arm64')
+  })
+
+  it('rejects an unsupported architecture before the DMG builder runs', () => {
+    const calls: CommandCall[] = []
+    const options = baseOptions({ [MAC_ARCH_ENV]: 'ia32' }, calls)
+    expect(() => releaseMac(options)).toThrow('must be')
+    expect(calls).toEqual([])
   })
 })

--- a/dsh-plugin-desktop/tests/verify-mac-release.spec.ts
+++ b/dsh-plugin-desktop/tests/verify-mac-release.spec.ts
@@ -10,6 +10,7 @@ function options(overrides: Partial<MacReleaseVerificationOptions> = {}) {
   const value: MacReleaseVerificationOptions = {
     distDir: '/release/dist',
     productName: 'DSH Desktop',
+    arch: 'arm64',
     listDmgs: () => ['/release/dist/DSH Desktop-2.0.0-arm64.dmg'],
     makeMountPoint: () => '/private/tmp/dsh-desktop-dmg-test',
     run: (command, args) => { calls.push({ command, args: [...args] }) },


### PR DESCRIPTION
## What

Add build support for an Intel (x64) macOS release, alongside the existing Apple silicon (arm64) build. The macOS release previously always derived its architecture from whoever ran the build; now one invocation targets exactly one arch, chosen explicitly. This is the build half of supporting Intel macOS.

## Why / Context

Closes #82 — "macos intel版 / 可以支持intel版吗".

A single `dist:mac` today bakes in the build host's arch, so an Intel user cannot get an Intel DMG unless an Intel host builds it, and a produced Intel DMG would otherwise collide with the arm64 artifact name.

## How

- `scripts/release-mac.ts` reads the new `DSH_MAC_ARCH` variable (`x64` | `arm64`, default `arm64` to preserve current behavior), forwards `--x64`/`--arm64` to `electron-builder`, and passes the selector through to the release verifier.
- `package.json` `build.mac.artifactName` = `DSH-Desktop-${version}-mac-${arch}.${ext}`, so one distribution directory can hold both DMGs without a naming collision.
- `scripts/verify-mac-release.ts` reports the expected architecture in its success/error messages (default arm64).
- Tests cover the x64 selection, the arm64 default, an invalid selector, and the artifact-name + verification surfaces.
- README (en/zh) documents the Intel/arm64 macOS build and the release-operator step of routing each installed architecture to its matching DMG.

## Notes for release operators

Supporting Intel is a build capability in this PR. Distribution still needs the version service and the macOS download endpoint to route each running application to the DMG for its installed architecture; the update client opens whichever DMG the endpoint serves. Building on native Intel vs. Apple silicon hosts keeps the correct Electron binary per DMG.

## Test plan

- `yarn workspace dsh-plugin-desktop typecheck`
- `yarn workspace dsh-plugin-desktop build`
- `yarn run check:layout`
- vitest: `release-mac`, `verify-mac-release`, `package`, `update-checker`, `update-download`, `plugin` all pass.
- Local `electron-builder --dir --x64` on an Intel Mac produces a `Mach-O ... x86_64` app with the bundled `node-pty` darwin-x64 prebuild.
- `tests/windows-pwsh-sandbox.spec.ts` failures are pre-existing Windows-only path tests that belong to the Windows `check:win-package` gate and are untouched by this change.
