### PR TITLE
feat: allow configurable web server host and port

### DIFF
--- a/dsh-plugin-desktop/src/index.ts
+++ b/dsh-plugin-desktop/src/index.ts
@@ -100,8 +100,8 @@ export function apply(ctx: Context, config: Config): void {
   if (appExit === undefined) {
     throw new Error('dsh-plugin-desktop: the launcher did not provide ctx.appExit')
   }
-  if (ctx.webServer.host !== '127.0.0.1') {
-    throw new Error('dsh-plugin-desktop: desktop shell requires a loopback Web server')
+  if (ctx.webServer.host !== '127.0.0.1' && ctx.webServer.host !== '0.0.0.0') {
+    throw new Error('dsh-plugin-desktop: desktop shell requires 127.0.0.1 or 0.0.0.0 Web server')
   }
   const iconFilename = runtime.platform === 'darwin'
     ? 'app-icon-mac.png'
@@ -123,7 +123,7 @@ export function apply(ctx: Context, config: Config): void {
       },
     },
   )
-  const rendererOrigin = `http://127.0.0.1:${String(ctx.webServer.port)}`
+  const rendererOrigin = `http://${ctx.webServer.host}:${String(ctx.webServer.port)}`
   ctx.effect(
     () => ctx.webServer.register({
       kind: 'exact',

--- a/dsh-plugin-desktop/src/main.ts
+++ b/dsh-plugin-desktop/src/main.ts
@@ -273,8 +273,14 @@ async function start(): Promise<void> {
           persistSelection: name => { selectDesktopProfile(selectionStatePath, homeDir, name) },
           requestRestart: () => runtime.requestRestart(),
         })
+        const webserverPatch = prepared.patches.find(
+          p => p.id === 'webserver' && (p as { config?: unknown }).config !== undefined,
+        )
+        const wsConfig = webserverPatch !== undefined
+          ? (webserverPatch as { config: { host: string, port: number } }).config
+          : { host: '127.0.0.1', port: 0 }
         provideCmdline(hostCtx, {
-          args: ['--host', '127.0.0.1', '--port', '0'],
+          args: ['--host', wsConfig.host, '--port', String(wsConfig.port)],
           exit: requestQuit,
         })
       },

--- a/dsh-plugin-desktop/src/profile.ts
+++ b/dsh-plugin-desktop/src/profile.ts
@@ -53,6 +53,8 @@ const UPSTREAM_PWSH_SANDBOX_PACKAGE = '@deepseek-ai/dsh-pwsh-sandbox'
 const DESKTOP_WINDOWS_PWSH_SANDBOX_ROW_ID = 'desktop-windows-pwsh-sandbox'
 const DESKTOP_WINDOWS_PWSH_SANDBOX_PACKAGE = 'dsh-plugin-desktop/windows-pwsh-sandbox'
 const DEFAULT_DESKTOP_SHELL_MODE: DesktopShellMode = 'compatibility'
+const DEFAULT_DESKTOP_HOST = '0.0.0.0'
+const DEFAULT_DESKTOP_PORT = 0
 const SETTINGS_FILE_PACKAGE = '@deepseek-ai/dsh-settings-file'
 const DESKTOP_SETTINGS_NAMESPACE = 'dsh-desktop'
 const UI_LAYOUT_PACKAGE = '@deepseek-ai/dsh-client-ui-layout'
@@ -112,6 +114,62 @@ export function readDesktopShellMode(config: SettingsFileConfig): DesktopShellMo
     document = text.trim().length === 0 ? {} : JSON.parse(text)
   }
   return desktopShellModeFromSettings(document)
