### PR TITLE
fix(desktop): exclude source maps from packaged app

### DIFF
--- a/dsh-plugin-desktop/package.json
+++ b/dsh-plugin-desktop/package.json
@@ -259,7 +259,8 @@
       "cordis.patch.yml",
       "lib/**",
       "package.json",
-      "!node_modules/node-pty/build/**"
+      "!node_modules/node-pty/build/**",
+      "!**/*.map"
     ],
     "mac": {
       "target": [

--- a/dsh-plugin-desktop/tests/package.spec.ts
+++ b/dsh-plugin-desktop/tests/package.spec.ts
@@ -172,6 +172,7 @@ describe('published package surface', () => {
       'lib/**',
       'package.json',
       '!node_modules/node-pty/build/**',
+      '!**/*.map',
     ])
     expect(manifest.build?.mac?.icon).toBe('build/app-icon-mac.png')
     expect(manifest.build?.mac?.mergeASARs).toBe(false)


### PR DESCRIPTION
## Summary

Exclude source map files from Electron release artifacts.

- Add `!**/*.map` to Electron Builder’s packaged-file exclusions.
- Prevent source maps from both `lib` and production `node_modules` being copied into `app.asar` or `app.asar.unpacked`.
- Keep development source maps enabled and add coverage for the packaging configuration.

## Verification

- `corepack yarn check`
- `corepack yarn workspace dsh-plugin-desktop package:dir`
- Confirmed no `.map` files in either `app.asar` or `app.asar.unpacked`.