### PR TITLE
fix(browser): allow unmarked web UI pages

### DIFF
--- a/dsh-plugin-desktop/src/client/environment.ts
+++ b/dsh-plugin-desktop/src/client/environment.ts
@@ -18,12 +18,17 @@ const PLATFORMS = new Set<DesktopClientPlatform>(['darwin', 'win32', 'linux'])
 /**
  * Validate the Electron-owned query marker before any desktop client effects run.
  * @param search - URL search string, including or omitting the leading question mark.
- * @returns the validated desktop renderer environment.
+ * @returns the validated desktop renderer environment, or undefined for a
+ *  normal browser page that carries no desktop markers.
  */
-export function parseDesktopClientEnvironment(search: string): DesktopClientEnvironment {
+export function parseDesktopClientEnvironment(search: string): DesktopClientEnvironment | undefined {
   const params = new URLSearchParams(search)
   const mode = params.get('dsh-desktop-mode')
   const platform = params.get('dsh-desktop-platform')
+  // The Host adds both markers to its BrowserWindow URL. A plain browser can
+  // still open the same Web UI without either marker; that is a supported
+  // non-desktop context and must not make the whole plugin loader fail.
+  if (mode === null && platform === null) return undefined
   if (!MODES.has(mode as DesktopClientMode)) {
     throw new Error(`dsh-plugin-desktop: invalid or missing dsh-desktop-mode ${JSON.stringify(mode)}`)
   }

--- a/dsh-plugin-desktop/src/client/index.ts
+++ b/dsh-plugin-desktop/src/client/index.ts
@@ -30,6 +30,7 @@ export const inject = [
 /** Register desktop-owned client surfaces for the current BrowserWindow mode. @param ctx - browser Cordis context. */
 export function apply(ctx: ClientContext): void {
   const environment = parseDesktopClientEnvironment(window.location.search)
+  if (environment === undefined) return
   ctx.effect(
     () => startRendererBootReporter(ctx.loader),
     'dsh-plugin-desktop: renderer boot health report',

--- a/dsh-plugin-desktop/tests/client-environment.spec.ts
+++ b/dsh-plugin-desktop/tests/client-environment.spec.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from 'vitest'
 import type { ClientContext } from '@deepseek-ai/dsh-client-runtime/client'
+import { apply as applyDesktopClient } from '../src/client/index.ts'
 import { provideDesktopLayout } from '../src/client/layout-service.ts'
 import { parseDesktopClientEnvironment } from '../src/client/environment.ts'
 import {
@@ -23,12 +24,24 @@ describe('desktop client environment', () => {
   })
 
   it.each([
-    ['', 'dsh-desktop-mode'],
     ['?dsh-desktop-mode=glass&dsh-desktop-platform=darwin', 'dsh-desktop-mode'],
     ['?dsh-desktop-mode=advanced', 'dsh-desktop-platform'],
     ['?dsh-desktop-mode=advanced&dsh-desktop-platform=android', 'dsh-desktop-platform'],
   ])('fails loud for malformed marker %s', (search, field) => {
     expect(() => parseDesktopClientEnvironment(search)).toThrow(field)
+  })
+
+  it('ignores an unmarked browser page instead of breaking plugin loading', () => {
+    const effect = vi.fn()
+    expect(parseDesktopClientEnvironment('')).toBeUndefined()
+    vi.stubGlobal('window', { location: { search: '' } })
+    try {
+      expect(() => applyDesktopClient({ effect } as unknown as ClientContext)).not.toThrow()
+    }
+    finally {
+      vi.unstubAllGlobals()
+    }
+    expect(effect).not.toHaveBeenCalled()
   })
 })
 


### PR DESCRIPTION
Fixes #88

Unmarked browser Web UI pages now return no desktop client environment and exit before registering desktop effects. Pages with malformed or incomplete desktop markers still fail loudly, so invalid integration states remain visible.

Validation:
- `corepack yarn workspace dsh-plugin-desktop typecheck`
- `corepack yarn workspace dsh-plugin-desktop vitest run tests/client-environment.spec.ts`
- `corepack yarn workspace dsh-plugin-desktop test` (284 passed, 2 skipped)
