### PR TITLE
fix(deps): patch dsh-llm-deepseek to ignore empty tool-call name/id deltas

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "app-builder-lib@npm:26.15.3": "patch:app-builder-lib@npm%3A26.15.3#./patches/app-builder-lib@26.15.3.patch",
     "@deepseek-ai/dsh-sandbox-windows-acl@npm:0.1.0-rc.6": "patch:@deepseek-ai/dsh-sandbox-windows-acl@npm%3A0.1.0-rc.6#./patches/dsh-sandbox-windows-acl@0.1.0-rc.6.patch",
     "@deepseek-ai/dsh-sandbox-windows-acl@npm:^0.1.0-rc.6": "patch:@deepseek-ai/dsh-sandbox-windows-acl@npm%3A0.1.0-rc.6#./patches/dsh-sandbox-windows-acl@0.1.0-rc.6.patch",
-    "koffi@npm:^3.1.0": "3.1.5"
+    "koffi@npm:^3.1.0": "3.1.5",
+    "@deepseek-ai/dsh-llm-deepseek@npm:^0.1.0-rc.6": "patch:@deepseek-ai/dsh-llm-deepseek@npm%3A0.1.0-rc.6#./patches/dsh-llm-deepseek@0.1.0-rc.6.patch"
   },
   "dependenciesMeta": {
     "@deepseek-ai/dsh-subprocess-local": {

--- a/patches/dsh-llm-deepseek@0.1.0-rc.6.patch
+++ b/patches/dsh-llm-deepseek@0.1.0-rc.6.patch
@@ -1,0 +1,15 @@
+diff --git a/lib/index.js b/lib/index.js
+index b9624f2b453f9056b5dc7ae5cc40c751e995179f..faf76bb7a6702519f6562a3c6d65872b74d23715 100644
+--- a/lib/index.js
++++ b/lib/index.js
+@@ -318,8 +318,8 @@ async function* translate(payloads) {
+ 						blockType: "tool-call"
+ 					};
+ 				}
+-				if (call.id !== void 0) block.callId = call.id;
+-				if (call.function?.name !== void 0) block.name = call.function.name;
++				if (call.id !== void 0 && call.id !== "") block.callId = call.id;
++				if (call.function?.name !== void 0 && call.function.name !== "") block.name = call.function.name;
+ 				const fragment = call.function?.arguments ?? "";
+ 				block.text += fragment;
+ 				yield {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2159,7 +2159,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@deepseek-ai/dsh-llm-deepseek@npm:^0.1.0-rc.6":
+"@deepseek-ai/dsh-llm-deepseek@npm:0.1.0-rc.6":
   version: 0.1.0-rc.6
   resolution: "@deepseek-ai/dsh-llm-deepseek@npm:0.1.0-rc.6"
   dependencies:
@@ -2175,6 +2175,25 @@ __metadata:
     "@deepseek-ai/dsh-settings": ^0.1.0-rc.6
     "@deepseek-ai/dsh-timeout": ^0.1.0-rc.6
   checksum: 10c0/8d3c1bd9e533de502e2366546e0640dc2401bcbffa31901cdbff5aa40993d126dfed6492371de5e45deba01c63529a99ba07dc08d9cc42036c50438ab3f5380b
+  languageName: node
+  linkType: hard
+
+"@deepseek-ai/dsh-llm-deepseek@patch:@deepseek-ai/dsh-llm-deepseek@npm%3A0.1.0-rc.6#./patches/dsh-llm-deepseek@0.1.0-rc.6.patch::locator=deepseek-harness-desktop%40workspace%3A.":
+  version: 0.1.0-rc.6
+  resolution: "@deepseek-ai/dsh-llm-deepseek@patch:@deepseek-ai/dsh-llm-deepseek@npm%3A0.1.0-rc.6#./patches/dsh-llm-deepseek@0.1.0-rc.6.patch::version=0.1.0-rc.6&hash=0525ca&locator=deepseek-harness-desktop%40workspace%3A."
+  dependencies:
+    "@deepseek-ai/schemastery": "npm:^3.18.1"
+    eventsource-parser: "npm:^3.1.0"
+  peerDependencies:
+    "@deepseek-ai/cordis": ^4.0.1
+    "@deepseek-ai/dsh-anonymous-user-id": ^0.1.0-rc.6
+    "@deepseek-ai/dsh-credentials": ^0.1.0-rc.6
+    "@deepseek-ai/dsh-invariants": ^0.1.0-rc.6
+    "@deepseek-ai/dsh-launch-environment": ^0.1.0-rc.6
+    "@deepseek-ai/dsh-llm": ^0.1.0-rc.6
+    "@deepseek-ai/dsh-settings": ^0.1.0-rc.6
+    "@deepseek-ai/dsh-timeout": ^0.1.0-rc.6
+  checksum: 10c0/a6664a06e528d1a312aaa1075147866326b6ba94bc730bbe90f059e5e036215be82e5b61e2754b32caabf31be24c1f5fa1b9f69d51018d099b397d053b20f666
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## What

用 yarn patch 修复 `@deepseek-ai/dsh-llm-deepseek@0.1.0-rc.6` 的流式 Tool Call 解析：空字符串 delta 不再覆盖已解析的 tool name / id。

**根因**（来自 #197 的分析）：流式解析器只在字段 `!== undefined` 时赋值：

```js
if (call.id !== void 0) block.callId = call.id;
if (call.function?.name !== void 0) block.name = call.function.name;
```

DeepSeek 的 SSE 后续 chunk 会携带 `function.name: ""`（空串），把首个 chunk 里正确的 `web_search` 覆盖掉，导致工具执行时报 `unknown tool ""`（#197、#157 两个 issue 同根因）。

**修复**：非空才赋值。

```js
if (call.id !== void 0 && call.id !== "") block.callId = call.id;
if (call.function?.name !== void 0 && call.function.name !== "") block.name = call.function.name;
```

## Why patch（而非等上游）

- npm 最新版本就是 `0.1.0-rc.6`，上游暂无修复版本
- 项目已有 yarn patch 先例（`app-builder-lib`、`dsh-sandbox-windows-acl`），走同一机制
- 修复点单一（两行判断），不改变任何接口行为

## 改动文件

- `patches/dsh-llm-deepseek@0.1.0-rc.6.patch` — 新增，由 `yarn patch` 工作流生成
- `package.json` — `resolutions` 增加 patch 条目（与现有条目同格式）
- `yarn.lock` — patch 解析条目（`hash=0525ca`，由 yarn 计算）

## 验证

- [x] **行为级验证**：提取 patched `translate()`，回放 #197 的失败 SSE 序列（chunk1 带真名 → chunk2 带空串名），最终 block 保持 `name="web_search", id="call_1"` ✅
- [x] **workspace 测试套件**：295 passed / 6 failed。6 个失败在 clean master 上同样失败（macOS 打包 spec 在 Windows 不可跑 + symlink 测试需管理员权限），与本次改动无关
- [x] `yarn install --immutable` 兼容性：lockfile 由 yarn 自身生成
- [ ] CI 实机验证（fork PR 需维护者批准 workflow）

## 备注

- #157 提到 id 也有空串问题，故 id 与 name 一并防护（同一 bug 模式）
- 若上游后续发新版修掉此问题，升级依赖时移除本 patch 即可（resolutions 只 pin 到 `0.1.0-rc.6`）

Closes #197. Related: #157.