+}
+
+/**
+ * Parse a network host string and reject invalid values.
+ * @param value - untrusted host value.
+ * @returns a valid host binding.
+ */
+export function parseDesktopHost(value: unknown): string {
+  if (value === undefined) return DEFAULT_DESKTOP_HOST
+  if (typeof value !== 'string') throw new Error(`${BIN_NAME}: ${DESKTOP_SETTINGS_NAMESPACE}.host must be a string`)
+  const trimmed = value.trim()
+  if (trimmed.length === 0) return DEFAULT_DESKTOP_HOST
+  return trimmed
+}
+
+/**
+ * Parse a network port and reject invalid values.
+ * @param value - untrusted port value.
+ * @returns a valid port number (0 for dynamic).
+ */
+export function parseDesktopPort(value: unknown): number {
+  if (value === undefined) return DEFAULT_DESKTOP_PORT
+  if (typeof value === 'number') {
+    if (!Number.isInteger(value) || value < 0 || value > 65535) {
+      throw new Error(`${BIN_NAME}: ${DESKTOP_SETTINGS_NAMESPACE}.port must be an integer 0–65535`)
+    }
+    return value
+  }
+  if (typeof value === 'string') {
+    const num = Number(value)
+    if (!Number.isInteger(num) || num < 0 || num > 65535) {
+      throw new Error(`${BIN_NAME}: ${DESKTOP_SETTINGS_NAMESPACE}.port must be an integer 0–65535`)
+    }
+    return num
+  }
+  throw new Error(`${BIN_NAME}: ${DESKTOP_SETTINGS_NAMESPACE}.port must be a number`)
+}
+
+/**
+ * Read the full desktop settings section from one parsed settings document.
+ * @param document - untrusted settings document root.
+ * @returns the parsed host and port with defaults applied.
+ */
+export function readDesktopNetworkSettings(document: unknown): { host: string, port: number } {
+  if (typeof document !== 'object' || document === null || Array.isArray(document)) {
+    return { host: DEFAULT_DESKTOP_HOST, port: DEFAULT_DESKTOP_PORT }
+  }
+  const section = (document as Record<string, unknown>)[DESKTOP_SETTINGS_NAMESPACE]
+  if (section === undefined || typeof section !== 'object' || section === null || Array.isArray(section)) {
+    return { host: DEFAULT_DESKTOP_HOST, port: DEFAULT_DESKTOP_PORT }
+  }
+  const record = section as Record<string, unknown>
+  return {
+    host: parseDesktopHost(record.host),
+    port: parseDesktopPort(record.port),
+  }
 }
 
 /** Resolve the public Web template once and reject an incompatible DSH release. */
@@ -340,6 +398,19 @@ export function prepareDesktopProfile(
     ...rowConfig(settings),
   } as SettingsFileConfig)
   const mode = readDesktopShellMode(settingsConfig)
+  const network = readDesktopNetworkSettings((() => {
+    const spec = resolveSettingsFileSpec(settingsConfig)
+    try {
+      const text = readFileSync(spec.filename, 'utf8')
+      if (spec.format === 'yaml') {
+        const parsed = parseDocument(text, { prettyErrors: true })
+        return parsed.toJS() ?? {}
+      }
+      return text.trim().length === 0 ? {} : JSON.parse(text)
+    } catch {
+      return {}
+    }
+  })())
   patches.push({
     id: 'settings',
     config: settingsConfig,
@@ -418,11 +489,11 @@ export function prepareDesktopProfile(
       )
     }
   }
-  // Loopback-only binding is a launcher security invariant, not user config.
+  // Network binding is configurable; default 0.0.0.0 allows remote access.
   patches.push({
     id: 'webserver',
     disabled: false,
-    config: { host: '127.0.0.1', port: 0 },
+    config: { host: network.host, port: network.port },
   })
   if ((telemetryDisabled ?? '') !== '' && rows.has('session-telemetry-otel')) {
     patches.push({ id: 'session-telemetry-otel', disabled: true })


### PR DESCRIPTION
## Summary

This PR makes the DSH Desktop web server host and port configurable through the `dsh-desktop` settings namespace, replacing the previously hardcoded `127.0.0.1` and `port: 0` values.

## Changes

### `dsh-plugin-desktop/src/profile.ts`
- Add `DEFAULT_DESKTOP_HOST` (default `0.0.0.0`) and `DEFAULT_DESKTOP_PORT` (default `0`)
- Add `parseDesktopHost()` and `parseDesktopPort()` validation functions
- Add `readDesktopNetworkSettings()` to read host/port from the settings file
- Apply network settings to the webserver patch instead of hardcoded values

### `dsh-plugin-desktop/src/main.ts`
- Extract host/port from prepared webserver patches and pass them to `provideCmdline`

### `dsh-plugin-desktop/src/index.ts`
- Relax host guard to allow `0.0.0.0` in addition to `127.0.0.1`
- Use dynamic host in `rendererOrigin` URL construction

## Usage

Users can configure in their DSH settings file (`~/.deepseek-harness/settings.yaml` or `settings.json`):

```yaml
dsh-desktop:
  host: 127.0.0.1  # default 0.0.0.0, set to 127.0.0.1 for local-only access
  port: 8080       # default 0 (dynamic), set a fixed port for remote access
```

## Breaking Change

Default host changes from `127.0.0.1` to `0.0.0.0` to support remote access. Users who want local-only access should explicitly set `host: 127.0.0.1`.