### PR TITLE
fix: preserve streamed tool call identity

### DIFF
--- a/dsh-plugin-desktop/tests/deepseek-streaming-tool-call.spec.ts
+++ b/dsh-plugin-desktop/tests/deepseek-streaming-tool-call.spec.ts
@@ -1,0 +1,100 @@
+import type { AnonymousUserId } from '@deepseek-ai/dsh-anonymous-user-id'
+import { MessageId, type StreamChunk } from '@deepseek-ai/dsh-llm'
+import {
+  DeepSeekAdapter,
+  resolveAdapterOptions,
+} from '@deepseek-ai/dsh-llm-deepseek'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+function sseResponse(payloads: readonly unknown[]): Response {
+  const body = payloads
+    .map(payload => `data: ${typeof payload === 'string' ? payload : JSON.stringify(payload)}\n\n`)
+    .join('')
+  return new Response(body, {
+    status: 200,
+    headers: { 'content-type': 'text/event-stream' },
+  })
+}
+
+describe('patched DeepSeek streaming tool calls', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('keeps the first non-empty id and name when continuation deltas contain empty strings', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => sseResponse([
+      {
+        choices: [{
+          delta: {
+            tool_calls: [{
+              index: 0,
+              id: 'call_web_search',
+              type: 'function',
+              function: { name: 'web_search', arguments: '{"query":' },
+            }],
+          },
+        }],
+      },
+      {
+        choices: [{
+          delta: {
+            tool_calls: [{
+              index: 0,
+              id: '',
+              function: { name: '', arguments: '"AI news today"}' },
+            }],
+          },
+        }],
+      },
+      {
+        choices: [{ delta: {}, finish_reason: 'tool_calls' }],
+        usage: { prompt_tokens: 10, completion_tokens: 5, total_tokens: 15 },
+      },
+      '[DONE]',
+    ])))
+
+    const connection = resolveAdapterOptions({
+      baseURL: 'https://example.test/v1',
+      thinking: 'disabled',
+    })
+    const adapter = new DeepSeekAdapter({
+      options: () => connection,
+      resolveApiKey: async () => 'test-key',
+      resolveUserId: () => 'test-user' as AnonymousUserId,
+    })
+    const chunks: StreamChunk[] = []
+
+    for await (const chunk of adapter.stream({
+      provider: 'deepseek-official',
+      model: 'deepseek-v4-pro',
+      messages: [{
+        id: MessageId('message-user'),
+        role: 'user',
+        content: [{ type: 'text', text: 'Search today AI news' }],
+        source: { kind: 'user' },
+      }],
+      tools: [{
+        name: 'web_search',
+        description: 'Search the web',
+        parameters: {
+          type: 'object',
+          properties: { query: { type: 'string' } },
+          required: ['query'],
+        },
+      }],
+    })) chunks.push(chunk)
+
+    expect(chunks.find(chunk => chunk.type === 'block-end')).toMatchObject({
+      block: {
+        type: 'tool-call',
+        id: 'call_web_search',
+        name: 'web_search',
+        arguments: '{"query":"AI news today"}',
+      },
+    })
+    expect(chunks.at(-1)).toMatchObject({
+      type: 'finish',
+      reason: { kind: 'tool-calls' },
+    })
+  })
+})

--- a/dsh-plugin-desktop/tests/package.spec.ts
+++ b/dsh-plugin-desktop/tests/package.spec.ts
@@ -308,6 +308,24 @@ describe('published package surface', () => {
     expect(installedCodeSign).toContain('"-k", keychainPassword, keychainFile')
   })
 
