### PR TITLE
feat(desktop): import community plugins from the web profile

### DIFF
--- a/docs/user-guide.en.md
+++ b/docs/user-guide.en.md
@@ -12,7 +12,7 @@ A profile is a composition of DSH bundles, dependencies, and patches. The tray *
 
 Selecting a profile performs an orderly restart. The new profile becomes the last-known-good choice only after the Host, window, and browser client all start successfully; a failed startup returns to the previous working choice. Official profiles normally use the same DSH home, so sessions, settings, and storage do not need to be migrated. A custom configuration (patch) can deliberately redirect a persistence root, in which case that profile's configuration wins.
 
-Switching profiles does not silently copy plugins from the old profile into the new one. Use an explicit profile in the terminal when preparing another profile, or use the default commands after switching.
+Switching profiles does not silently copy plugins from the old profile into the new one. Use an explicit profile in the terminal when preparing another profile, or use the default commands after switching. When the `desktop` profile is created for the first time and an existing `web` profile has community plugins, DSH Desktop asks whether to import them in one step; the **Import Web Profile Plugins…** tray command imports them into the active profile at any time.
 
 ## Compatibility and advanced modes
 
@@ -42,6 +42,10 @@ dsh plugin update
 ```
 
 An explicit `--profile <name>` always wins. Restart DSH Desktop after plugin changes so the new bundle enters the Loader composition.
+
+### Importing plugins from the web profile
+
+Community plugins installed in the official web client (`web` profile) do not appear in other profiles automatically. When the `desktop` profile is created for the first time and a `web` profile with community plugins exists, DSH Desktop asks whether to import them in one step; the **Import Web Profile Plugins…** tray command imports them into the active profile at any time. Imports go through the official `dsh plugin add` flow, and Desktop-owned bundles or already-present plugins are skipped. When every plugin imports successfully the application restarts automatically to apply them; when some fail, the notification lists the failed plugins and you can import again after a restart.
 
 ## Opening the terminal
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -12,7 +12,7 @@ Profile 是一组 DSH bundle、依赖和 patch 的组合。托盘中的 **Profil
 
 选择 profile 后应用会有序重启。新 profile 在 Host、窗口和浏览器客户端都成功启动后才会被记录为最近一次可用 profile；启动失败会回到上一次可用选择。官方 profile 默认使用同一个 DSH home，所以 sessions、settings 和 storage 通常不需要迁移。自定义配置（patch）如果主动改写持久化路径，则以该 profile 自己的设置为准。
 
-切换 profile 不会把旧 profile 的插件偷偷复制到新 profile。要管理目标 profile，请在终端中显式写出 profile，或者在切换后使用终端里的默认命令。
+切换 profile 不会把旧 profile 的插件偷偷复制到新 profile。要管理目标 profile，请在终端中显式写出 profile，或者在切换后使用终端里的默认命令。首次创建 `desktop` profile 时，如果本机已有的 `web` profile 装有社区插件，应用会询问是否一键导入；之后也可以随时用托盘的 **Import Web Profile Plugins…** 命令把 `web` profile 的社区插件导入当前 profile。
 
 ## 兼容模式与高级模式
 
@@ -42,6 +42,10 @@ dsh plugin update
 ```
 
 显式 `--profile <name>` 始终优先。插件变更后需要重启 DSH Desktop，才能让新的 bundle 进入 Loader 组合。
+
+### 从 web profile 导入插件
+
+在官方网页端（`web` profile）安装过的社区插件不会自动出现在其它 profile。首次创建 `desktop` profile 时，如果检测到 `web` profile 装有社区插件，应用会询问是否一键导入；托盘的 **Import Web Profile Plugins…** 命令可以随时把 `web` profile 的社区插件导入当前 profile。导入走官方 `dsh plugin add` 流程，Desktop 自带的 bundle 和已存在的插件会被跳过；全部成功时应用会自动重启以应用新的 bundle，部分失败时会列出失败的插件，重启后再次导入即可。
 
 ## 打开终端
 

--- a/dsh-plugin-desktop/cordis.patch.yml
+++ b/dsh-plugin-desktop/cordis.patch.yml
@@ -12,6 +12,8 @@
       name: dsh-plugin-desktop/pnpm
     - id: desktop-profiles
       name: dsh-plugin-desktop/profiles
+    - id: desktop-plugin-import
+      name: dsh-plugin-desktop/plugin-import
     - id: desktop-updates
       name: dsh-plugin-desktop/updates
 

--- a/dsh-plugin-desktop/docs/plugin-services.md
+++ b/dsh-plugin-desktop/docs/plugin-services.md
@@ -135,6 +135,10 @@ Invalid argv, an invalid `invokingDir`, a closed or busy generation, and a signa
 
 The fact that a private type is present in emitted declarations does not make its runtime service a supported third-party capability. The two public service names and their contract modules are the compatibility boundary.
 
