### PR TITLE
feat(desktop): allow pinning the Web server port via DSH_DESKTOP_WEB_PORT

### DIFF
--- a/docs/user-guide.en.md
+++ b/docs/user-guide.en.md
@@ -49,6 +49,16 @@ Choose **Open DSH Terminal** from the tray. macOS opens Terminal; Windows prefer
 
 The welcome text shows the application version, active profile, profile directory, and DSH home. Desktop creates private `dsh`, `pnpm`, and `node` shims in its user-data directory and prepends that directory only for the new terminal process. It does not modify the system PATH or the user's shell files.
 
+## Web server port
+
+By default the desktop app binds its Web UI to a random port on `127.0.0.1`, so the port can change on every launch and concurrent instances never collide. Scenarios that need a fixed port (for example, the browser helper discovers DSH instances by a fixed port range) can set the `DSH_DESKTOP_WEB_PORT` environment variable:
+
+```bash
+DSH_DESKTOP_WEB_PORT=3080
+```
+
+The value is a decimal integer between 0 and 65535; `0` explicitly requests a random port, and unset or empty keeps today's random-port behaviour. Invalid values log a warning and fall back to a random port instead of failing startup. Whether the port is pinned or not, the Web server always binds loopback (`127.0.0.1`) only and is never exposed to external networks.
+
 ## Updates
 
 Packaged macOS and Windows applications check `https://www.dshdesktop.cn/api/desktop/version` in the background. Startup is not blocked; network errors, non-200 responses, invalid versions, and a server version that is not newer remain silent in the background.

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -49,6 +49,16 @@ dsh plugin update
 
 欢迎信息会显示：应用版本、当前 profile、profile 目录和 DSH home。Desktop 会在自己的 user-data 目录生成 `dsh`、`pnpm` 和 `node` 私有 shim，只对这个终端进程设置 PATH，不会修改系统 PATH 或用户 shell 配置。
 
+## Web 服务端口
+
+桌面版默认把 Web 界面绑定在 `127.0.0.1` 的随机端口上，每次启动端口都可能变化，多实例并行时也不会冲突。需要固定端口的场景（例如浏览器助手依赖固定端口段发现 DSH 实例）可以设置环境变量 `DSH_DESKTOP_WEB_PORT`：
+
+```bash
+DSH_DESKTOP_WEB_PORT=3080
+```
+
+取值为 0–65535 的十进制整数；`0` 表示显式使用随机端口，不设置或留空时保持默认随机行为。非法值会告警并回退到随机端口，不会导致启动失败。无论端口是否固定，Web 服务始终只绑定 loopback（`127.0.0.1`），不会对外网开放。
+
 ## 更新
 
 打包后的 macOS/Windows 应用会在后台检查 `https://www.dshdesktop.cn/api/desktop/version`。后台检查不阻塞启动；网络错误、非 200、非法版本或服务端版本不新时保持静默。

--- a/dsh-plugin-desktop/src/main.ts
+++ b/dsh-plugin-desktop/src/main.ts
@@ -30,6 +30,7 @@ import {
 } from './profile-manager.ts'
 import { DesktopProfileService } from './profile-service.ts'
 import { prepareDesktopProfile, type SkippedOptionalEntry } from './profile.ts'
+import { resolveWebServerPort } from './web-server-port.ts'
 import type { DesktopPnpmBootstrap } from './pnpm.ts'
 import {
   createDesktopExitCoordinator,
@@ -274,7 +275,7 @@ async function start(): Promise<void> {
           requestRestart: () => runtime.requestRestart(),
         })
         provideCmdline(hostCtx, {
-          args: ['--host', '127.0.0.1', '--port', '0'],
+          args: ['--host', '127.0.0.1', '--port', String(resolveWebServerPort())],
           exit: requestQuit,
         })
       },

--- a/dsh-plugin-desktop/src/profile.ts
+++ b/dsh-plugin-desktop/src/profile.ts
@@ -28,6 +28,7 @@ import FileSettingsProvider, {
 } from '@deepseek-ai/dsh-settings-file'
 import { parseDocument } from 'yaml'
 import { unpackedAsarPath } from './packaged-runtime-path.ts'
+import { resolveWebServerPort } from './web-server-port.ts'
 import type { DesktopShellMode } from './runtime.ts'
 
 /** Persistent profile managed by the desktop launcher and the ordinary dsh plugin command. */
