### PR TITLE
feat(desktop): 启动时可选开启跨 Profile 插件同步

### DIFF
--- a/docs/plugin-ecosystem.md
+++ b/docs/plugin-ecosystem.md
@@ -38,6 +38,24 @@ Fabric 的 capability 首先用于兼容判断、用户确认和审计，不会�
 
 市场目前仍处于[产品与安全设计阶段](../dsh-community-market/README.zh.md)，尚未提供可用页面或安装器。目录收录只代表符合目录规则，不等于安全审核或推荐。
 
+## 桌面配置项：跨 Profile 插件同步（可选）
+
+桌面壳同时管理 `web`（`dsh web`）与 `desktop`（桌面壳自身）两个独立的 Profile。两者默认互相隔离：在一个 Profile 里通过 `dsh plugin add` 安装的插件不会自动出现在另一个 Profile。
+
+为满足"装一次、两边都能用"的诉求，桌面壳提供了一个**默认关闭**的配置项 `dsh-desktop.syncProfiles`（写入设置文件，等价于桌面壳命名空间下的 `mode` 开关）。开启后，桌面壳在启动时执行一次单向收敛：
+
+- 取 `web` 与 `desktop` 两个 Profile 中**用户第三方 bundle** 的并集；
+- 仅把缺失的 bundle 写入各自 Profile 的 `package.json`（`dsh.profile.bundles`），**不触碰框架包与桌面壳自身**；
+- 仅对"已在另一个 Profile 安装过"的 bundle 执行补齐安装，避免启动期联网。
+
+这一设计刻意遵循本倡议的三条原则：
+
+- **组合优先**：同步只调整 `dsh.profile.bundles` 声明，不假设或覆盖任何插件的内部实现。
+- **声明清晰**：只搬运用户显式安装的第三方 bundle，框架包与桌面壳 bundle 被显式排除，绝不重新引入被 `profile-manager` 禁止写入 `bundles` 的桌面壳包。
+- **兼容优先**：功能默认关闭；已有 Profile 在开关前后行为完全一致，开启也只是把缺失 bundle 补齐为并集，不会删除任何已有插件。
+
+> 注意：该同步是"尽力而为"的。并非所有插件都在两个 Profile 下行为一致；开启前请确认你希望共享的插件在两边都能正常加载。
+
 ## 如何参与
 
 - 在[插件开发](plugin-development.md)中了解插件如何编写。

--- a/dsh-plugin-desktop/src/main.ts
+++ b/dsh-plugin-desktop/src/main.ts
@@ -22,14 +22,17 @@ import { installProfilePackageResolver } from './module-resolution.ts'
 import { packagedDependencyPath } from './packaged-runtime-path.ts'
 import {
   beginDesktopProfileStartup,
+  DEFAULT_PROFILE_NAME,
   listDesktopProfiles,
   markDesktopProfileFailed,
   markDesktopProfileHealthy,
   selectDesktopProfile,
+  WEB_PROFILE_NAME,
   type DesktopProfileStartup,
 } from './profile-manager.ts'
 import { DesktopProfileService } from './profile-service.ts'
 import { prepareDesktopProfile, type SkippedOptionalEntry } from './profile.ts'
+import { runProfileSync } from './profile-sync.ts'
 import type { DesktopPnpmBootstrap } from './pnpm.ts'
 import {
   createDesktopExitCoordinator,
@@ -277,6 +280,23 @@ async function start(): Promise<void> {
           args: ['--host', '127.0.0.1', '--port', '0'],
           exit: requestQuit,
         })
