### PR TITLE
fix(desktop): allow clipboard-sanitized-write so Web UI copy buttons work

### DIFF
--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -16,6 +16,7 @@ import {
   type MenuItemConstructorOptions,
 } from 'electron'
 import { createHostSupervisor, spawnDshWeb, type HostSupervisor } from './host-supervisor.ts'
+import { isAllowedPermission } from './permissions.ts'
 import { createDesktopLifecycle, type DesktopLifecycle } from './window-lifecycle.ts'
 
 const APP_NAME = 'DeepSeek Harness'
@@ -90,8 +91,16 @@ function hasOrigin(raw: string, expected: string): boolean {
 /** Install navigation and permission policy before the first renderer loads. */
 function hardenSession(): void {
   const desktopSession = session.defaultSession
-  desktopSession.setPermissionCheckHandler(() => false)
-  desktopSession.setPermissionRequestHandler((_webContents, _permission, callback) => { callback(false) })
+  desktopSession.setPermissionCheckHandler((_webContents, permission) => {
+    // Copy controls across the Web UI write text through the async Clipboard
+    // API; Electron gates that write on the `clipboard-sanitized-write`
+    // permission check. Deny-all blocked it, silently breaking every copy
+    // button, so allow exactly that permission and keep the rest denied.
+    return isAllowedPermission(permission)
+  })
+  desktopSession.setPermissionRequestHandler((_webContents, permission, callback) => {
+    callback(isAllowedPermission(permission))
+  })
 }
 
 async function createMainWindow(): Promise<BrowserWindow> {

--- a/apps/desktop/src/permissions.ts
+++ b/apps/desktop/src/permissions.ts
@@ -1,0 +1,25 @@
+/**
+ * Renderer permission policy for the desktop shell.
+ *
+ * The Web UI runs with every Electron permission denied by default, which is
+ * the right posture for a loopback-only shell. The one deliberate exception
+ * is the sanitized clipboard write: every copy control in the Web UI
+ * (message copy, code blocks, diffs, JSON trees, …) writes through the async
+ * Clipboard API, and Electron gates that write on the
+ * `clipboard-sanitized-write` permission check. Denying it turns every copy
+ * button into a silent no-op, so it is explicitly allow-listed here.
+ */
+
+/** Permission names the Web UI legitimately needs inside the desktop shell. */
+export const ALLOWED_RENDERER_PERMISSIONS = new Set<string>([
+  'clipboard-sanitized-write',
+])
+
+/**
+ * Decide whether the renderer may use a permission.
+ * @param permission - Electron permission name being checked or requested.
+ * @returns true only for the explicitly allow-listed permissions.
+ */
+export function isAllowedPermission(permission: string): boolean {
+  return ALLOWED_RENDERER_PERMISSIONS.has(permission)
+}

--- a/apps/desktop/tests/permissions.spec.ts
+++ b/apps/desktop/tests/permissions.spec.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest'
+import { ALLOWED_RENDERER_PERMISSIONS, isAllowedPermission } from '../src/permissions.ts'
+
+describe('desktop renderer permission policy', () => {
+  it('allows the sanitized clipboard write used by Web UI copy controls', () => {
+    expect(ALLOWED_RENDERER_PERMISSIONS.has('clipboard-sanitized-write')).toBe(true)
+    expect(isAllowedPermission('clipboard-sanitized-write')).toBe(true)
+  })
+
+  it('denies every other permission, including raw clipboard access', () => {
+    for (const permission of [
+      'clipboard-read',
+      'clipboard-write',
+      'media',
+      'geolocation',
+      'notifications',
+      'fullscreen',
+      'pointerLock',
+      'display-capture',
+      'unknown-future-permission',
+    ]) {
+      expect(isAllowedPermission(permission)).toBe(false)
+    }
+  })
+
+  it('rejects an empty permission name', () => {
+    expect(isAllowedPermission('')).toBe(false)
+  })
+})


### PR DESCRIPTION
关联 Issue：Fixes #188

Related to #44 — that PR adds `focus()` to the `execCommand` fallback, but in the desktop shell the async Clipboard API **exists and rejects with NotAllowedError before any fallback runs**, so the copy button still fails there. The shell permission policy is the root cause.

> 目标分支说明：master / v2 已重构为插件架构（`dsh-plugin-desktop`）且不再设置权限拒绝处理器，本修复针对仍在使用 `apps/desktop` 架构的 **`desktop` 分支（0.1.0-rc.5 安装版代码线）**。

<details>
<summary>变更与验证</summary>

- 变更：
  - 新增 `apps/desktop/src/permissions.ts`：权限白名单（仅 `clipboard-sanitized-write`）与 `isAllowedPermission()`
  - `apps/desktop/src/main.ts`：`hardenSession()` 的 check/request 两个权限处理器改为按白名单判定，其余权限仍全部拒绝（安全姿态不变）
  - 新增 `apps/desktop/tests/permissions.spec.ts`：3 个用例
- 验证：
  - vitest 4.1.8：`tests/permissions.spec.ts` 全部通过
  - Electron 43.4.0（与桌面构建同版本）对照实验，真实鼠标点击触发 `navigator.clipboard.writeText`：
    - 全拒（旧行为）：`rejected:NotAllowedError`，系统剪贴板为空
    - 仅放行 `clipboard-sanitized-write`（本修复）：`resolved`，系统剪贴板 = 预期文本 ✅
    - 仅放行 `clipboard-write`（错误权限名）：仍 `rejected`
  - 本地安装版 app.asar 打补丁后人工验证复制正常
</details>

根因：desktop 壳 `hardenSession()` 全拒渲染进程权限；Electron 将 `navigator.clipboard.writeText()`（Web UI 所有复制控件经 `writeClipboard()` 调用）绑定在 `clipboard-sanitized-write` 权限检查上，被拒后 `writeClipboard` 仅在 API 不存在时才回退 `execCommand`，因此所有复制按钮静默失效。