+  it('preserves streamed DeepSeek tool call identity across empty continuation fields', () => {
+    const patchResolution = 'patch:@deepseek-ai/dsh-llm-deepseek@npm%3A0.1.0-rc.6#./patches/dsh-llm-deepseek@0.1.0-rc.6.patch'
+    const lockfile = readFileSync(new URL('yarn.lock', workspaceRoot), 'utf8')
+    const patch = readFileSync(new URL('patches/dsh-llm-deepseek@0.1.0-rc.6.patch', workspaceRoot), 'utf8')
+    const workspaceRequire = createRequire(new URL('package.json', packageRoot))
+    const adapterManifest = workspaceRequire.resolve('@deepseek-ai/dsh-llm-deepseek/package.json')
+    const installedAdapter = readFileSync(join(dirname(adapterManifest), 'lib/index.js'), 'utf8')
+
+    expect(workspaceManifest.resolutions).toMatchObject({
+      '@deepseek-ai/dsh-llm-deepseek@npm:^0.1.0-rc.6': patchResolution,
+    })
+    expect(lockfile).toContain('@deepseek-ai/dsh-llm-deepseek@patch:@deepseek-ai/dsh-llm-deepseek@npm%3A0.1.0-rc.6#./patches/dsh-llm-deepseek@0.1.0-rc.6.patch')
+    expect(patch).toContain('if (call.id) block.callId = call.id;')
+    expect(patch).toContain('if (call.function?.name) block.name = call.function.name;')
+    expect(installedAdapter).toContain('if (call.id) block.callId = call.id;')
+    expect(installedAdapter).toContain('if (call.function?.name) block.name = call.function.name;')
+  })
+
   it('starts restricted Windows shells with a hidden console show state', () => {
     const patchResolution = 'patch:@deepseek-ai/dsh-sandbox-windows-acl@npm%3A0.1.0-rc.6#./patches/dsh-sandbox-windows-acl@0.1.0-rc.6.patch'
     const lockfile = readFileSync(new URL('yarn.lock', workspaceRoot), 'utf8')

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "app-builder-lib@npm:26.15.3": "patch:app-builder-lib@npm%3A26.15.3#./patches/app-builder-lib@26.15.3.patch",
     "@deepseek-ai/dsh-sandbox-windows-acl@npm:0.1.0-rc.6": "patch:@deepseek-ai/dsh-sandbox-windows-acl@npm%3A0.1.0-rc.6#./patches/dsh-sandbox-windows-acl@0.1.0-rc.6.patch",
     "@deepseek-ai/dsh-sandbox-windows-acl@npm:^0.1.0-rc.6": "patch:@deepseek-ai/dsh-sandbox-windows-acl@npm%3A0.1.0-rc.6#./patches/dsh-sandbox-windows-acl@0.1.0-rc.6.patch",
+    "@deepseek-ai/dsh-llm-deepseek@npm:^0.1.0-rc.6": "patch:@deepseek-ai/dsh-llm-deepseek@npm%3A0.1.0-rc.6#./patches/dsh-llm-deepseek@0.1.0-rc.6.patch",
     "koffi@npm:^3.1.0": "3.1.5"
   },
   "dependenciesMeta": {

--- a/patches/dsh-llm-deepseek@0.1.0-rc.6.patch
+++ b/patches/dsh-llm-deepseek@0.1.0-rc.6.patch
@@ -1,0 +1,15 @@
+diff --git a/lib/index.js b/lib/index.js
+index 453363566a291b13f4e90ea6ba03732265253d3e..f538f7e3c2f2d2972e237a42d653aed8231705e7 100644
+--- a/lib/index.js
++++ b/lib/index.js
+@@ -318,8 +318,8 @@ async function* translate(response, request) {
+ 						blockType: "tool-call"
+ 					};
+ 				}
+-				if (call.id !== void 0) block.callId = call.id;
+-				if (call.function?.name !== void 0) block.name = call.function.name;
++				if (call.id) block.callId = call.id;
++				if (call.function?.name) block.name = call.function.name;
+ 				const fragment = call.function?.arguments ?? "";
+ 				block.text += fragment;
+ 				yield {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2159,7 +2159,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@deepseek-ai/dsh-llm-deepseek@npm:^0.1.0-rc.6":
+"@deepseek-ai/dsh-llm-deepseek@npm:0.1.0-rc.6":
   version: 0.1.0-rc.6
   resolution: "@deepseek-ai/dsh-llm-deepseek@npm:0.1.0-rc.6"
   dependencies:
@@ -2175,6 +2175,25 @@ __metadata:
     "@deepseek-ai/dsh-settings": ^0.1.0-rc.6
     "@deepseek-ai/dsh-timeout": ^0.1.0-rc.6
   checksum: 10c0/8d3c1bd9e533de502e2366546e0640dc2401bcbffa31901cdbff5aa40993d126dfed6492371de5e45deba01c63529a99ba07dc08d9cc42036c50438ab3f5380b
+  languageName: node
+  linkType: hard
+
+"@deepseek-ai/dsh-llm-deepseek@patch:@deepseek-ai/dsh-llm-deepseek@npm%3A0.1.0-rc.6#./patches/dsh-llm-deepseek@0.1.0-rc.6.patch::locator=deepseek-harness-desktop%40workspace%3A.":
+  version: 0.1.0-rc.6
+  resolution: "@deepseek-ai/dsh-llm-deepseek@patch:@deepseek-ai/dsh-llm-deepseek@npm%3A0.1.0-rc.6#./patches/dsh-llm-deepseek@0.1.0-rc.6.patch::version=0.1.0-rc.6&hash=206321&locator=deepseek-harness-desktop%40workspace%3A."
+  dependencies:
+    "@deepseek-ai/schemastery": "npm:^3.18.1"
+    eventsource-parser: "npm:^3.1.0"
+  peerDependencies:
+    "@deepseek-ai/cordis": ^4.0.1
+    "@deepseek-ai/dsh-anonymous-user-id": ^0.1.0-rc.6
+    "@deepseek-ai/dsh-credentials": ^0.1.0-rc.6
+    "@deepseek-ai/dsh-invariants": ^0.1.0-rc.6
+    "@deepseek-ai/dsh-launch-environment": ^0.1.0-rc.6
+    "@deepseek-ai/dsh-llm": ^0.1.0-rc.6
+    "@deepseek-ai/dsh-settings": ^0.1.0-rc.6
+    "@deepseek-ai/dsh-timeout": ^0.1.0-rc.6
+  checksum: 10c0/834397b9c627b76a9a427ab71c144d7b01855a3d556c4240e1fa5b8e1218a367a6933e28dbb01067c3d4f2d1ede187eeeeffcf6011cf017757a4d64c6f2bf440
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

- patch `@deepseek-ai/dsh-llm-deepseek@0.1.0-rc.6` so empty continuation fields do not overwrite a previously captured tool call ID or function name
- add a behavioral regression test using real SSE-shaped deltas
- verify the patch is retained by the workspace resolution, lockfile, and installed package

## Problem

Some OpenAI-compatible endpoints emit the tool call ID and function name in the
first SSE delta, then use empty strings for those fields in continuation deltas.

The DeepSeek adapter treated the empty strings as replacements, so a valid tool
call such as `web_search` was assembled with an empty name and failed repeatedly:

```text
unknown tool ""
```
Closes #197