+        if (prepared.syncProfiles) {
+          const syncController = new AbortController()
+          hostCtx.effect(
+            () => () => syncController.abort(),
+            'dsh-plugin-desktop: profile sync cancellation',
+          )
+          void runProfileSync(
+            hostCtx,
+            homeDir,
+            [WEB_PROFILE_NAME, DEFAULT_PROFILE_NAME],
+            syncController.signal,
+          ).catch((cause: unknown) => {
+            process.stderr.write(
+              `${BIN_NAME}: profile sync failed: ${cause instanceof Error ? cause.message : String(cause)}\n`,
+            )
+          })
+        }
       },
       prepared.bareModuleBaseUrl,
     ).catch((cause: unknown) => {

--- a/dsh-plugin-desktop/src/pnpm.ts
+++ b/dsh-plugin-desktop/src/pnpm.ts
@@ -174,8 +174,10 @@ export class DesktopPnpm extends Service {
     args: readonly string[],
     invokingDir: string,
     signal?: AbortSignal,
+    profileName: string = this.bootstrap.activeProfileName,
   ): DesktopPnpmHandle {
     const resolvedArgs = validatedArgs(args)
+    assertDesktopProfileName(profileName)
     assertAbsolutePath('plugin invoking directory', invokingDir)
     return this.start({
       argv: [
@@ -184,7 +186,7 @@ export class DesktopPnpm extends Service {
         this.bootstrap.dshBootstrapPath,
         'plugin',
         '--profile',
-        this.bootstrap.activeProfileName,
+        profileName,
         ...resolvedArgs,
       ],
       cwd: invokingDir,

--- a/dsh-plugin-desktop/src/profile-manager.ts
+++ b/dsh-plugin-desktop/src/profile-manager.ts
@@ -23,8 +23,8 @@ import {
 } from '@deepseek-ai/dsh-app-boot'
 
 const BIN_NAME = 'dsh-plugin-desktop'
-const DEFAULT_PROFILE_NAME = 'desktop'
-const WEB_PROFILE_NAME = 'web'
+export const DEFAULT_PROFILE_NAME = 'desktop'
+export const WEB_PROFILE_NAME = 'web'
 const BASE_BUNDLE_NAME = '@deepseek-ai/dsh-base'
 const WEB_BUNDLE_NAME = '@deepseek-ai/dsh-web-app'
 const DESKTOP_BUNDLE_NAME = 'dsh-plugin-desktop'

--- a/dsh-plugin-desktop/src/profile-sync.ts
+++ b/dsh-plugin-desktop/src/profile-sync.ts
@@ -1,0 +1,225 @@
+/** Opt-in cross-profile bundle synchronization for the desktop launcher. */
+
+import { existsSync } from 'node:fs'
+import { join } from 'node:path'
+import type { Context } from '@deepseek-ai/cordis'
+import {
+  PROFILE_TEMPLATES,
+  readProfileManifest,
+  resolveProfileDir,
+  writeProfileManifest,
+  type ProfileManifest,
+} from '@deepseek-ai/dsh-app-boot'
+import type {} from './pnpm.ts'
+
+const BIN_NAME = 'dsh-plugin-desktop'
+
+/** Standalone Web profile name managed by the ordinary `dsh web` command. */
+export const WEB_PROFILE_NAME = 'web'
+/** Launcher-owned desktop profile name. */
+export const DESKTOP_PROFILE_NAME = 'desktop'
+const DESKTOP_PACKAGE_NAME = 'dsh-plugin-desktop'
+
+/**
+ * Bundles that belong to the shared framework or the launcher shell. They are
+ * present in every product profile by construction and must never be copied
+ * across profiles: doing so would duplicate the framework or re-introduce the
+ * launcher-owned shell into `dsh.profile.bundles`, which `profile-manager`
+ * explicitly forbids.
+ */
+const PROTECTED_BUNDLES: ReadonlySet<string> = new Set([
+  '@deepseek-ai/dsh-base',
+  '@deepseek-ai/dsh-web-app',
+  DESKTOP_PACKAGE_NAME,
+  ...(PROFILE_TEMPLATES.web ?? []),
+])
+
+/** Return whether a bundle is a candidate for cross-profile synchronization. */
+export function isSyncedBundle(name: string): boolean {
+  return !PROTECTED_BUNDLES.has(name)
+}
+
+/** Read the ordered bundle list declared by one profile manifest. */
+export function readProfileBundles(dir: string): string[] {
+  let manifest: ProfileManifest
+  try {
+    manifest = readProfileManifest(BIN_NAME, dir)
+  } catch {
+    return []
+  }
+  const raw = (manifest.dsh?.profile as { bundles?: unknown } | undefined)?.bundles
+  if (raw === undefined) return []
+  if (!Array.isArray(raw) || raw.some(value => typeof value !== 'string')) {
+    throw new Error(`${BIN_NAME}: dsh.profile.bundles must be an array of package names`)
+  }
+  return [...raw] as string[]
+}
+
+/** Return whether two ordered bundle lists are identical. */
+function sameList(left: readonly string[], right: readonly string[]): boolean {
+  return left.length === right.length && left.every((value, index) => value === right[index])
+}
+
+/**
+ * Merge one profile's existing bundles with the union of third-party bundles.
+ *
+ * Framework bundles keep their original order; existing third-party bundles
+ * keep their order; newly shared third-party bundles are appended. The
+ * protected framework set is never duplicated or relocated.
+ *
+ * @param existing - current bundle list of the target profile.
+ * @param unionThirdParty - union of third-party bundles across all synced profiles.
+ * @returns the merged bundle list for the target profile.
+ */
+export function mergeBundlesForProfile(
+  existing: readonly string[],
+  unionThirdParty: ReadonlySet<string>,
+): string[] {
+  const protectedExisting = existing.filter(name => PROTECTED_BUNDLES.has(name))
+  const thirdPartyExisting = existing.filter(name => !PROTECTED_BUNDLES.has(name))
+  const added = [...unionThirdParty].filter(name => !thirdPartyExisting.includes(name))
+  return [...protectedExisting, ...thirdPartyExisting, ...added]
+}
+
+/**
+ * Collect the union of third-party bundles across the given profiles.
+ * @param home - Harness home containing the shared profile directory.
+ * @param profiles - profile names to include in the union.
+ * @returns every user bundle present in at least one existing profile.
+ */
+export function computeProfileBundleUnion(home: string, profiles: readonly string[]): Set<string> {
+  const union = new Set<string>()
+  for (const name of profiles) {
+    const dir = resolveProfileDir(name, home)
+    if (!existsSync(join(dir, 'package.json'))) continue
+    for (const bundle of readProfileBundles(dir)) {
+      if (isSyncedBundle(bundle)) union.add(bundle)
+    }
+  }
+  return union
+}
+
+/** Result of aligning profile manifests to the shared bundle union. */
+export interface ProfileManifestSyncReport {
+  /** Profiles whose manifest was rewritten to include the shared bundles. */
+  readonly updatedProfiles: string[]
+}
+
+/**
+ * Align every existing profile manifest to the shared third-party bundle union.
+ *
+ * Only `package.json` is rewritten; package installation is handled separately
+ * so this step never performs network I/O and cannot block startup.
+ *
+ * @param home - Harness home containing the shared profile directory.
+ * @param profiles - profile names to synchronize.
+ * @returns which profiles had their manifest updated.
+ */
+export function syncProfileManifests(home: string, profiles: readonly string[]): ProfileManifestSyncReport {
+  const union = computeProfileBundleUnion(home, profiles)
+  const updated: string[] = []
+  for (const name of profiles) {
+    const dir = resolveProfileDir(name, home)
+    if (!existsSync(join(dir, 'package.json'))) continue
+    const existing = readProfileBundles(dir)
+    const merged = mergeBundlesForProfile(existing, union)
+    if (!sameList(existing, merged)) {
+      const manifest = readProfileManifest(BIN_NAME, dir)
+      writeProfileManifest(dir, {
+        ...manifest,
+        dsh: {
+          ...manifest.dsh,
+          profile: {
+            ...manifest.dsh?.profile,
+            bundles: merged,
+          },
+        },
+      })
+      updated.push(name)
+    }
+  }
+  return { updatedProfiles: updated }
+}
+
+/** Return whether a package is materialized under a profile's node_modules. */
+function packageInstalled(dir: string, name: string): boolean {
+  return existsSync(join(dir, 'node_modules', ...name.split('/')))
+}
+
+/** Result of installing shared bundles that were missing on disk. */
+export interface ProfileInstallSyncReport {
+  /** `package@profile` entries successfully installed. */
+  readonly installed: string[]
+  /** `package@profile` entries skipped (not available elsewhere or failed). */
+  readonly skipped: string[]
+}
+
+/**
+ * Install shared bundles that are missing on disk but already installed in
+ * another synced profile.
+ *
+ * The "available elsewhere" gate keeps startup offline: a bundle is only
+ * installed into a profile when it already exists under a sibling profile, so
+ * `dsh plugin add` resolves from the local store instead of the network.
+ *
+ * @param ctx - Cordis context providing the managed package-manager service.
+ * @param home - Harness home containing the shared profile directory.
+ * @param profiles - profile names to synchronize.
+ * @param signal - optional cancellation for every install operation.
+ * @returns installed and skipped `package@profile` entries.
+ */
+export async function installSyncedBundles(
+  ctx: Context,
+  home: string,
+  profiles: readonly string[],
+  signal?: AbortSignal,
+): Promise<ProfileInstallSyncReport> {
+  const union = computeProfileBundleUnion(home, profiles)
+  const installed: string[] = []
+  const skipped: string[] = []
+  const dirs = new Map<string, string>()
+  for (const name of profiles) {
+    const dir = resolveProfileDir(name, home)
+    if (existsSync(join(dir, 'package.json'))) dirs.set(name, dir)
+  }
+  for (const name of profiles) {
+    const dir = dirs.get(name)
+    if (dir === undefined) continue
+    for (const bundle of union) {
+      if (packageInstalled(dir, bundle)) continue
+      const availableElsewhere = [...dirs.entries()]
+        .some(([other, otherDir]) => other !== name && packageInstalled(otherDir, bundle))
+      if (!availableElsewhere) {
+        skipped.push(`${bundle}@${name}`)
+        continue
+      }
+      try {
+        const handle = ctx.desktopPnpm.runPlugin(['add', bundle], dir, signal, name)
+        const outcome = await handle.done
+        if (outcome.exitCode === 0) installed.push(`${bundle}@${name}`)
+        else skipped.push(`${bundle}@${name}`)
+      } catch {
+        skipped.push(`${bundle}@${name}`)
+      }
+    }
+  }
+  return { installed, skipped }
+}
+
+/**
+ * Run the full opt-in synchronization: align manifests, then install bundles
+ * that are missing on disk but available in a sibling profile.
+ * @param ctx - Cordis context providing the managed package-manager service.
+ * @param home - Harness home containing the shared profile directory.
+ * @param profiles - profile names to synchronize.
+ * @param signal - optional cancellation for the install phase.
+ */
+export async function runProfileSync(
+  ctx: Context,
+  home: string,
+  profiles: readonly string[],
+  signal?: AbortSignal,
+): Promise<void> {
+  syncProfileManifests(home, profiles)
+  await installSyncedBundles(ctx, home, profiles, signal)
+}

--- a/dsh-plugin-desktop/src/profile.ts
+++ b/dsh-plugin-desktop/src/profile.ts
@@ -114,6 +114,64 @@ export function readDesktopShellMode(config: SettingsFileConfig): DesktopShellMo
   return desktopShellModeFromSettings(document)
 }
 
+/** Default for the opt-in cross-profile bundle synchronization flag. */
+export const DEFAULT_SYNC_PROFILES = false
+
+/**
+ * Parse the cross-profile synchronization flag and reject corrupted values.
+ * @param value - untrusted settings value.
+ * @returns whether web/desktop bundle synchronization is enabled.
+ */
+export function parseDesktopSyncEnabled(value: unknown): boolean {
+  if (value === undefined) return DEFAULT_SYNC_PROFILES
+  if (typeof value === 'boolean') return value
+  throw new Error(`${BIN_NAME}: ${DESKTOP_SETTINGS_NAMESPACE}.syncProfiles must be a boolean`)
+}
+
+/**
+ * Read the cross-profile synchronization flag from one parsed settings document.
+ * @param document - untrusted settings document root.
+ * @returns whether synchronization is enabled, defaulting to off when absent.
+ */
+export function desktopSyncFromSettings(document: unknown): boolean {
+  if (typeof document !== 'object' || document === null || Array.isArray(document)) {
+    throw new Error(`${BIN_NAME}: settings document must be a map of namespace sections`)
+  }
+  const section = (document as Record<string, unknown>)[DESKTOP_SETTINGS_NAMESPACE]
+  if (section === undefined) return DEFAULT_SYNC_PROFILES
+  if (typeof section !== 'object' || section === null || Array.isArray(section)) {
+    throw new Error(`${BIN_NAME}: ${DESKTOP_SETTINGS_NAMESPACE} settings must be a map`)
+  }
+  return parseDesktopSyncEnabled((section as Record<string, unknown>).syncProfiles)
+}
+
+/**
+ * Read the cross-profile synchronization flag from the same file resolved by the settings provider.
+ * @param config - validated settings-file row config.
+ * @returns whether synchronization is enabled.
+ */
+export function readDesktopSyncEnabled(config: SettingsFileConfig): boolean {
+  const spec = resolveSettingsFileSpec(config)
+  let text: string
+  try {
+    text = readFileSync(spec.filename, 'utf8')
+  } catch (cause) {
+    if ((cause as NodeJS.ErrnoException).code === 'ENOENT') return DEFAULT_SYNC_PROFILES
+    throw cause
+  }
+  let document: unknown
+  if (spec.format === 'yaml') {
+    const parsed = parseDocument(text, { prettyErrors: true })
+    if (parsed.errors.length > 0) {
+      throw new Error(`${BIN_NAME}: invalid settings document at ${spec.filename}: ${parsed.errors.map(error => error.message).join('; ')}`)
+    }
+    document = parsed.toJS() ?? {}
+  } else {
+    document = text.trim().length === 0 ? {} : JSON.parse(text)
+  }
+  return desktopSyncFromSettings(document)
+}
+
 /** Resolve the public Web template once and reject an incompatible DSH release. */
 function requiredWebBundles(): string[] {
   const bundles = PROFILE_TEMPLATES.web
@@ -139,6 +197,8 @@ export interface PreparedDesktopProfile {
   skippedOptionalEntries: SkippedOptionalEntry[]
   /** Persisted shell mode applied after every user-owned patch. */
   mode: DesktopShellMode
+  /** Whether web/desktop bundles are synchronized on startup (opt-in). */
+  syncProfiles: boolean
 }
 
 /** User patch entry skipped to keep a profile bootable. */
@@ -340,6 +400,7 @@ export function prepareDesktopProfile(
     ...rowConfig(settings),
   } as SettingsFileConfig)
   const mode = readDesktopShellMode(settingsConfig)
+  const syncProfiles = readDesktopSyncEnabled(settingsConfig)
   patches.push({
     id: 'settings',
     config: settingsConfig,
@@ -447,6 +508,7 @@ export function prepareDesktopProfile(
     patches: structuredClone(patches),
     skippedOptionalEntries,
     mode,
+    syncProfiles,
   }
 }
 

--- a/dsh-plugin-desktop/tests/profile-sync.spec.ts
+++ b/dsh-plugin-desktop/tests/profile-sync.spec.ts
@@ -1,0 +1,129 @@
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
+import {
+  initProfile,
+  PROFILE_TEMPLATES,
+  readProfileManifest,
+  writeProfileManifest,
+} from '@deepseek-ai/dsh-app-boot'
+import {
+  computeProfileBundleUnion,
+  DESKTOP_PROFILE_NAME,
+  isSyncedBundle,
+  mergeBundlesForProfile,
+  readProfileBundles,
+  syncProfileManifests,
+  WEB_PROFILE_NAME,
+} from '../src/profile-sync.ts'
+
+const homes: string[] = []
+
+function temporaryHome(): string {
+  const home = mkdtempSync(join(tmpdir(), 'dsh-desktop-sync-'))
+  homes.push(home)
+  return home
+}
+
+function initProfileWithBundles(home: string, name: string, thirdParty: string[]): string {
+  const dir = join(home, 'profiles', name)
+  const template = PROFILE_TEMPLATES.web
+  if (template === undefined) throw new Error('test requires the shipped Web template')
+  initProfile(dir, template)
+  const manifest = readProfileManifest('test', dir)
+  writeProfileManifest(dir, {
+    ...manifest,
+    dsh: {
+      ...manifest.dsh,
+      profile: {
+        ...manifest.dsh?.profile,
+        bundles: [...template, ...thirdParty],
+      },
+    },
+  })
+  return dir
+}
+
+afterEach(() => {
+  while (homes.length > 0) {
+    const home = homes.pop()
+    if (home !== undefined) rmSync(home, { recursive: true, force: true })
+  }
+})
+
+describe('profile bundle synchronization', () => {
+  it('treats framework and launcher bundles as non-synced', () => {
+    expect(isSyncedBundle('@deepseek-ai/dsh-base')).toBe(false)
+    expect(isSyncedBundle('@deepseek-ai/dsh-web-app')).toBe(false)
+    expect(isSyncedBundle('dsh-plugin-desktop')).toBe(false)
+    expect(isSyncedBundle('dshmarket')).toBe(true)
+  })
+
+  it('merges framework order first, then existing third-party, then new union', () => {
+    const existing = ['@deepseek-ai/dsh-base', '@deepseek-ai/dsh-web-app', 'dsh-a']
+    const merged = mergeBundlesForProfile(existing, new Set(['dsh-a', 'dsh-b']))
+    expect(merged).toEqual([
+      '@deepseek-ai/dsh-base',
+      '@deepseek-ai/dsh-web-app',
+      'dsh-a',
+      'dsh-b',
+    ])
+  })
+
+  it('does not duplicate framework bundles when both profiles share them', () => {
+    const union = new Set(['dshmarket'])
+    const merged = mergeBundlesForProfile(
+      ['@deepseek-ai/dsh-base', '@deepseek-ai/dsh-web-app'],
+      union,
+    )
+    expect(merged.filter(bundle => bundle === '@deepseek-ai/dsh-base')).toHaveLength(1)
+  })
+
+  it('computes the union of third-party bundles across existing profiles', () => {
+    const home = temporaryHome()
+    initProfileWithBundles(home, WEB_PROFILE_NAME, ['dshmarket'])
+    initProfileWithBundles(home, DESKTOP_PROFILE_NAME, ['dsh-workbench-plugin'])
+    const union = computeProfileBundleUnion(home, [WEB_PROFILE_NAME, DESKTOP_PROFILE_NAME])
+    expect(union.has('dshmarket')).toBe(true)
+    expect(union.has('dsh-workbench-plugin')).toBe(true)
+  })
+
+  it('aligns both profile manifests to the shared bundle union', () => {
+    const home = temporaryHome()
+    initProfileWithBundles(home, WEB_PROFILE_NAME, ['dshmarket'])
+    initProfileWithBundles(home, DESKTOP_PROFILE_NAME, ['dsh-workbench-plugin'])
+
+    const report = syncProfileManifests(home, [WEB_PROFILE_NAME, DESKTOP_PROFILE_NAME])
+
+    expect(report.updatedProfiles.sort()).toEqual([DESKTOP_PROFILE_NAME, WEB_PROFILE_NAME])
+    const webBundles = readProfileBundles(join(home, 'profiles', WEB_PROFILE_NAME))
+    const desktopBundles = readProfileBundles(join(home, 'profiles', DESKTOP_PROFILE_NAME))
+    expect(webBundles).toContain('dsh-workbench-plugin')
+    expect(desktopBundles).toContain('dshmarket')
+    // Framework bundles must remain present and unduplicated in both profiles.
+    for (const bundles of [webBundles, desktopBundles]) {
+      expect(bundles.filter(bundle => bundle === '@deepseek-ai/dsh-base')).toHaveLength(1)
+      expect(bundles.filter(bundle => bundle === '@deepseek-ai/dsh-web-app')).toHaveLength(1)
+      expect(bundles).not.toContain('dsh-plugin-desktop')
+    }
+  })
+
+  it('skips profiles that do not exist on disk without touching the existing one', () => {
+    const home = temporaryHome()
+    initProfileWithBundles(home, WEB_PROFILE_NAME, ['dshmarket'])
+    const report = syncProfileManifests(home, [WEB_PROFILE_NAME, DESKTOP_PROFILE_NAME])
+    // The missing desktop profile is skipped; web already holds the only union
+    // member, so no manifest rewrite is needed and nothing crashes.
+    expect(report.updatedProfiles).toEqual([])
+    expect(readProfileBundles(join(home, 'profiles', WEB_PROFILE_NAME))).toContain('dshmarket')
+  })
+
+  it('is idempotent when profiles already share the union', () => {
+    const home = temporaryHome()
+    initProfileWithBundles(home, WEB_PROFILE_NAME, ['dshmarket', 'dsh-workbench-plugin'])
+    initProfileWithBundles(home, DESKTOP_PROFILE_NAME, ['dshmarket', 'dsh-workbench-plugin'])
+    const report = syncProfileManifests(home, [WEB_PROFILE_NAME, DESKTOP_PROFILE_NAME])
+    expect(report.updatedProfiles).toEqual([])
+  })
+})


### PR DESCRIPTION
## 背景

DSH Desktop 同时管理两个互相独立的 Profile：`web`（供 `ds web` 使用）与 `desktop`（桌面壳自身）。两者是**刻意隔离**的——`profile-manager.ts` 甚至明确禁止把桌面壳自有的 `dsh-plugin-desktop` bundle 写进 `dsh.profile.bundles`。因此，通过 `ds plugin --profile web add X` 安装的插件在 `desktop` Profile 中不可用，反之亦然。

但实际上这两个 Profile 渲染的是同一套 Web UI 界面，用户自然会期待"装一次、两边都能用"。这个缺口目前只能手动弥补（比如分别跑两次 `ds plugin add`，或写外部脚本监听 manifest 文件变化来同步）。

## 为什么做这个改动

新增一个**默认关闭**的桌面配置项 `dsh-desktop.syncProfiles`（默认 **off**），在启动时把 `web` 与 `desktop` 两个 Profile 中"用户安装的插件 bundle"对齐：

- 计算两个 Profile 中第三方 bundle 的**并集**；
- 改写各自 Profile 的 manifest，把缺失的 bundle 补上；
- 对于"已在另一个 Profile 装过"的 bundle，尽力执行安装（借助"已在别处安装"的闸门，保证启动期**不联网**——`ds plugin add` 从本地 store 解析，而非走网络）。

## 是否合适（坦诚评估）

这是一个合理的**可选便利项**，但它确实触及了核心心智模型（Profile 是互相独立的运行时），所以给维护者几点提醒：

- **可选且只增不减。** 开关关闭时，行为与现状完全一致；开启后，同步只会把缺失的 bundle *补齐到并集*，绝不会删除任何内容，也绝不触碰框架/桌面壳 bundle。
- **安全边界已守住。** 框架 bundle（`@deepseek-ai/dsh-base`、`@deepseek-ai/dsh-web-app`）与桌面壳自身（`dsh-plugin-desktop`）被**显式排除**，因此同步不会复制框架，也不会把被禁止的桌面壳 bundle 重新写回 `dsh.profile.bundles`。
- **兼容风险由用户自负。** 并非每个插件在两边行为都一致。该开关被标注为 best-effort；开启即意味着用户已确认其共享插件在两侧都能正常加载。
- **给维护者的开放问题：** 因为这改变了 Profile 隔离的语义，你们可能希望先以 RFC / issue 形式讨论再合并。实现刻意做得**窄而聚焦**，且完全挂在现有的 settings-file 机制之后，便于在不引入额外改动的情况下被拒绝或调整。

## 改了什么

- `dsh-plugin-desktop/src/profile-sync.ts`（新增）：并集计算、manifest 对齐、best-effort 安装。
- `dsh-plugin-desktop/src/profile.ts`：通过现有的 settings-file 读取器读出 `dsh-desktop.syncProfiles`；并在 `prepareDesktopProfile` 中暴露。
- `dsh-plugin-desktop/src/pnpm.ts`：`runPlugin` 接受可选的 `profileName`，使同步能安装到**非当前** Profile。
- `dsh-plugin-desktop/src/main.ts`：开关开启时，在启动期触发同步（可取消、错误不致命）。
- `dsh-plugin-desktop/src/profile-manager.ts`：导出 `WEB_PROFILE_NAME` / `DEFAULT_PROFILE_NAME`。
- `dsh-plugin-desktop/tests/profile-sync.spec.ts`（新增）：7 个单元测试。
- `docs/plugin-ecosystem.md`：补充了一节说明该可选能力。

## 测试

- `yarn workspace dsh-plugin-desktop typecheck` 通过。
- `yarn workspace dsh-plugin-desktop test`（profile / pnpm / profile-manager / profiles / profile-sync 套件）通过——7 个新测试，29 个既有测试不受影响。
- `yarn workspace dsh-plugin-desktop build` 成功。

## 说明

本 PR 目前**尚未提供 Settings 界面开关**，该标志需直接编辑桌面设置文件生效。若维护者认可，后续可再在设置界面中暴露此选项。