+### Desktop-owned plugin import surface
+
+`dsh-plugin-desktop/plugin-import` registers the **Import Web Profile Plugins…** tray command for the active profile. It computes a one-shot import offer from the `web` profile's community bundles (skipping launcher-owned and already-present bundles), confirms through a native dialog, runs `desktopPnpm.runPlugin(['add', ...])` once per bundle, and restarts the application when every bundle imports successfully. Like the profile selector, this row is Desktop-owned: the `desktopRuntime.confirm()` native dialog and tray methods are not part of the third-party service contract.
+
 ## Injection patterns
 
 ### Desktop-only plugin: required injection

--- a/dsh-plugin-desktop/docs/plugin-services.zh.md
+++ b/dsh-plugin-desktop/docs/plugin-services.zh.md
@@ -135,6 +135,10 @@ Service 在每个 generation 同时最多启动一个 package operation；已有
 
 私有类型出现在生成的 declaration 中，并不代表其 runtime service 成为了受支持第三方 capability。两个公开 service 名称及其 contract module 才是兼容边界。
 
+### Desktop 自有的插件导入 surface
+
+`dsh-plugin-desktop/plugin-import` 为当前 profile 注册 **Import Web Profile Plugins…** 托盘命令。它会根据 `web` profile 的社区 bundle 计算一次性导入清单（跳过 Desktop 自带与已存在的 bundle），通过原生对话框确认，逐条调用 `desktopPnpm.runPlugin(['add', ...])`，全部成功时自动重启应用以应用新的 bundle。与 profile 选择器一样，这一 row 由 Desktop 持有：`desktopRuntime.confirm()` 原生对话框与托盘方法不属于第三方 service contract。
+
 ## Injection 模式
 
 ### 仅支持 Desktop 的插件：required injection

--- a/dsh-plugin-desktop/package.json
+++ b/dsh-plugin-desktop/package.json
@@ -51,6 +51,10 @@
       "types": "./lib/types/profiles.d.ts",
       "default": "./lib/profiles.js"
     },
+    "./plugin-import": {
+      "types": "./lib/types/plugin-import.d.ts",
+      "default": "./lib/plugin-import.js"
+    },
     "./updates": {
       "types": "./lib/types/updates.d.ts",
       "default": "./lib/updates.js"

--- a/dsh-plugin-desktop/src/electron-runtime.ts
+++ b/dsh-plugin-desktop/src/electron-runtime.ts
@@ -19,6 +19,7 @@ import { fileURLToPath } from 'node:url'
 import { desktopTerminalStateDirectory, openDesktopTerminal } from './desktop-terminal.ts'
 import { packagedDependencyPath } from './packaged-runtime-path.ts'
 import type {
+  DesktopConfirmRequest,
   DesktopNotification,
   DesktopPlatform,
   DesktopRuntime,
@@ -301,6 +302,24 @@ export class ElectronDesktopRuntime implements DesktopRuntime {
       body: notification.body,
     })
     nativeNotification.show()
+  }
+
+  /** Ask before applying a desktop-owned change to the active profile. */
+  async confirm(request: DesktopConfirmRequest): Promise<boolean> {
+    const options: Electron.MessageBoxOptions = {
+      type: 'question',
+      title: request.title,
+      message: request.message,
+      ...(request.detail === undefined ? {} : { detail: request.detail }),
+      buttons: [request.confirmLabel ?? 'Confirm', request.cancelLabel ?? 'Cancel'],
+      defaultId: 1,
+      cancelId: 1,
+      noLink: true,
+    }
+    const result = this.window === undefined
+      ? await dialog.showMessageBox(options)
+      : await dialog.showMessageBox(this.window, options)
+    return result.response === 0
   }
 
   /** Ask before making the fixed download endpoint's counted request. */

--- a/dsh-plugin-desktop/src/main.ts
+++ b/dsh-plugin-desktop/src/main.ts
@@ -2,12 +2,14 @@
 
 import { app } from 'electron'
 import type { Context } from '@deepseek-ai/cordis'
+import { existsSync } from 'node:fs'
 import { join } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import {
   boot,
   installFailLoud,
   loadLayeredEnv,
+  resolveProfileDir,
   type FailLoudProcess,
 } from '@deepseek-ai/dsh-app-boot'
 import { provideCmdline } from '@deepseek-ai/dsh-cmdline'
@@ -26,7 +28,13 @@ import {
   type DesktopProfileStartup,
 } from './profile-manager.ts'
 import { DesktopProfileService } from './profile-service.ts'
-import { prepareDesktopProfile, type SkippedOptionalEntry } from './profile.ts'
+import { DESKTOP_PROFILE_NAME, prepareDesktopProfile, type SkippedOptionalEntry } from './profile.ts'
+import {
+  desktopOwnedBundles,
+  desktopProfileJustCreated,
+  pluginImportPlanForProfiles,
+} from './profile-plugin-import.ts'
+import { runPluginImportFlow } from './plugin-import.ts'
 import type { DesktopPnpmBootstrap } from './pnpm.ts'
 import {
   createDesktopExitCoordinator,
@@ -97,6 +105,27 @@ function notifyWindowsVolumeConcerns(
       `${BIN_NAME}: failed to show Windows volume warning: ${cause instanceof Error ? cause.message : String(cause)}\n`,
     )
   }