@@ -419,10 +420,13 @@ export function prepareDesktopProfile(
     }
   }
   // Loopback-only binding is a launcher security invariant, not user config.
+  // The port defaults to 0 (OS-assigned random) so concurrent desktop
+  // instances never collide; DSH_DESKTOP_WEB_PORT pins it for external tools
+  // (e.g. the browser helper) that discover DSH by a fixed port.
   patches.push({
     id: 'webserver',
     disabled: false,
-    config: { host: '127.0.0.1', port: 0 },
+    config: { host: '127.0.0.1', port: resolveWebServerPort() },
   })
   if ((telemetryDisabled ?? '') !== '' && rows.has('session-telemetry-otel')) {
     patches.push({ id: 'session-telemetry-otel', disabled: true })

--- a/dsh-plugin-desktop/src/web-server-port.ts
+++ b/dsh-plugin-desktop/src/web-server-port.ts
@@ -1,0 +1,46 @@
+/**
+ * Resolve the loopback Web server port for the desktop launcher.
+ *
+ * The desktop shell binds the DSH Web UI to 127.0.0.1 with a random port
+ * (port 0) by default so concurrent desktop instances never collide. Some
+ * external tools (e.g. the DSH browser helper) discover a DSH instance by
+ * scanning the fixed port range the CLI uses (3080 / 3081 / 3090) and
+ * cannot follow a desktop instance that moves port on every launch.
+ *
+ * `DSH_DESKTOP_WEB_PORT` lets a user pin a port for that scenario. Unset
+ * (or empty) keeps the default random-port behaviour, so existing installs
+ * are unchanged. The host stays 127.0.0.1 — loopback binding is a launcher
+ * security invariant and is not configurable here.
+ *
+ * Accepted values: a non-negative decimal integer (0..65535). `0` requests
+ * an OS-assigned random port explicitly. Anything else (fractions, hex,
+ * scientific notation, signs, text) falls back to `0` with a warning,
+ * rather than failing startup over a bad port override.
+ */
+
+const ENV_NAME = 'DSH_DESKTOP_WEB_PORT'
+const MAX_PORT = 65535
+// Strict decimal integer: rejects signs, fractions, hex (0x..), and
+// scientific notation (1e3) that Number()/parseInt() would otherwise accept.
+const DECIMAL_INTEGER = /^\d+$/u
+
+/** Resolve the Web server port from `DSH_DESKTOP_WEB_PORT`, defaulting to 0. */
+export function resolveWebServerPort(env: NodeJS.ProcessEnv = process.env): number {
+  const raw = env[ENV_NAME]
+  if (raw === undefined || raw.trim() === '') return 0
+  const trimmed = raw.trim()
+  if (!DECIMAL_INTEGER.test(trimmed)) {
+    console.warn(
+      `[dsh-plugin-desktop] ${ENV_NAME}="${raw}" is not a decimal integer; falling back to a random port.`,
+    )
+    return 0
+  }
+  const parsed = Number.parseInt(trimmed, 10)
+  if (parsed > MAX_PORT) {
+    console.warn(
+      `[dsh-plugin-desktop] ${ENV_NAME}="${raw}" exceeds ${MAX_PORT}; falling back to a random port.`,
+    )
+    return 0
+  }
+  return parsed
+}

--- a/dsh-plugin-desktop/tests/web-server-port.spec.ts
+++ b/dsh-plugin-desktop/tests/web-server-port.spec.ts
@@ -1,0 +1,70 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { resolveWebServerPort } from '../src/web-server-port.ts'
+
+describe('resolveWebServerPort', () => {
+  const original = process.env.DSH_DESKTOP_WEB_PORT
+  afterEach(() => {
+    if (original === undefined) delete process.env.DSH_DESKTOP_WEB_PORT
+    else process.env.DSH_DESKTOP_WEB_PORT = original
+    vi.restoreAllMocks()
+  })
+
+  it('returns 0 (random) when the env var is unset', () => {
+    delete process.env.DSH_DESKTOP_WEB_PORT
+    expect(resolveWebServerPort()).toBe(0)
+  })
+
+  it('returns 0 (random) when the env var is empty or whitespace', () => {
+    for (const value of ['', '   ', '\t']) {
+      process.env.DSH_DESKTOP_WEB_PORT = value
+      expect(resolveWebServerPort()).toBe(0)
+    }
+  })
+
+  it('returns the pinned port for a positive integer', () => {
+    process.env.DSH_DESKTOP_WEB_PORT = '3080'
+    expect(resolveWebServerPort()).toBe(3080)
+  })
+
+  it('accepts an explicit 0 to request a random port', () => {
+    process.env.DSH_DESKTOP_WEB_PORT = '0'
+    expect(resolveWebServerPort()).toBe(0)
+  })
+
+  it('accepts the upper bound 65535', () => {
+    process.env.DSH_DESKTOP_WEB_PORT = '65535'
+    expect(resolveWebServerPort()).toBe(65535)
+  })
+
+  it('falls back to 0 with a warning for non-numeric input', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    process.env.DSH_DESKTOP_WEB_PORT = 'abc'
+    expect(resolveWebServerPort()).toBe(0)
+    expect(warn).toHaveBeenCalledOnce()
+  })
+
+  it('rejects out-of-range integers and falls back to 0', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    for (const value of ['-1', '65536', '99999']) {
+      process.env.DSH_DESKTOP_WEB_PORT = value
+      expect(resolveWebServerPort()).toBe(0)
+    }
+    expect(warn).toHaveBeenCalledTimes(3)
+  })
+
+  it('rejects fractional values and falls back to 0', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    process.env.DSH_DESKTOP_WEB_PORT = '3080.5'
+    expect(resolveWebServerPort()).toBe(0)
+    expect(warn).toHaveBeenCalledOnce()
+  })
+
+  it('rejects hex and scientific notation that Number() would accept', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    for (const value of ['0x10', '1e3', '+3080']) {
+      process.env.DSH_DESKTOP_WEB_PORT = value
+      expect(resolveWebServerPort()).toBe(0)
+    }
+    expect(warn).toHaveBeenCalledTimes(3)
+  })
+})


