### PR TITLE
fix(desktop): recover login-shell PATH for packaged Unix launches

### DIFF
--- a/dsh-plugin-desktop/src/main.ts
+++ b/dsh-plugin-desktop/src/main.ts
@@ -18,6 +18,7 @@ import {
   installDesktopPnpmRuntime,
 } from './desktop-runtime-environment.ts'
 import { ElectronDesktopRuntime } from './electron-runtime.ts'
+import { resolveDesktopShellPath } from './shell-environment.ts'
 import { installProfilePackageResolver } from './module-resolution.ts'
 import { packagedDependencyPath } from './packaged-runtime-path.ts'
 import {
@@ -164,6 +165,19 @@ async function start(): Promise<void> {
   await app.whenReady()
   if (process.platform === 'win32') app.setAppUserModelId('ai.deepseek.dsh.desktop')
   if (app.isPackaged && process.cwd() === '/') process.chdir(app.getPath('home'))
+  const shellPathResolution = await resolveDesktopShellPath({
+    environment: process.env,
+    home: app.getPath('home'),
+    isPackaged: app.isPackaged,
+    platform: process.platform,
+  })
+  if (
+    shellPathResolution.source === 'login-shell'
+    && shellPathResolution.path !== undefined
+    && shellPathResolution.path !== ''
+  ) {
+    process.env.PATH = shellPathResolution.path
+  }
   const homeDir = resolveDshHome()
   const windowsVolumeConcerns = diagnoseWindowsVolumes(process.platform, [
     { label: 'application install', path: process.execPath },

--- a/dsh-plugin-desktop/src/shell-environment.ts
+++ b/dsh-plugin-desktop/src/shell-environment.ts
@@ -1,0 +1,205 @@
+/** Resolve the login-shell PATH used by a packaged Unix desktop launch. */
+
+import { spawn } from 'node:child_process'
+import { randomBytes } from 'node:crypto'
+import { userInfo } from 'node:os'
+
+const DEFAULT_CAPTURE_TIMEOUT_MS = 2_000
+const MAX_CAPTURE_BYTES = 1024 * 1024
+
+/** Result of resolving the PATH inherited by the desktop Host. */
+export interface DesktopShellPathResolution {
+  /** PATH value to use; `undefined` only when no inherited PATH exists. */
+  readonly path: string | undefined
+  /** Whether a login shell contributed the PATH. */
+  readonly source: 'process' | 'login-shell'
+  /** Stable diagnostic reason when the inherited process PATH was retained. */
+  readonly fallbackReason?:
+    | 'not-packaged'
+    | 'windows'
+    | 'unsupported-platform'
+    | 'missing-shell'
+    | 'capture-failed'
+    | 'missing-path'
+}
+
+/** Inputs for {@link resolveDesktopShellPath}. */
+export interface ResolveDesktopShellPathOptions {
+  readonly environment: NodeJS.ProcessEnv
+  readonly home: string
+  readonly isPackaged: boolean
+  readonly platform: NodeJS.Platform
+  readonly shell?: string
+  readonly timeoutMs?: number
+  readonly capture?: (shell: string, home: string, environment: NodeJS.ProcessEnv, timeoutMs: number) => Promise<NodeJS.ProcessEnv>
+}
+
+/**
+ * Parse the NUL-delimited payload emitted by the shell capture command.
+ * @param payload - Captured bytes from the command's private file descriptor.
+ * @param startMarker - Random record that begins the environment payload.
+ * @param endMarker - Random record that ends the environment payload.
+ * @returns Environment entries found between the markers.
+ */
+export function parseShellEnvironment(payload: Buffer, startMarker: string, endMarker: string): NodeJS.ProcessEnv {
+  const start = `${startMarker}\0`
+  const end = `${endMarker}\0`
+  const text = payload.toString('utf8')
+  const startIndex = text.indexOf(start)
+  if (startIndex < 0) throw new Error('desktop shell environment did not emit its start marker')
+  const bodyStart = startIndex + start.length
+  const endIndex = text.indexOf(end, bodyStart)
+  if (endIndex < 0) throw new Error('desktop shell environment did not emit its end marker')
+
+  const environment: NodeJS.ProcessEnv = {}
+  for (const record of text.slice(bodyStart, endIndex).split('\0')) {
+    if (record === '') continue
+    const separator = record.indexOf('=')
+    if (separator <= 0) throw new Error('desktop shell environment emitted an invalid record')
+    environment[record.slice(0, separator)] = record.slice(separator + 1)
+  }
+  return environment
+}
+
+/**
+ * Capture one login shell's environment without accepting its ordinary stdout or stderr.
+ * @param shell - Absolute or PATH-resolved shell executable.
+ * @param home - Working directory for shell startup.
+ * @param environment - Environment inherited by the shell.
+ * @param timeoutMs - Hard deadline before the shell is killed.
+ * @returns Environment printed after the shell startup files finish.
+ */
+export async function captureLoginShellEnvironment(
+  shell: string,
+  home: string,
+  environment: NodeJS.ProcessEnv,
+  timeoutMs: number = DEFAULT_CAPTURE_TIMEOUT_MS,
+): Promise<NodeJS.ProcessEnv> {
+  const nonce = randomBytes(16).toString('hex')
+  const startMarker = `dsh-shell-env-start-${nonce}`
+  const endMarker = `dsh-shell-env-end-${nonce}`
+  const command = `printf '%s\\0' '${startMarker}' >&3; /usr/bin/env -0 >&3; printf '%s\\0' '${endMarker}' >&3`
+  const shellName = shell.split('/').at(-1)?.toLowerCase()
+  const args = shellName === 'nu' || shellName === 'nushell'
+    ? ['--login', '--interactive', '--commands', command]
+    : ['-ilc', command]
+  const child = spawn(shell, args, {
+    cwd: home,
+    detached: true,
+    env: environment,
+    stdio: ['ignore', 'ignore', 'ignore', 'pipe'],
+  })
+  const killShellTree = (): void => {
+    try {
+      if (child.pid === undefined) child.kill('SIGKILL')
+      else process.kill(-child.pid, 'SIGKILL')
+    } catch {
+      // A spawn failure or an already-exited process needs no further cleanup.
+    }
+  }
+  const output = child.stdio[3]
+  if (output === null || output === undefined) {
+    const closed = new Promise<void>((resolve) => {
+      child.once('error', () => {})
+      child.once('close', () => { resolve() })
+    })
+    killShellTree()
+    await closed
+    throw new Error('desktop shell environment has no capture stream')
+  }
+
+  return await new Promise<NodeJS.ProcessEnv>((resolve, reject) => {
+    const chunks: Buffer[] = []
+    let byteLength = 0
+    let failure: Error | undefined
+    let reading = true
+
+    const stopReading = (): void => {
+      if (!reading) return
+      reading = false
+      output.off('data', accept)
+    }
+    const failAndKill = (error: Error): void => {
+      if (failure !== undefined) return
+      failure = error
+      stopReading()
+      output.destroy()
+      killShellTree()
+    }
+    const accept = (chunk: Buffer | string): void => {
+      try {
+        const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk)
+        byteLength += buffer.byteLength
+        if (byteLength > MAX_CAPTURE_BYTES) {
+          failAndKill(new Error(`desktop shell environment exceeded ${String(MAX_CAPTURE_BYTES)} bytes`))
+          return
+        }
+        chunks.push(buffer)
+      } catch (error) {
+        failAndKill(error instanceof Error ? error : new Error(String(error)))
+      }
+    }
+
+    output.on('data', accept)
+    child.once('error', failAndKill)
+    const timer = setTimeout(() => {
+      failAndKill(new Error(`desktop shell environment timed out after ${String(timeoutMs)}ms`))
+    }, timeoutMs)
+    child.once('close', () => {
+      clearTimeout(timer)
+      stopReading()
+      if (failure !== undefined) {
+        reject(failure)
+        return
+      }
+      try {
+        resolve(parseShellEnvironment(Buffer.concat(chunks), startMarker, endMarker))
+      } catch (error) {
+        reject(error instanceof Error ? error : new Error(String(error)))
+      }
+    })
+  })
+}
+
+function inheritedPath(
+  environment: NodeJS.ProcessEnv,
+  fallbackReason: NonNullable<DesktopShellPathResolution['fallbackReason']>,
+): DesktopShellPathResolution {
+  return { path: environment.PATH, source: 'process', fallbackReason }
+}
+
+/**
+ * Resolve the PATH for a desktop Host launch.
+ * @param options - Platform, launch environment and optional capture seam.
+ * @returns A login-shell PATH on packaged Unix desktops, otherwise the inherited PATH.
+ */
+export async function resolveDesktopShellPath(options: ResolveDesktopShellPathOptions): Promise<DesktopShellPathResolution> {
+  if (!options.isPackaged) return inheritedPath(options.environment, 'not-packaged')
+  if (options.platform === 'win32') return inheritedPath(options.environment, 'windows')
+  if (options.platform !== 'darwin' && options.platform !== 'linux') {
+    return inheritedPath(options.environment, 'unsupported-platform')
+  }
+
+  let shell = options.shell ?? options.environment.SHELL
+  if (shell === undefined || shell === '') {
+    try {
+      shell = userInfo().shell ?? undefined
+    } catch {
+      return inheritedPath(options.environment, 'missing-shell')
+    }
+  }
+  if (shell === '') return inheritedPath(options.environment, 'missing-shell')
+  if (shell === undefined) return inheritedPath(options.environment, 'missing-shell')
+
+  try {
+    const capture = options.capture ?? captureLoginShellEnvironment
+    const captured = await capture(shell, options.home, options.environment, options.timeoutMs ?? DEFAULT_CAPTURE_TIMEOUT_MS)
+    const capturedPath = captured.PATH
+    if (capturedPath !== undefined && capturedPath !== '') {
+      return { path: capturedPath, source: 'login-shell' }
+    }
+    return inheritedPath(options.environment, 'missing-path')
+  } catch {
+    return inheritedPath(options.environment, 'capture-failed')
+  }
+}

--- a/dsh-plugin-desktop/tests/desktop-runtime-environment.spec.ts
+++ b/dsh-plugin-desktop/tests/desktop-runtime-environment.spec.ts
@@ -107,6 +107,23 @@ describe('desktop Host pnpm runtime', () => {
     expect(environment).toEqual(original)
   })
 
+  it('keeps recovered login-shell PATH beneath the Desktop runtime PATH', () => {
+    const stateDir = join(temporaryDirectory(), 'runtime')
+    const recoveredPath = '/opt/homebrew/bin:/opt/homebrew/sbin:/usr/bin:/bin'
+    const environment: NodeJS.ProcessEnv = {
+      PATH: recoveredPath,
+      KEEP: 'value',
+    }
+    const original = { ...environment }
+
+    const installation = installDesktopPnpmRuntime(options(stateDir, 'linux', environment))
+
+    expect(environment.PATH).toBe(`${installation.pathDir}:${recoveredPath}`)
+    installation.dispose()
+    installation.dispose()
+    expect(environment).toEqual(original)
+  })
+
   it('clears every RunAsNode casing before the requested Node entry executes', () => {
     const stateDir = join(temporaryDirectory(), 'runtime')
     const installation = installDesktopPnpmRuntime(options(stateDir, 'linux', { PATH: '/usr/bin' }))

--- a/dsh-plugin-desktop/tests/shell-environment.spec.ts
+++ b/dsh-plugin-desktop/tests/shell-environment.spec.ts
@@ -1,0 +1,211 @@
+import { chmodSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import {
+  captureLoginShellEnvironment,
+  parseShellEnvironment,
+  resolveDesktopShellPath,
+} from '../src/shell-environment.ts'
+
+const temporaryDirectories: string[] = []
+
+afterEach(() => {
+  for (const directory of temporaryDirectories.splice(0)) rmSync(directory, { recursive: true, force: true })
+})
+
+function fakeShell(body: string): { home: string; shell: string } {
+  const home = mkdtempSync(join(tmpdir(), 'dsh-shell-environment-'))
+  temporaryDirectories.push(home)
+  const shell = join(home, 'test-shell')
+  writeFileSync(shell, `#!/bin/sh\n${body}\n`)
+  chmodSync(shell, 0o700)
+  return { home, shell }
+}
+
+describe('desktop shell environment parser', () => {
+  it('reads NUL-delimited values between private markers', () => {
+    const payload = Buffer.from('noise\0start\0PATH=/opt/homebrew/bin:/usr/bin\0MULTILINE=first\nsecond\0EMPTY=\0end\0trailing')
+
+    expect(parseShellEnvironment(payload, 'start', 'end')).toEqual({
+      PATH: '/opt/homebrew/bin:/usr/bin',
+      MULTILINE: 'first\nsecond',
+      EMPTY: '',
+    })
+  })
+
+  it('rejects missing framing and malformed records', () => {
+    expect(() => parseShellEnvironment(Buffer.from('PATH=/usr/bin\0'), 'start', 'end')).toThrow('start marker')
+    expect(() => parseShellEnvironment(Buffer.from('start\0PATH=/usr/bin\0'), 'start', 'end')).toThrow('end marker')
+    expect(() => parseShellEnvironment(Buffer.from('start\0invalid\0end\0'), 'start', 'end')).toThrow('invalid record')
+  })
+})
+
+describe.skipIf(process.platform === 'win32')('desktop login shell capture', () => {
+  it('reads only the private descriptor framed by the generated command', async () => {
+    const { home, shell } = fakeShell('printf ordinary-output; exec /bin/sh -c "$2"')
+
+    await expect(captureLoginShellEnvironment(shell, home, { CAPTURED_VALUE: 'available' }, 10_000))
+      .resolves.toMatchObject({ CAPTURED_VALUE: 'available' })
+  }, 15_000)
+
+  it('enforces its deadline when a shell and background child retain the capture descriptor', async () => {
+    const { home, shell } = fakeShell('sleep 30 >&3 &\nsleep 30')
+    const startedAt = Date.now()
+
+    await expect(captureLoginShellEnvironment(shell, home, {}, 25)).rejects.toThrow('timed out after 25ms')
+    expect(Date.now() - startedAt).toBeLessThan(1_000)
+  })
+
+  it('rejects an oversized capture and terminates the shell tree', async () => {
+    const { home, shell } = fakeShell('head -c 1048577 /dev/zero >&3\nsleep 30')
+
+    await expect(captureLoginShellEnvironment(shell, home, {}, 10_000)).rejects.toThrow('exceeded 1048576 bytes')
+  }, 15_000)
+})
+
+describe('desktop shell PATH resolution', () => {
+  it.each([
+    { isPackaged: false, platform: 'darwin' as const, reason: 'not-packaged' },
+    { isPackaged: true, platform: 'win32' as const, reason: 'windows' },
+    { isPackaged: true, platform: 'aix' as const, reason: 'unsupported-platform' },
+  ])('keeps the inherited PATH for $reason', async ({ isPackaged, platform, reason }) => {
+    const capture = vi.fn()
+
+    await expect(resolveDesktopShellPath({
+      environment: { PATH: '/inherited' },
+      home: '/Users/tester',
+      isPackaged,
+      platform,
+      shell: '/bin/zsh',
+      capture,
+    })).resolves.toEqual({
+      path: '/inherited',
+      source: 'process',
+      fallbackReason: reason,
+    })
+    expect(capture).not.toHaveBeenCalled()
+  })
+
+  it('uses the captured login PATH on packaged macOS', async () => {
+    const capture = vi.fn(async () => ({
+      PATH: '/opt/homebrew/bin:/opt/homebrew/sbin:/usr/bin:/bin',
+      DEEPSEEK_API_KEY: 'shell-secret',
+      SHELL_ONLY: 'do-not-import',
+    }))
+
+    await expect(resolveDesktopShellPath({
+      environment: { PATH: '/usr/bin:/bin', DEEPSEEK_API_KEY: 'explicit-key' },
+      home: '/Users/tester',
+      isPackaged: true,
+      platform: 'darwin',
+      shell: '/bin/zsh',
+      capture,
+    })).resolves.toEqual({
+      path: '/opt/homebrew/bin:/opt/homebrew/sbin:/usr/bin:/bin',
+      source: 'login-shell',
+    })
+    expect(capture).toHaveBeenCalledWith('/bin/zsh', '/Users/tester', expect.any(Object), 2_000)
+  })
+
+  it('uses the captured login PATH on packaged Linux', async () => {
+    const capture = vi.fn(async () => ({
+      PATH: '/home/tester/.local/bin:/usr/local/bin:/usr/bin:/bin',
+      OTHER: 'value',
+    }))
+
+    await expect(resolveDesktopShellPath({
+      environment: { PATH: '/usr/bin:/bin' },
+      home: '/home/tester',
+      isPackaged: true,
+      platform: 'linux',
+      shell: '/bin/bash',
+      timeoutMs: 75,
+      capture,
+    })).resolves.toEqual({
+      path: '/home/tester/.local/bin:/usr/local/bin:/usr/bin:/bin',
+      source: 'login-shell',
+    })
+    expect(capture).toHaveBeenCalledWith('/bin/bash', '/home/tester', expect.any(Object), 75)
+  })
+
+  it('falls back without exposing a capture failure', async () => {
+    const capture = vi.fn(async () => { throw new Error('secret shell output') })
+
+    const resolution = await resolveDesktopShellPath({
+      environment: { PATH: '/usr/bin' },
+      home: '/Users/tester',
+      isPackaged: true,
+      platform: 'linux',
+      shell: '/bin/bash',
+      capture,
+    })
+
+    expect(resolution).toEqual({
+      path: '/usr/bin',
+      source: 'process',
+      fallbackReason: 'capture-failed',
+    })
+    expect(JSON.stringify(resolution)).not.toContain('secret shell output')
+  })
+
+  it.each([
+    { captured: { OTHER: 'value' }, description: 'missing PATH' },
+    { captured: { PATH: '' }, description: 'empty PATH' },
+  ])('retains the inherited PATH when capture reports $description', async ({ captured }) => {
+    const capture = vi.fn(async () => captured)
+
+    await expect(resolveDesktopShellPath({
+      environment: { PATH: '/usr/bin:/bin' },
+      home: '/Users/tester',
+      isPackaged: true,
+      platform: 'darwin',
+      shell: '/bin/zsh',
+      capture,
+    })).resolves.toEqual({
+      path: '/usr/bin:/bin',
+      source: 'process',
+      fallbackReason: 'missing-path',
+    })
+  })
+
+  it('imports only PATH from the login shell, never other shell variables', async () => {
+    const capture = vi.fn(async () => ({
+      PATH: '/opt/homebrew/bin:/usr/bin',
+      DEEPSEEK_API_KEY: 'shell-secret',
+      AWS_SECRET_ACCESS_KEY: 'aws-secret',
+      SHELL_ONLY: 'do-not-import',
+    }))
+    const environment: NodeJS.ProcessEnv = {
+      PATH: '/usr/bin:/bin',
+      DEEPSEEK_API_KEY: 'explicit-key',
+      EXPLICIT_ONLY: 'available',
+    }
+
+    const resolution = await resolveDesktopShellPath({
+      environment,
+      home: '/Users/tester',
+      isPackaged: true,
+      platform: 'darwin',
+      shell: '/bin/zsh',
+      capture,
+    })
+
+    expect(resolution).toEqual({
+      path: '/opt/homebrew/bin:/usr/bin',
+      source: 'login-shell',
+    })
+    const applied = { ...environment }
+    if (resolution.source === 'login-shell' && resolution.path !== undefined && resolution.path !== '') {
+      applied.PATH = resolution.path
+    }
+    expect(applied).toEqual({
+      PATH: '/opt/homebrew/bin:/usr/bin',
+      DEEPSEEK_API_KEY: 'explicit-key',
+      EXPLICIT_ONLY: 'available',
+    })
+    expect(JSON.stringify(applied)).not.toContain('shell-secret')
+    expect(JSON.stringify(applied)).not.toContain('aws-secret')
+    expect(JSON.stringify(applied)).not.toContain('do-not-import')
+  })
+})


### PR DESCRIPTION
Fixes #156
Related to #143

## Summary

- recover the user's login-shell `PATH` for packaged macOS and Linux Desktop launches before the in-process DSH Host is booted
- preserve the current Desktop-owned runtime-command precedence by installing the pnpm shim only after PATH recovery
- safely fall back to the inherited GUI environment when shell capture is unavailable, malformed, oversized, or times out
- import only `PATH` from the login shell; no other shell environment values are copied into Electron's `process.env`

## Root cause

The packaged v2 Desktop boots the DSH Host in the Electron main process.

When launched through macOS Finder / LaunchServices, Electron can inherit a minimal GUI `PATH`. `installDesktopPnpmRuntime()` then prepends its own `runtime-commands/bin` to that already-minimal value, so Harness subprocesses correctly preserve the wrong parent PATH.

A real affected session observed:

`~/Library/Application Support/DSH Desktop/runtime-commands/bin:/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/bin`

while Homebrew tools including `gh`, `node`, and `npm` existed under `/opt/homebrew/bin`. Manually prepending `/opt/homebrew/bin` immediately restored them.

The pinned Harness subprocess implementation preserves ordinary `PATH`; the missing environment originates at the Desktop GUI boundary.

## Implementation

This is a narrow v2 port of the login-shell capture mechanism previously implemented in #48.

The capture keeps #48's bounded design:

- isolated process group
- private fd for capture data
- randomized framing markers
- NUL-delimited `env -0`
- 2-second timeout
- 1 MiB output limit
- process-tree termination on timeout/overflow
- safe fallback on shell/spawn/parse/capture failure

Unlike the old supervisor architecture in #48, current v2 runs the Host in-process. Therefore this port intentionally imports only the captured `PATH`, rather than merging the entire login-shell environment into Electron.

PATH recovery happens before `loadLayeredEnv()` and before `installDesktopPnpmRuntime()`. The final PATH therefore remains:

`<Desktop runtime-commands/bin>:<user login-shell PATH>`

## Security / compatibility

- no hard-coded Homebrew path
- no shell environment written to disk
- no captured environment values logged
- arbitrary shell variables/secrets are not imported into `process.env`
- Windows behavior is unchanged
- unpackaged development launches keep their inherited environment
- capture failures do not block Desktop startup

## Verification

- `yarn workspace dsh-plugin-desktop vitest run tests/shell-environment.spec.ts tests/desktop-runtime-environment.spec.ts` — 27 passed, 1 skipped
- `yarn workspace dsh-plugin-desktop typecheck` — passed
- `yarn workspace dsh-plugin-desktop check` — passed (build, typecheck, 299 tests + 2 skipped, runtime closure, CLI/loader/profile smokes, licenses)
- `git diff --check` — passed
- macOS login-shell capture smoke with a minimal GUI-like `PATH=/usr/bin:/bin` restored the user's login-shell PATH including `/opt/homebrew/bin` — passed
- macOS packaged GUI smoke: not run

## Prior work

The shell-capture protocol and failure handling are intentionally based on #48. This PR ports only that relevant mechanism to the current `dsh-plugin-desktop` v2 in-process architecture rather than bringing over #48's unrelated startup-recovery changes.
