### PR TITLE
fix(desktop): exit with 143 on SIGTERM instead of 0

### DIFF
--- a/dsh-plugin-desktop/src/shutdown.ts
+++ b/dsh-plugin-desktop/src/shutdown.ts
@@ -126,7 +126,7 @@ export function installShutdownRequests(
   requestQuit: (code: number) => void,
 ): () => void {
   const interrupt = (): void => { requestQuit(130) }
-  const terminate = (): void => { requestQuit(0) }
+  const terminate = (): void => { requestQuit(143) }
   const beforeQuit = (event: DesktopQuitEvent): void => {
     event.preventDefault()
     requestQuit(0)

--- a/dsh-plugin-desktop/tests/shutdown.spec.ts
+++ b/dsh-plugin-desktop/tests/shutdown.spec.ts
@@ -127,7 +127,7 @@ describe('application shutdown requests', () => {
     signalListeners.get('SIGTERM')?.()
     appListeners.get('before-quit')?.(quitEvent)
 
-    expect(requestQuit.mock.calls).toEqual([[130], [0], [0]])
+    expect(requestQuit.mock.calls).toEqual([[130], [143], [0]])
     expect(quitEvent.preventDefault).toHaveBeenCalledOnce()
 
     remove()


### PR DESCRIPTION
## Summary

`installShutdownRequests` maps SIGTERM to `requestQuit(0)`, so a process manager or CI that stops the app with SIGTERM sees a clean exit and cannot distinguish it from a normal quit. SIGINT already correctly maps to 130 (128+2); SIGTERM should map to 143 (128+15) by the same convention.

## Verification

- `vitest run tests/shutdown.spec.ts`: 7/7 pass (updated the assertion that previously pinned the wrong code)
- `tsc --noEmit` typecheck passes
- No other code depends on the SIGTERM exit code being 0 (checked all `requestQuit` call sites)