### PR DESCRIPTION
## What

允许通过环境变量 `DSH_DESKTOP_WEB_PORT` 固定桌面版 Web 服务的端口，解决 #202（原 #199）描述的互操作缺口：桌面版随机端口导致浏览器助手等外部工具无法稳定连接。

```bash
DSH_DESKTOP_WEB_PORT=3080  # 固定 3080；不设置则维持今天的随机端口行为
```

- 新增 `resolveWebServerPort()`：接受 [0, 65535] 的十进制整数，`0` = 显式请求随机端口；非法值（分数 / hex / 科学计数法 / 越界 / 文本）告警并回退 0，不让启动因错误覆盖值而失败
- 接入两处调用点：`main.ts` 的 cmdline args、`profile.ts` 的 webserver patch
- host 保持 `127.0.0.1` 不变 —— 如 profile.ts 注释所述，loopback 绑定是启动器的安全不变量，本 PR 只放开 port，不放开 host

## Why

- #199 / #202：CLI 版用固定段 3080/3081/3090，浏览器助手靠扫描发现实例；桌面版每次启动随机端口，该能力退化
- #174 曾尝试解决但被关；本 PR 采用**环境变量透传**的最小方案（不碰 UI、不改默认行为、不碰上游子模块），降低合并门槛

## 验证

- [x] 新增 `tests/web-server-port.spec.ts` 9 个测试覆盖：unset/空值、正整数、显式 0、上界 65535、非数字、越界、分数、hex、科学计数法
- [x] 本地用 Node 对 helper 逻辑跑了 15 个用例全部通过（含 `parseInt("3080.5")` 静默截断这类边界——严格正则已挡住）
- [ ] 完整 `yarn check` 交给 CI（本地未装完整 workspace + submodule）
- [ ] 实机行为未验证（未打包运行）

## 待确认（转为 ready-for-review 前）

1. **env var 名称**：我用的是 `DSH_DESKTOP_WEB_PORT`。如果维护者倾向更短的名字（如 `DSH_DESKTOP_PORT`）或想走 #202 里的方案 A（设置 UI 配置项），请指出——改动集中在 helper 一处，改起来很快
2. **文档**：确认方向后我会补 `docs/user-guide.md` + `.en.md` 的环境变量说明，并更新 `README.i18n.yaml` 的双语 hash（CONTRIBUTING 要求）

Related: #202, #199, closed #174