+}
+
+/** Offer a one-shot import of web-profile community plugins when the desktop profile is first created. */
+function offerFirstRunPluginImport(
+  ctx: Context,
+  homeDir: string,
+  activeProfileName: string,
+  hadDesktopProfile: boolean,
+): void {
+  if (!desktopProfileJustCreated(hadDesktopProfile, activeProfileName)) return
+  const plan = pluginImportPlanForProfiles(
+    listDesktopProfiles(homeDir),
+    DESKTOP_PROFILE_NAME,
+    desktopOwnedBundles(),
+  )
+  if (plan === undefined) return
+  void runPluginImportFlow(ctx, plan).catch((cause: unknown) => {
+    process.stderr.write(
+      `${BIN_NAME}: failed to run first-run plugin import: ${cause instanceof Error ? cause.message : String(cause)}\n`,
+    )
+  })
 }
 
 /** Start one Electron process and leave lifetime to the mounted desktop plugin. */
@@ -202,6 +231,7 @@ async function start(): Promise<void> {
     profileStatePath = selectionStatePath
     profileStartup = beginDesktopProfileStartup(selectionStatePath, homeDir)
     const activeProfileName = profileStartup.profileName
+    const hadDesktopProfile = existsSync(join(resolveProfileDir(DESKTOP_PROFILE_NAME, homeDir), 'package.json'))
     const prepared = prepareDesktopProfile(
       process.env.DSH_TELEMETRY_DISABLED,
       homeDir,
@@ -266,6 +296,7 @@ async function start(): Promise<void> {
     await runtime.mountScheduled()
     notifySkippedOptionalEntries(runtime, prepared.skippedOptionalEntries)
     notifyWindowsVolumeConcerns(runtime, windowsVolumeConcerns)
+    offerFirstRunPluginImport(ctx, homeDir, activeProfileName, hadDesktopProfile)
     if (profileStartup.rolledBackFrom !== undefined) {
       notifyProfileRecovery(
         runtime,

--- a/dsh-plugin-desktop/src/plugin-import.ts
+++ b/dsh-plugin-desktop/src/plugin-import.ts
@@ -1,0 +1,131 @@
+/** Desktop Host surface: one-click import of community plugins from the web profile. */
+
+import type { Context } from '@deepseek-ai/cordis'
+import type { PluginImportPlan } from './profile-plugin-import.ts'
+import { desktopOwnedBundles, pluginImportPlanForProfiles } from './profile-plugin-import.ts'
+import type {} from './profile-service.ts'
+import type {} from './pnpm.ts'
+import type {} from './runtime.ts'
+
+/** Stable Cordis plugin name. */
+export const name = 'desktop-plugin-import'
+
+/** Services required before the import surface can offer or run an import. */
+export const inject = ['desktopRuntime', 'desktopProfiles', 'desktopPnpm']
+
+/** Per-package outcome of one import run, in source manifest order. */
+export interface PluginImportOutcome {
+  /** Bundles installed successfully. */
+  readonly imported: readonly string[]
+  /** Bundles that failed to install. */
+  readonly failed: readonly string[]
+}
+
+/** Build the web-to-active-profile import offer, or `undefined` when nothing can be imported. */
+export function importPlanForActiveProfile(ctx: Context): PluginImportPlan | undefined {
+  return pluginImportPlanForProfiles(
+    ctx.desktopProfiles.list(),
+    ctx.desktopProfiles.current.name,
+    desktopOwnedBundles(),
+  )
+}
+
+/**
+ * Install every planned bundle through the authoritative DSH plugin CLI.
+ * @param ctx - Host context carrying the active-profile package manager.
+ * @param plan - validated import offer.
+ * @returns per-package success and failure lists.
+ */
+export async function executePluginImport(ctx: Context, plan: PluginImportPlan): Promise<PluginImportOutcome> {
+  const imported: string[] = []
+  const failed: string[] = []
+  for (const bundle of plan.toImport) {
+    try {
+      const handle = ctx.desktopPnpm.runPlugin(['add', bundle], ctx.desktopProfiles.current.dir)
+      handle.stdout.resume()
+      handle.stderr.resume()
+      const outcome = await handle.done
+      if (outcome.exitCode === 0) imported.push(bundle)
+      else failed.push(bundle)
+    } catch (cause) {
+      ctx.logger.warn(`dsh-plugin-desktop: failed to import ${bundle}`)
+      ctx.logger.warn(cause)
+      failed.push(bundle)
+    }
+  }
+  return { imported, failed }
+}
+
+/**
+ * Confirm, run, and report one import, restarting when every bundle was installed.
+ * @param ctx - Host context carrying the native runtime and profile services.
+ * @param plan - validated import offer.
+ */
+export async function runPluginImportFlow(ctx: Context, plan: PluginImportPlan): Promise<void> {
+  let confirmed: boolean
+  try {
+    confirmed = await ctx.desktopRuntime.confirm({
+      title: 'Import Community Plugins',
+      message: `Import ${plan.toImport.length} plugin(s) from the ${plan.source} profile into ${plan.target}?`,
+      detail: plan.toImport.join('\n'),
+      confirmLabel: 'Import',
+      cancelLabel: 'Cancel',
+    })
+  } catch (cause) {
+    ctx.logger.warn('dsh-plugin-desktop: failed to show plugin import confirmation')
+    ctx.logger.warn(cause)
+    return
+  }
+  if (!confirmed) return
+  let outcome: PluginImportOutcome
+  try {
+    outcome = await executePluginImport(ctx, plan)
+  } catch (cause) {
+    ctx.logger.error('dsh-plugin-desktop: failed to import web profile plugins')
+    ctx.logger.error(cause)
+    return
+  }
+  if (outcome.failed.length === 0) {
+    ctx.desktopRuntime.updates.notify({
+      title: 'Plugins Imported',
+      body: `Imported ${outcome.imported.length} plugin(s) into ${plan.target}. Restarting to apply.`,
+    })
+    try {
+      await ctx.desktopRuntime.requestRestart()
+    } catch (cause) {
+      ctx.logger.warn('dsh-plugin-desktop: failed to restart after plugin import')
+      ctx.logger.warn(cause)
+    }
+  } else {
+    ctx.desktopRuntime.updates.notify({
+      title: 'Plugin Import Incomplete',
+      body: `Imported ${outcome.imported.length}, failed ${outcome.failed.length}: ${outcome.failed.join(', ')}. Restart DSH Desktop to apply the imported plugins.`,
+    })
+  }
+}
+
+/**
+ * Register the native tray command for one active-profile generation.
+ * @param ctx - Host context carrying the desktop runtime and profile services.
+ */
+export function apply(ctx: Context): void {
+  ctx.effect(() => {
+    const registration = ctx.desktopRuntime.registerTrayItem({
+      group: 'profiles',
+      order: 20,
+      label: () => 'Import Web Profile Plugins…',
+      enabled: () => importPlanForActiveProfile(ctx) !== undefined,
+      invoke: async () => {
+        try {
+          const plan = importPlanForActiveProfile(ctx)
+          if (plan === undefined) return
+          await runPluginImportFlow(ctx, plan)
+        } catch (cause) {
+          ctx.logger.error('dsh-plugin-desktop: web profile plugin import tray command failed')
+          ctx.logger.error(cause)
+        }
+      },
+    })
+    return () => { registration.dispose() }
+  }, 'dsh-plugin-desktop: web profile plugin import tray command')
+}

--- a/dsh-plugin-desktop/src/profile-plugin-import.ts
+++ b/dsh-plugin-desktop/src/profile-plugin-import.ts
@@ -1,0 +1,89 @@
+/** Cross-profile plugin import planning for launcher-owned desktop surfaces. */
+
+import {
+  DESKTOP_PACKAGE_NAME,
+  DESKTOP_PROFILE_NAME,
+  desktopRequiredBundleNames,
+} from './profile.ts'
+import type { DesktopProfileSummary } from './profile-manager.ts'
+
+/** Official Web profile that carries the upstream default plugin set. */
+export const WEB_PROFILE_NAME = 'web'
+
+/** One ordered import offer computed from two profile manifests. */
+export interface PluginImportPlan {
+  /** Profile supplying the community bundles. */
+  readonly source: string
+  /** Profile receiving the community bundles. */
+  readonly target: string
+  /** Bundles to install, in source manifest order. */
+  readonly toImport: readonly string[]
+  /** Bundles already present in the target profile. */
+  readonly alreadyPresent: readonly string[]
+  /** Launcher-owned bundles skipped to preserve the desktop shell invariant. */
+  readonly skippedOwned: readonly string[]
+}
+
+/**
+ * Return the launcher-owned bundle set that must never be imported across profiles.
+ * @returns required Web bundles plus the desktop shell package.
+ */
+export function desktopOwnedBundles(): readonly string[] {
+  return [...desktopRequiredBundleNames(), DESKTOP_PACKAGE_NAME]
+}
+
+/**
+ * Compute an import plan without modifying either profile.
+ * @param source - profile whose community bundles are inspected.
+ * @param target - profile receiving the community bundles.
+ * @param ownedBundles - launcher-owned bundle names excluded from the offer.
+ * @returns ordered plan with every source bundle classified exactly once.
+ */
+export function computePluginImportPlan(
+  source: DesktopProfileSummary,
+  target: DesktopProfileSummary,
+  ownedBundles: readonly string[],
+): PluginImportPlan {
+  const owned = new Set(ownedBundles)
+  const targetBundles = new Set(target.bundles)
+  const toImport: string[] = []
+  const alreadyPresent: string[] = []
+  const skippedOwned: string[] = []
+  for (const bundle of source.bundles) {
+    if (owned.has(bundle)) skippedOwned.push(bundle)
+    else if (targetBundles.has(bundle)) alreadyPresent.push(bundle)
+    else toImport.push(bundle)
+  }
+  return { source: source.name, target: target.name, toImport, alreadyPresent, skippedOwned }
+}
+
+/**
+ * Build the web-to-target import offer for one target profile, if any.
+ * @param summaries - current profile discovery.
+ * @param targetName - profile that would receive the bundles.
+ * @param ownedBundles - launcher-owned bundle names excluded from the offer.
+ * @returns a non-empty offer, or `undefined` when nothing can be imported.
+ */
+export function pluginImportPlanForProfiles(
+  summaries: readonly DesktopProfileSummary[],
+  targetName: string,
+  ownedBundles: readonly string[],
+): PluginImportPlan | undefined {
+  const source = summaries.find(profile => profile.name === WEB_PROFILE_NAME
+    && profile.exists
+    && profile.problem === undefined)
+  const target = summaries.find(profile => profile.name === targetName && profile.problem === undefined)
+  if (source === undefined || target === undefined) return undefined
+  const plan = computePluginImportPlan(source, target, ownedBundles)
+  return plan.toImport.length === 0 ? undefined : plan
+}
+
+/**
+ * Return whether the desktop profile is being created for the first time.
+ * @param hadDesktopProfile - whether the desktop manifest existed before this launch.
+ * @param activeProfileName - profile selected for this generation.
+ * @returns true only when the desktop profile is fresh and active.
+ */
+export function desktopProfileJustCreated(hadDesktopProfile: boolean, activeProfileName: string): boolean {
+  return !hadDesktopProfile && activeProfileName === DESKTOP_PROFILE_NAME
+}

--- a/dsh-plugin-desktop/src/profile.ts
+++ b/dsh-plugin-desktop/src/profile.ts
@@ -42,6 +42,11 @@ export const DESKTOP_PROFILE_ROOT = 'cordis.yml'
 const BIN_NAME = DESKTOP_PACKAGE_NAME
 const REQUIRED_BUNDLES = requiredWebBundles()
 const REQUIRED_BUNDLE_SET = new Set(REQUIRED_BUNDLES)
+
+/** Expose the desktop-owned required bundle set for cross-profile import planning. */
+export function desktopRequiredBundleNames(): readonly string[] {
+  return [...REQUIRED_BUNDLES]
+}
 const INSTALL_ANCHOR = unpackedAsarPath(fileURLToPath(new URL('../package.json', import.meta.url)))
 const DESKTOP_PATCH_PATH = fileURLToPath(new URL('../cordis.patch.yml', import.meta.url))
 const DIRECTORY_PICKER_ROW_ID = 'directory-picker'

--- a/dsh-plugin-desktop/src/runtime.ts
+++ b/dsh-plugin-desktop/src/runtime.ts
@@ -82,6 +82,20 @@ export interface DesktopNotification {
   body: string
 }
 
+/** Native confirmation requested by a desktop-owned Host plugin. */
+export interface DesktopConfirmRequest {
+  /** Dialog heading. */
+  readonly title: string
+  /** Primary question presented as the message. */
+  readonly message: string
+  /** Optional supporting detail, for example the affected package list. */
+  readonly detail?: string
+  /** Label of the affirmative button. */
+  readonly confirmLabel?: string
+  /** Label of the dismiss button. */
+  readonly cancelLabel?: string
+}
+
 /** Electron capabilities used by the headless update plugin. */
 export interface DesktopUpdateAdapter {
   /** Whether the running executable came from an Electron package. */
@@ -169,6 +183,9 @@ export interface DesktopRuntime {
 
   /** Open a native terminal containing packaged DSH command shims. */
   openTerminal(): void
+
+  /** Ask the user to confirm one desktop-owned operation. */
+  confirm(request: DesktopConfirmRequest): Promise<boolean>
 
   /** Accept the terminal client Loader outcome for the mounted generation. */
   reportRendererBoot(report: RendererBootReport): void

--- a/dsh-plugin-desktop/tests/plugin-import.spec.ts
+++ b/dsh-plugin-desktop/tests/plugin-import.spec.ts
@@ -1,0 +1,213 @@
+import type { Context } from '@deepseek-ai/cordis'
+import { describe, expect, it, vi } from 'vitest'
+import type { DesktopRuntime, DesktopTrayItem } from '../src/runtime.ts'
+import type { DesktopProfiles } from '../src/profile-service.ts'
+import type { DesktopPnpm, DesktopPnpmHandle } from '../src/pnpm.ts'
+import type { DesktopProfileSummary } from '../src/profile-manager.ts'
+import { WEB_PROFILE_NAME } from '../src/profile-plugin-import.ts'
+import { apply, inject, name } from '../src/plugin-import.ts'
+
+function summary(
+  name: string,
+  bundles: readonly string[],
+  overrides: Partial<DesktopProfileSummary> = {},
+): DesktopProfileSummary {
+  return {
+    name,
+    dir: `/profiles/${name}`,
+    exists: true,
+    bundles,
+    webCapable: true,
+    ...overrides,
+  }
+}
+
+function handle(exitCode: number | null): DesktopPnpmHandle {
+  return {
+    stdout: { resume: vi.fn() },
+    stderr: { resume: vi.fn() },
+    done: Promise.resolve({ exitCode, signal: null }),
+    cancel: vi.fn(),
+  } as unknown as DesktopPnpmHandle
+}
+
+interface Harness {
+  trayItem?: DesktopTrayItem
+  events: string[]
+  runPlugin: ReturnType<typeof vi.fn>
+  confirm: ReturnType<typeof vi.fn>
+  notify: ReturnType<typeof vi.fn>
+  requestRestart: ReturnType<typeof vi.fn>
+  disposeRegistration: ReturnType<typeof vi.fn>
+  disposeEffect?: () => void
+}
+
+function makeContext(
+  profiles: DesktopProfiles,
+  handleFor: (args: readonly string[]) => DesktopPnpmHandle = () => handle(0),
+): { ctx: Context; harness: Harness } {
+  const harness: Harness = {
+    events: [],
+    runPlugin: vi.fn((args: readonly string[]) => handleFor(args)),
+    confirm: vi.fn(async () => true),
+    notify: vi.fn(),
+    requestRestart: vi.fn(async () => { harness.events.push('restart') }),
+    disposeRegistration: vi.fn(),
+  }
+  const runtime = {
+    registerTrayItem: (item: DesktopTrayItem) => {
+      harness.trayItem = item
+      return { refresh: () => {}, dispose: harness.disposeRegistration }
+    },
+    confirm: harness.confirm,
+    updates: { notify: harness.notify },
+    requestRestart: harness.requestRestart,
+  } as unknown as DesktopRuntime
+  const ctx = {
+    desktopRuntime: runtime,
+    desktopProfiles: profiles,
+    desktopPnpm: { runPlugin: harness.runPlugin } as unknown as DesktopPnpm,
+    logger: { warn: vi.fn(), error: vi.fn() },
+    effect: (register: () => (() => void)) => {
+      harness.disposeEffect = register()
+      return harness.disposeEffect
+    },
+  } as unknown as Context
+  return { ctx, harness }
+}
+
+const webProfiles = (bundles: readonly string[]): DesktopProfiles => ({
+  current: { name: 'desktop', dir: '/profiles/desktop' },
+  list: () => [
+    summary('desktop', ['@deepseek-ai/dsh-base']),
+    summary(WEB_PROFILE_NAME, ['@deepseek-ai/dsh-base', ...bundles]),
+  ],
+  select: async () => {},
+})
+
+describe('desktop plugin import Host plugin', () => {
+  it('registers a profiles tray command that offers web bundles not yet present', () => {
+    const { ctx, harness } = makeContext(webProfiles(['community-a', 'community-b']))
+    apply(ctx)
+
+    expect(name).toBe('desktop-plugin-import')
+    expect(inject).toEqual(['desktopRuntime', 'desktopProfiles', 'desktopPnpm'])
+    expect(harness.trayItem).toMatchObject({ group: 'profiles', order: 20 })
+    expect(harness.trayItem?.label()).toBe('Import Web Profile Plugins…')
+    expect(harness.trayItem?.enabled?.()).toBe(true)
+  })
+
+  it('disables the command when the web profile has nothing importable', () => {
+    const profiles: DesktopProfiles = {
+      current: { name: 'desktop', dir: '/profiles/desktop' },
+      list: () => [
+        summary('desktop', ['@deepseek-ai/dsh-base', 'community-a']),
+        summary(WEB_PROFILE_NAME, ['@deepseek-ai/dsh-base', 'community-a']),
+      ],
+      select: async () => {},
+    }
+    const { ctx, harness } = makeContext(profiles)
+    apply(ctx)
+    expect(harness.trayItem?.enabled?.()).toBe(false)
+  })
+
+  it('disables the command when the web profile is absent', () => {
+    const profiles: DesktopProfiles = {
+      current: { name: 'desktop', dir: '/profiles/desktop' },
+      list: () => [summary('desktop', ['@deepseek-ai/dsh-base'])],
+      select: async () => {},
+    }
+    const { ctx, harness } = makeContext(profiles)
+    apply(ctx)
+    expect(harness.trayItem?.enabled?.()).toBe(false)
+  })
+
+  it('confirms, imports each bundle in order, notifies, and restarts on full success', async () => {
+    const { ctx, harness } = makeContext(webProfiles(['community-a', 'community-b']))
+    apply(ctx)
+
+    await harness.trayItem?.invoke()
+
+    expect(harness.confirm).toHaveBeenCalledOnce()
+    expect(harness.confirm.mock.calls[0]?.[0]).toMatchObject({
+      title: 'Import Community Plugins',
+      confirmLabel: 'Import',
+    })
+    expect(harness.runPlugin.mock.calls.map(call => call[0])).toEqual([
+      ['add', 'community-a'],
+      ['add', 'community-b'],
+    ])
+    expect(harness.runPlugin.mock.calls.map(call => call[1])).toEqual(['/profiles/desktop', '/profiles/desktop'])
+    expect(harness.notify).toHaveBeenCalledWith(expect.objectContaining({ title: 'Plugins Imported' }))
+    expect(harness.events).toEqual(['restart'])
+  })
+
+  it('does nothing when the user declines the confirmation', async () => {
+    const { ctx, harness } = makeContext(webProfiles(['community-a']))
+    harness.confirm.mockResolvedValue(false)
+    apply(ctx)
+
+    await harness.trayItem?.invoke()
+
+    expect(harness.confirm).toHaveBeenCalledOnce()
+    expect(harness.runPlugin).not.toHaveBeenCalled()
+    expect(harness.notify).not.toHaveBeenCalled()
+    expect(harness.events).toEqual([])
+  })
+
+  it('does nothing when the command is invoked without an importable plan', async () => {
+    const profiles: DesktopProfiles = {
+      current: { name: 'desktop', dir: '/profiles/desktop' },
+      list: () => [summary('desktop', [])],
+      select: async () => {},
+    }
+    const { ctx, harness } = makeContext(profiles)
+    apply(ctx)
+
+    await harness.trayItem?.invoke()
+
+    expect(harness.confirm).not.toHaveBeenCalled()
+    expect(harness.runPlugin).not.toHaveBeenCalled()
+  })
+
+  it('reports partial failure without restarting', async () => {
+    const { ctx, harness } = makeContext(
+      webProfiles(['community-a', 'community-b']),
+      args => handle(args[1] === 'community-b' ? 1 : 0),
+    )
+    apply(ctx)
+
+    await harness.trayItem?.invoke()
+
+    expect(harness.runPlugin).toHaveBeenCalledTimes(2)
+    expect(harness.notify).toHaveBeenCalledWith(expect.objectContaining({
+      title: 'Plugin Import Incomplete',
+      body: expect.stringContaining('community-b'),
+    }))
+    expect(harness.events).toEqual([])
+  })
+
+  it('treats a throwing install as a failure without restarting', async () => {
+    const { ctx, harness } = makeContext(webProfiles(['community-a']), () => {
+      throw new Error('another operation is running')
+    })
+    apply(ctx)
+
+    await harness.trayItem?.invoke()
+
+    expect(harness.notify).toHaveBeenCalledWith(expect.objectContaining({
+      title: 'Plugin Import Incomplete',
+      body: expect.stringContaining('community-a'),
+    }))
+    expect(harness.events).toEqual([])
+  })
+
+  it('disposes the tray registration with the owning effect', () => {
+    const { ctx, harness } = makeContext(webProfiles([]))
+    apply(ctx)
+    expect(harness.disposeRegistration).not.toHaveBeenCalled()
+
+    harness.disposeEffect?.()
+    expect(harness.disposeRegistration).toHaveBeenCalledOnce()
+  })
+})

--- a/dsh-plugin-desktop/tests/plugin.spec.ts
+++ b/dsh-plugin-desktop/tests/plugin.spec.ts
@@ -72,6 +72,7 @@ function createHarness(platform: DesktopRuntime['platform'] = 'darwin'): PluginH
     show: () => {},
     registerTrayItem: () => ({ refresh: () => {}, dispose: () => {} }),
     openTerminal: () => {},
+    confirm: async () => false,
     reportRendererBoot: rendererBoot,
     setThemeSource,
     requestRestart: restart,

--- a/dsh-plugin-desktop/tests/profile-plugin-import.spec.ts
+++ b/dsh-plugin-desktop/tests/profile-plugin-import.spec.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from 'vitest'
+import { DESKTOP_PACKAGE_NAME } from '../src/profile.ts'
+import type { DesktopProfileSummary } from '../src/profile-manager.ts'
+import {
+  computePluginImportPlan,
+  desktopOwnedBundles,
+  desktopProfileJustCreated,
+  pluginImportPlanForProfiles,
+  WEB_PROFILE_NAME,
+} from '../src/profile-plugin-import.ts'
+
+function summary(
+  name: string,
+  bundles: readonly string[],
+  overrides: Partial<DesktopProfileSummary> = {},
+): DesktopProfileSummary {
+  return {
+    name,
+    dir: `/profiles/${name}`,
+    exists: true,
+    bundles,
+    webCapable: true,
+    ...overrides,
+  }
+}
+
+describe('web profile plugin import planning', () => {
+  it('classifies every source bundle exactly once and preserves source order', () => {
+    const plan = computePluginImportPlan(
+      summary(WEB_PROFILE_NAME, ['@deepseek-ai/dsh-base', 'community-a', DESKTOP_PACKAGE_NAME, 'community-b']),
+      summary('desktop', ['@deepseek-ai/dsh-base', 'community-a']),
+      desktopOwnedBundles(),
+    )
+    expect(plan).toEqual({
+      source: WEB_PROFILE_NAME,
+      target: 'desktop',
+      toImport: ['community-b'],
+      alreadyPresent: ['community-a'],
+      skippedOwned: ['@deepseek-ai/dsh-base', DESKTOP_PACKAGE_NAME],
+    })
+  })
+
+  it('never offers launcher-owned required bundles for import', () => {
+    const plan = computePluginImportPlan(
+      summary(WEB_PROFILE_NAME, ['@deepseek-ai/dsh-base', '@deepseek-ai/dsh-web-app']),
+      summary('desktop', []),
+      desktopOwnedBundles(),
+    )
+    expect(plan.toImport).toEqual([])
+    expect(plan.skippedOwned).toEqual(['@deepseek-ai/dsh-base', '@deepseek-ai/dsh-web-app'])
+  })
+
+  it('exposes the desktop-owned bundle set with the shell package last', () => {
+    const owned = desktopOwnedBundles()
+    expect(owned).toContain('@deepseek-ai/dsh-base')
+    expect(owned).toContain('@deepseek-ai/dsh-web-app')
+    expect(owned[owned.length - 1]).toBe(DESKTOP_PACKAGE_NAME)
+  })
+
+  it('returns the web-to-target offer with a non-empty import list', () => {
+    const plan = pluginImportPlanForProfiles(
+      [summary(WEB_PROFILE_NAME, ['community-a', 'community-b']), summary('desktop', [])],
+      'desktop',
+      desktopOwnedBundles(),
+    )
+    expect(plan?.source).toBe(WEB_PROFILE_NAME)
+    expect(plan?.target).toBe('desktop')
+    expect(plan?.toImport).toEqual(['community-a', 'community-b'])
+  })
+
+  it('returns undefined when the target already has every web bundle', () => {
+    expect(pluginImportPlanForProfiles(
+      [summary(WEB_PROFILE_NAME, ['community-a']), summary('desktop', ['community-a'])],
+      'desktop',
+      desktopOwnedBundles(),
+    )).toBeUndefined()
+  })
+
+  it('returns undefined when the web profile is missing or broken', () => {
+    expect(pluginImportPlanForProfiles(
+      [summary('desktop', [])],
+      'desktop',
+      desktopOwnedBundles(),
+    )).toBeUndefined()
+    expect(pluginImportPlanForProfiles(
+      [summary(WEB_PROFILE_NAME, ['community-a'], { problem: 'broken manifest' }), summary('desktop', [])],
+      'desktop',
+      desktopOwnedBundles(),
+    )).toBeUndefined()
+  })
+
+  it('returns undefined when the target profile is missing', () => {
+    expect(pluginImportPlanForProfiles(
+      [summary(WEB_PROFILE_NAME, ['community-a'])],
+      'desktop',
+      desktopOwnedBundles(),
+    )).toBeUndefined()
+  })
+
+  it('detects the one-shot first-creation window only for a fresh active desktop profile', () => {
+    expect(desktopProfileJustCreated(false, 'desktop')).toBe(true)
+    expect(desktopProfileJustCreated(true, 'desktop')).toBe(false)
+    expect(desktopProfileJustCreated(false, 'web')).toBe(false)
+  })
+})

--- a/dsh-plugin-desktop/tsdown.config.ts
+++ b/dsh-plugin-desktop/tsdown.config.ts
@@ -13,6 +13,7 @@ export default defineConfig([
       'profile-service': 'src/profile-service.ts',
       pnpm: 'src/pnpm.ts',
       profiles: 'src/profiles.ts',
+      'plugin-import': 'src/plugin-import.ts',
       runtime: 'src/runtime.ts',
       'electron-runtime': 'src/electron-runtime.ts',
       'desktop-runtime-environment': 'src/desktop-runtime-environment.ts',


### PR DESCRIPTION
## Summary

Implements [#93](https://github.com/anywhere-labs/deepseek-harness-desktop/issues/93): users who migrate from the official Web client to DSH Desktop no longer have to re-run \dsh plugin add\ for every community plugin.

Two entry points:

1. **First-run one-click import** — when the \desktop\ profile is created for the first time and an existing \web\ profile has community plugins, a native dialog asks whether to import them in one step.
2. **Tray command** — \Import Web Profile Plugins…\ imports the \web\ profile's community bundles into the active profile at any time, enabled only when something can be imported.

## How it works

- A pure plan computation (\profile-plugin-import.ts\) diffs the \web\ profile's \dsh.profile.bundles\ against the target profile, skipping launcher-owned bundles (required Web set + \dsh-plugin-desktop\) and already-present ones, preserving source order.
- Installs run through the supported \desktopPnpm.runPlugin(['add', …])\ path, keeping upstream \dsh plugin\ authoritative for dependency resolution and bundle reconciliation.
- On full success the application restarts automatically to apply the new bundles; on partial failure a notification lists the failed plugins.
- Adds a narrow \confirm()\ capability to the \DesktopRuntime\ adapter (Electron \dialog.showMessageBox\), used by both the first-run prompt and the tray command.

## Verification

- \yarn workspace dsh-plugin-desktop check\: build, typecheck, and all verify steps (\erify:closure\, \erify:cli\, \erify:loader\, \erify:profile\, \erify:licenses\) pass; root \yarn check:layout\ passes.
- Vitest: 17 new tests (plan logic + Host surface) pass; full suite passes except two pre-existing \desktop-runtime-environment\ symlink tests that require Windows symlink privilege (environment-only).
- No new runtime dependencies; \THIRD_PARTY_NOTICES.md\ unchanged.
- Documentation updated bilingually (user guide first-launch/plugin-management sections, plugin-services contract).