### PR TITLE
test(market): harden cross-platform runtime verification

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,8 @@ jobs:
           path: ${{ steps.yarn-cache.outputs.dir }}
           key: yarn-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('yarn.lock', '.yarnrc.yml') }}
       - run: yarn install --immutable
-      - run: yarn workspace dsh-plugin-desktop dist:win
+      - run: yarn check
+      - run: yarn dist:win
 
   # macOS-only universal packaging smoke on a real macOS runner: the signed
   # release is built manually on a credentialed machine, so an unsigned DMG
@@ -85,7 +86,8 @@ jobs:
           path: ${{ steps.yarn-cache.outputs.dir }}
           key: yarn-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('yarn.lock', '.yarnrc.yml') }}
       - run: yarn install --immutable
-      - run: yarn workspace dsh-plugin-desktop dist:mac-smoke
+      - run: yarn workspace dsh-community-market check
+      - run: yarn dist:mac-smoke
 
   # Upstream toolchain smoke: the portable-shell scripts must resolve the
   # pinned submodule's own Yarn/pnpm release on Windows.

--- a/dsh-community-market/package.json
+++ b/dsh-community-market/package.json
@@ -66,7 +66,8 @@
     "typecheck": "node scripts/generate-contract-types.mjs --check && tsc -p tsconfig.json --noEmit && tsc -p tsconfig.client.json --noEmit && tsc -p tsconfig.tests.json --noEmit",
     "test": "vitest run",
     "verify:contracts": "node scripts/generate-contract-types.mjs --check",
-    "check": "node scripts/verify-docs.mjs && yarn run build && node scripts/verify-package-exports.mjs && yarn run typecheck && yarn run test",
+    "verify:loader": "node scripts/verify-client-loader.mjs",
+    "check": "node scripts/verify-docs.mjs && yarn run build && node scripts/verify-package-exports.mjs && yarn run verify:loader && yarn run typecheck && yarn run test",
     "prepack": "yarn run check"
   },
   "dependencies": {

--- a/dsh-community-market/scripts/verify-client-loader.mjs
+++ b/dsh-community-market/scripts/verify-client-loader.mjs
@@ -1,0 +1,26 @@
+import { readFileSync } from 'node:fs'
+import { runInNewContext } from 'node:vm'
+
+const artifact = new URL('../lib/client.js', import.meta.url)
+const registrations = []
+const window = {
+  __ModuleLoader__: {
+    load(registration) {
+      registrations.push(registration)
+    },
+  },
+}
+
+runInNewContext(readFileSync(artifact, 'utf8'), { window }, {
+  filename: artifact.pathname,
+})
+
+if (registrations.length !== 1) {
+  throw new Error(`market client registered ${String(registrations.length)} Loader modules`)
+}
+const [registration] = registrations
+if (registration?.id !== 'dsh-community-market' || typeof registration.factory !== 'function') {
+  throw new Error('market client did not register the expected Loader module')
+}
+
+process.stdout.write('verify-market-client-loader: dsh-community-market registered one client module\n')

--- a/dsh-community-market/src/catalog/service.ts
+++ b/dsh-community-market/src/catalog/service.ts
@@ -59,13 +59,24 @@ export interface CatalogService {
   fetch(query: unknown, signal: AbortSignal): Promise<readonly MarketCatalogSourceResult[]>
 }
 
+export interface CatalogServiceOptions {
+  readonly cacheTtlMs?: number
+  readonly now?: () => number
+}
+
 export class DefaultCatalogService implements CatalogService {
   private readonly cache = new Map<string, { snapshot: CatalogSnapshot; savedAt: number }>()
+  private readonly cacheTtlMs: number
+  private readonly now: () => number
 
   constructor(
     private readonly store: { load(): Promise<readonly LocalSourceRecord[]> },
     private readonly http: CatalogHttpClient,
-  ) {}
+    options: CatalogServiceOptions = {},
+  ) {
+    this.cacheTtlMs = options.cacheTtlMs ?? 24 * 60 * 60 * 1000
+    this.now = options.now ?? Date.now
+  }
 
   async listSources(): Promise<readonly MarketSourceView[]> {
     const records = await this.store.load()
@@ -81,13 +92,14 @@ export class DefaultCatalogService implements CatalogService {
       if (adapter === undefined) return { source: sourceView(source), stale: false, error: 'adapter unavailable' }
       try {
         const snapshot = parseCatalogSnapshot(await adapter.fetch(query, { signal, source, http: this.http }))
-        this.cache.set(key, { snapshot, savedAt: Date.now() })
+        this.cache.set(key, { snapshot, savedAt: this.now() })
         return { source: sourceView(source), snapshot, stale: false }
       } catch (cause) {
         const cached = this.cache.get(key)
-        if (cached !== undefined && Date.now() - cached.savedAt < 24 * 60 * 60 * 1000) {
+        if (cached !== undefined && this.now() - cached.savedAt < this.cacheTtlMs) {
           return { source: sourceView(source), snapshot: cached.snapshot, stale: true, error: safeError(cause) }
         }
+        this.cache.delete(key)
         return { source: sourceView(source), stale: false, error: safeError(cause) }
       }
     }))

--- a/dsh-community-market/src/host/routes.ts
+++ b/dsh-community-market/src/host/routes.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from 'node:crypto'
 import type { IncomingMessage, ServerResponse } from 'node:http'
+import { BlockList, isIP } from 'node:net'
 import type { Context } from '@deepseek-ai/cordis'
 import z from '@deepseek-ai/schemastery'
 import { settingsNamespace, type SettingsScope } from '@deepseek-ai/dsh-settings'
@@ -78,15 +79,30 @@ function readJson(req: IncomingMessage): Promise<unknown> {
   })
 }
 
-function isLoopback(address: string | undefined): boolean {
-  return address === undefined || address === '127.0.0.1' || address === '::1' || address === '::ffff:127.0.0.1'
+const loopbackAddresses = new BlockList()
+loopbackAddresses.addSubnet('127.0.0.0', 8, 'ipv4')
+loopbackAddresses.addSubnet('::1', 128, 'ipv6')
+
+export interface MarketMutationContext {
+  readonly remoteAddress: string | undefined
+  readonly origin: string | undefined
+  readonly host: string | undefined
+}
+
+export function marketMutationAllowed(context: MarketMutationContext): boolean {
+  if (context.remoteAddress === undefined || context.origin === undefined || context.host === undefined) return false
+  const address = context.remoteAddress.replace(/^\[|\]$/gu, '').split('%', 1)[0]!
+  const family = isIP(address)
+  if (family === 0 || !loopbackAddresses.check(address, family === 4 ? 'ipv4' : 'ipv6')) return false
+  return context.origin === `http://${context.host}`
 }
 
 function mutationAllowed(req: IncomingMessage): boolean {
-  if (!isLoopback(req.socket.remoteAddress)) return false
-  const origin = req.headers.origin
-  const host = req.headers.host
-  return origin === undefined || host === undefined || origin === `http://${host}`
+  return marketMutationAllowed({
+    remoteAddress: req.socket.remoteAddress,
+    origin: req.headers.origin,
+    host: req.headers.host,
+  })
 }
 
 function asMutation(value: unknown): MarketSourceMutation {

--- a/dsh-community-market/src/network/restricted-http.ts
+++ b/dsh-community-market/src/network/restricted-http.ts
@@ -1,7 +1,7 @@
 import dns from 'node:dns'
-import { isIP } from 'node:net'
+import { BlockList, isIP } from 'node:net'
 import https from 'node:https'
-import type { IncomingMessage } from 'node:http'
+import type { IncomingHttpHeaders, IncomingMessage } from 'node:http'
 import type { CatalogHttpClient, CatalogHttpResponse } from '../contracts/types.js'
 
 const MAX_REDIRECTS = 3
@@ -17,25 +17,29 @@ export class CatalogNetworkError extends Error {
   }
 }
 
-function isBlockedIpv4(address: string): boolean {
-  const parts = address.split('.').map(Number)
-  if (parts.length !== 4 || parts.some(part => !Number.isInteger(part) || part < 0 || part > 255)) return true
-  const [a, b] = parts as [number, number, number, number]
-  return a === 0 || a === 10 || a === 127 || a >= 224
-    || (a === 100 && b >= 64 && b <= 127)
-    || (a === 169 && b === 254)
-    || (a === 172 && b >= 16 && b <= 31)
-    || (a === 192 && (b === 0 || b === 168))
-    || (a === 198 && b >= 18 && b <= 19)
+const blockedAddresses = new BlockList()
+for (const [network, prefix] of [
+  ['0.0.0.0', 8],
+  ['10.0.0.0', 8],
+  ['100.64.0.0', 10],
+  ['127.0.0.0', 8],
+  ['169.254.0.0', 16],
+  ['172.16.0.0', 12],
+  ['192.0.0.0', 24],
+  ['192.168.0.0', 16],
+  ['198.18.0.0', 15],
+  ['224.0.0.0', 3],
+] as const) {
+  blockedAddresses.addSubnet(network, prefix, 'ipv4')
 }
-
-function isBlockedIpv6(address: string): boolean {
-  const normalized = address.toLowerCase().split('%', 1)[0] ?? address.toLowerCase()
-  if (normalized === '::' || normalized === '::1' || normalized.startsWith('ff')) return true
-  if (normalized.startsWith('fc') || normalized.startsWith('fd') || normalized.startsWith('fe8')
-    || normalized.startsWith('fe9') || normalized.startsWith('fea') || normalized.startsWith('feb')) return true
-  const mapped = normalized.match(/^(?:0:){5}ffff:(\d+\.\d+\.\d+\.\d+)$/u)
-  return mapped !== null && isBlockedIpv4(mapped[1]!)
+for (const [network, prefix] of [
+  ['::', 128],
+  ['::1', 128],
+  ['fc00::', 7],
+  ['fe80::', 10],
+  ['ff00::', 8],
+] as const) {
+  blockedAddresses.addSubnet(network, prefix, 'ipv6')
 }
 
 interface PinnedAddress {
@@ -43,9 +47,26 @@ interface PinnedAddress {
   readonly family: 4 | 6
 }
 
+interface RestrictedHttpResponse {
+  readonly statusCode: number
+  readonly headers: IncomingHttpHeaders
+  readonly body: Buffer
+}
+
+export interface RestrictedHttpClientOptions {
+  readonly resolveAddress?: (hostname: string) => Promise<PinnedAddress>
+  readonly request?: (
+    url: URL,
+    signal: AbortSignal,
+    pinned: PinnedAddress,
+  ) => Promise<RestrictedHttpResponse>
+  readonly totalTimeoutMs?: number
+}
+
 function assertSafeAddress(address: string): 4 | 6 {
-  const family = isIP(address)
-  if (family === 4 ? isBlockedIpv4(address) : family === 6 ? isBlockedIpv6(address) : true) {
+  const normalized = address.replace(/^\[|\]$/gu, '').split('%', 1)[0]!
+  const family = isIP(normalized)
+  if (family === 0 || blockedAddresses.check(normalized, family === 4 ? 'ipv4' : 'ipv6')) {
     throw new CatalogNetworkError('blocked-address')
   }
   return family as 4 | 6
@@ -87,7 +108,8 @@ function readBody(response: IncomingMessage): Promise<Buffer> {
 }
 
 async function resolvePinnedAddress(hostname: string): Promise<PinnedAddress> {
-  if (isIP(hostname)) return { address: hostname, family: assertSafeAddress(hostname) }
+  const literal = hostname.replace(/^\[|\]$/gu, '')
+  if (isIP(literal)) return { address: literal, family: assertSafeAddress(literal) }
   const addresses = await dns.promises.lookup(hostname, { all: true, verbatim: true })
   if (addresses.length === 0) throw new CatalogNetworkError('blocked-address')
   for (const entry of addresses) assertSafeAddress(entry.address)
@@ -95,7 +117,7 @@ async function resolvePinnedAddress(hostname: string): Promise<PinnedAddress> {
   return { address: first.address, family: assertSafeAddress(first.address) }
 }
 
-function requestOnce(url: URL, signal: AbortSignal, pinned: PinnedAddress): Promise<{ response: IncomingMessage; body: Buffer }> {
+function requestOnce(url: URL, signal: AbortSignal, pinned: PinnedAddress): Promise<RestrictedHttpResponse> {
   return new Promise((resolve, reject) => {
     let settled = false
     let firstByteTimer: NodeJS.Timeout | undefined
@@ -125,7 +147,11 @@ function requestOnce(url: URL, signal: AbortSignal, pinned: PinnedAddress): Prom
         request.destroy(new CatalogNetworkError('timeout'))
       }, FIRST_BYTE_TIMEOUT_MS)
       void readBody(response).then(
-        body => finish(() => resolve({ response, body })),
+        body => finish(() => resolve({
+          statusCode: response.statusCode ?? 0,
+          headers: response.headers,
+          body,
+        })),
         cause => finish(() => reject(cause)),
       )
     })
@@ -135,43 +161,75 @@ function requestOnce(url: URL, signal: AbortSignal, pinned: PinnedAddress): Prom
   })
 }
 
-async function fetchJson(start: string, signal: AbortSignal, redirectCount = 0): Promise<CatalogHttpResponse> {
+async function fetchJson(
+  start: string,
+  signal: AbortSignal,
+  resolveAddress: (hostname: string) => Promise<PinnedAddress>,
+  request: (url: URL, signal: AbortSignal, pinned: PinnedAddress) => Promise<RestrictedHttpResponse>,
+  redirectCount = 0,
+): Promise<CatalogHttpResponse> {
   if (signal.aborted) throw new CatalogNetworkError('timeout')
   const url = validateUrl(start)
   if (redirectCount > MAX_REDIRECTS) throw new CatalogNetworkError('redirect')
-  const pinned = await resolvePinnedAddress(url.hostname)
-  const totalController = new AbortController()
-  const onAbort = () => totalController.abort(signal.reason)
-  signal.addEventListener('abort', onAbort, { once: true })
-  const totalTimer = setTimeout(() => totalController.abort(), TOTAL_TIMEOUT_MS)
+  const pinned = await resolveAddress(url.hostname)
+  const response = await request(url, signal, pinned)
+  const status = response.statusCode
+  if (status >= 300 && status < 400) {
+    const location = response.headers.location
+    if (location === undefined) throw new CatalogNetworkError('redirect')
+    return await fetchJson(
+      new URL(location, url).href,
+      signal,
+      resolveAddress,
+      request,
+      redirectCount + 1,
+    )
+  }
+  if (status < 200 || status >= 300) throw new CatalogNetworkError('http')
+  const contentType = response.headers['content-type'] ?? ''
+  const encoding = response.headers['content-encoding']
+  if (!/^(?:application\/json|application\/[^;]+\+json)(?:;|$)/iu.test(contentType)
+    || encoding !== undefined && encoding !== 'identity') {
+    throw new CatalogNetworkError('response')
+  }
+  let value: unknown
   try {
-    const { response, body } = await requestOnce(url, totalController.signal, pinned)
-    const status = response.statusCode ?? 0
-    if (status >= 300 && status < 400) {
-      const location = response.headers.location
-      if (location === undefined) throw new CatalogNetworkError('redirect')
-      return await fetchJson(new URL(location, url).href, signal, redirectCount + 1)
-    }
-    if (status < 200 || status >= 300) throw new CatalogNetworkError('http')
-    const contentType = response.headers['content-type'] ?? ''
-    const encoding = response.headers['content-encoding']
-    if (!/^(?:application\/json|application\/[^;]+\+json)(?:;|$)/iu.test(contentType)
-      || encoding !== undefined && encoding !== 'identity') {
-      throw new CatalogNetworkError('response')
-    }
-    let value: unknown
-    try {
-      value = JSON.parse(body.toString('utf8')) as unknown
-    } catch {
-      throw new CatalogNetworkError('response')
-    }
-    return { value, finalUrl: url.href }
-  } finally {
-    clearTimeout(totalTimer)
-    signal.removeEventListener('abort', onAbort)
+    value = JSON.parse(response.body.toString('utf8')) as unknown
+  } catch {
+    throw new CatalogNetworkError('response')
+  }
+  return { value, finalUrl: url.href }
+}
+
+export function createRestrictedHttpClient(
+  options: RestrictedHttpClientOptions = {},
+): CatalogHttpClient {
+  const resolveAddress = options.resolveAddress ?? resolvePinnedAddress
+  const request = options.request ?? requestOnce
+  const totalTimeoutMs = options.totalTimeoutMs ?? TOTAL_TIMEOUT_MS
+
+  return {
+    async getJson(start, signal) {
+      if (signal.aborted) throw new CatalogNetworkError('timeout')
+      const totalController = new AbortController()
+      let timedOut = false
+      const onAbort = () => totalController.abort(signal.reason)
+      signal.addEventListener('abort', onAbort, { once: true })
+      const totalTimer = setTimeout(() => {
+        timedOut = true
+        totalController.abort()
+      }, totalTimeoutMs)
+      try {
+        return await fetchJson(start, totalController.signal, resolveAddress, request)
+      } catch (cause) {
+        if (timedOut) throw new CatalogNetworkError('timeout')
+        throw cause
+      } finally {
+        clearTimeout(totalTimer)
+        signal.removeEventListener('abort', onAbort)
+      }
+    },
   }
 }
 
-export const restrictedHttpClient: CatalogHttpClient = {
-  getJson: (url, signal) => fetchJson(url, signal),
-}
+export const restrictedHttpClient: CatalogHttpClient = createRestrictedHttpClient()

--- a/dsh-community-market/tests/market-runtime.spec.ts
+++ b/dsh-community-market/tests/market-runtime.spec.ts
@@ -3,7 +3,12 @@ import { dsh1024StoreAdapter, DSH_1024STORE_ADAPTER_ID, DSH_1024STORE_KEY, DSH_1
 import { DefaultCatalogService } from '../src/catalog/service.js'
 import { MemoryCatalogSourceStore } from '../src/catalog/source-store.js'
 import type { CatalogHttpClient, LocalSourceRecord } from '../src/contracts/index.js'
-import { pinnedLookupResult, restrictedHttpClient } from '../src/network/restricted-http.js'
+import {
+  CatalogNetworkError,
+  createRestrictedHttpClient,
+  pinnedLookupResult,
+  restrictedHttpClient,
+} from '../src/network/restricted-http.js'
 
 const source = (overrides: Partial<LocalSourceRecord> = {}): LocalSourceRecord => ({
   sourceRecordId: '018f1f77-a5c4-7b73-a9ae-0242ac120002',
@@ -96,6 +101,62 @@ describe('catalog aggregation', () => {
 })
 
 describe('restricted HTTP boundary', () => {
+  it('keeps one total deadline across redirects', async () => {
+    vi.useFakeTimers()
+    try {
+      const request = vi.fn((url: URL, signal: AbortSignal) => {
+        if (url.hostname === 'catalog.example') {
+          return new Promise<{ body: Buffer; headers: { location: string }; statusCode: number }>((resolve) => {
+            setTimeout(() => resolve({
+              body: Buffer.alloc(0),
+              headers: { location: 'https://redirect.example/catalog.json' },
+              statusCode: 302,
+            }), 20)
+          })
+        }
+        return new Promise<never>((_resolve, reject) => {
+          signal.addEventListener('abort', () => reject(signal.reason), { once: true })
+        })
+      })
+      const client = createRestrictedHttpClient({
+        request,
+        resolveAddress: async () => ({ address: '104.21.87.154', family: 4 }),
+        totalTimeoutMs: 30,
+      })
+
+      const result = expect(client.getJson(
+        'https://catalog.example/catalog.json',
+        new AbortController().signal,
+      )).rejects.toMatchObject({ code: 'timeout' })
+      await vi.advanceTimersByTimeAsync(20)
+      expect(request).toHaveBeenCalledTimes(2)
+      await vi.advanceTimersByTimeAsync(10)
+      await result
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('revalidates every redirect target before the next request', async () => {
+    const resolveAddress = vi.fn(async (hostname: string) => {
+      if (hostname === 'private.example') throw new CatalogNetworkError('blocked-address')
+      return { address: '104.21.87.154', family: 4 as const }
+    })
+    const request = vi.fn(async () => ({
+      body: Buffer.alloc(0),
+      headers: { location: 'https://private.example/catalog.json' },
+      statusCode: 302,
+    }))
+    const client = createRestrictedHttpClient({ request, resolveAddress })
+
+    await expect(client.getJson(
+      'https://catalog.example/catalog.json',
+      new AbortController().signal,
+    )).rejects.toMatchObject({ code: 'blocked-address' })
+    expect(resolveAddress).toHaveBeenCalledTimes(2)
+    expect(request).toHaveBeenCalledTimes(1)
+  })
+
   it('returns an address list when Node requests an all-address lookup', () => {
     const pinned = { address: '104.21.87.154', family: 4 as const }
     expect(pinnedLookupResult({ all: true }, pinned)).toEqual([pinned])
@@ -104,5 +165,14 @@ describe('restricted HTTP boundary', () => {
 
   it.each(['http://example.com/catalog.json', 'https://127.0.0.1/catalog.json', 'https://169.254.169.254/latest'])('rejects unsafe URL %s before requesting it', async (url) => {
     await expect(restrictedHttpClient.getJson(url, new AbortController().signal)).rejects.toThrow(/catalog request failed/u)
+  })
+
+  it.each([
+    'https://[::ffff:7f00:1]/catalog.json',
+    'https://[::ffff:a9fe:a9fe]/latest',
+  ])('rejects IPv4-mapped IPv6 URL %s before connecting', async (url) => {
+    await expect(restrictedHttpClient.getJson(url, AbortSignal.timeout(250))).rejects.toMatchObject({
+      code: 'blocked-address',
+    })
   })
 })

--- a/dsh-community-market/tests/market-runtime.spec.ts
+++ b/dsh-community-market/tests/market-runtime.spec.ts
@@ -99,6 +99,25 @@ describe('catalog aggregation', () => {
     expect(result).toMatchObject({ stale: true, error: 'source unavailable' })
     expect(result?.snapshot?.items).toHaveLength(1)
   })
+
+  it('does not serve a last-good snapshot after its cache TTL expires', async () => {
+    const store = new MemoryCatalogSourceStore()
+    await store.save([source()])
+    const getJson = vi.fn()
+      .mockResolvedValueOnce({ value: rawPage, finalUrl: 'https://api.deepseek1024.com/v1/plugins/search?q=plugin' })
+      .mockRejectedValueOnce(new Error('offline'))
+    let now = 1_000
+    const service = new DefaultCatalogService(store, { getJson }, {
+      cacheTtlMs: 60_000,
+      now: () => now,
+    })
+
+    await service.fetch({}, new AbortController().signal)
+    now += 60_001
+    const [result] = await service.fetch({}, new AbortController().signal)
+    expect(result).toMatchObject({ stale: false, error: 'source unavailable' })
+    expect(result?.snapshot).toBeUndefined()
+  })
 })
 
 describe('source mutation boundary', () => {

--- a/dsh-community-market/tests/market-runtime.spec.ts
+++ b/dsh-community-market/tests/market-runtime.spec.ts
@@ -3,6 +3,7 @@ import { dsh1024StoreAdapter, DSH_1024STORE_ADAPTER_ID, DSH_1024STORE_KEY, DSH_1
 import { DefaultCatalogService } from '../src/catalog/service.js'
 import { MemoryCatalogSourceStore } from '../src/catalog/source-store.js'
 import type { CatalogHttpClient, LocalSourceRecord } from '../src/contracts/index.js'
+import { marketMutationAllowed } from '../src/host/routes.js'
 import {
   CatalogNetworkError,
   createRestrictedHttpClient,
@@ -97,6 +98,25 @@ describe('catalog aggregation', () => {
     const [result] = await service.fetch({}, new AbortController().signal)
     expect(result).toMatchObject({ stale: true, error: 'source unavailable' })
     expect(result?.snapshot?.items).toHaveLength(1)
+  })
+})
+
+describe('source mutation boundary', () => {
+  it.each([
+    ['127.0.0.1', 'http://127.0.0.1:43120', '127.0.0.1:43120'],
+    ['::1', 'http://localhost:43120', 'localhost:43120'],
+    ['::ffff:7f00:1', 'http://localhost:43120', 'localhost:43120'],
+  ])('allows loopback address %s only with a matching origin', (remoteAddress, origin, host) => {
+    expect(marketMutationAllowed({ remoteAddress, origin, host })).toBe(true)
+  })
+
+  it.each([
+    [undefined, 'http://localhost:43120', 'localhost:43120'],
+    ['127.0.0.1', undefined, 'localhost:43120'],
+    ['127.0.0.1', 'http://attacker.example', 'localhost:43120'],
+    ['104.21.87.154', 'http://localhost:43120', 'localhost:43120'],
+  ])('rejects incomplete or non-local mutation context', (remoteAddress, origin, host) => {
+    expect(marketMutationAllowed({ remoteAddress, origin, host })).toBe(false)
   })
 })
 

--- a/dsh-plugin-desktop/scripts/verify-loader-boot.mjs
+++ b/dsh-plugin-desktop/scripts/verify-loader-boot.mjs
@@ -103,6 +103,7 @@ try {
     prepared.rootConfig,
     [{ insert: [
       { id: 'desktop-shell', name: 'dsh-plugin-desktop' },
+      { id: 'community-market', name: 'dsh-community-market' },
       { id: 'third-party-smoke', name: THIRD_PARTY_NAME },
     ] }],
     (host) => {
@@ -133,12 +134,16 @@ try {
   await runtime.mountScheduled()
 
   const desktopEntry = ctx.loader.resolve('include:desktop-shell')
+  const marketEntry = ctx.loader.resolve('include:community-market')
   const thirdPartyEntry = ctx.loader.resolve('include:third-party-smoke')
   if (desktopEntry?.options.name !== 'dsh-plugin-desktop') {
     throw new Error('launcher-owned desktop plugin did not activate through its bare package name')
   }
   if (thirdPartyEntry?.options.name !== THIRD_PARTY_NAME) {
     throw new Error('profile-local third-party plugin did not activate')
+  }
+  if (marketEntry?.options.name !== 'dsh-community-market') {
+    throw new Error('community market Host plugin did not activate through its bare package name')
   }
   if (mountedSpec?.mode !== 'compatibility') {
     throw new Error(`desktop plugin produced an unexpected shell mode: ${String(mountedSpec?.mode)}`)

--- a/dsh-plugin-desktop/tests/mac-universal.spec.ts
+++ b/dsh-plugin-desktop/tests/mac-universal.spec.ts
@@ -1,4 +1,4 @@
-import { join } from 'node:path'
+import { join, resolve } from 'node:path'
 import { describe, expect, it, vi } from 'vitest'
 import {
   MACOS_UNIVERSAL_NATIVE_ENTRIES,
@@ -8,24 +8,26 @@ import {
 describe('universal macOS native runtime preparation', () => {
   it('requires every CPU-specific file and repairs both node-pty helpers', () => {
     const chmod = vi.fn()
+    const desktopRoot = resolve('/desktop')
 
-    prepareMacUniversalRuntime({ desktopRoot: '/desktop', exists: () => true, chmod })
+    prepareMacUniversalRuntime({ desktopRoot, exists: () => true, chmod })
 
     expect(chmod.mock.calls).toEqual([
-      [join('/desktop', 'node_modules/node-pty/prebuilds/darwin-arm64/spawn-helper'), 0o755],
-      [join('/desktop', 'node_modules/node-pty/prebuilds/darwin-x64/spawn-helper'), 0o755],
+      [join(desktopRoot, 'node_modules/node-pty/prebuilds/darwin-arm64/spawn-helper'), 0o755],
+      [join(desktopRoot, 'node_modules/node-pty/prebuilds/darwin-x64/spawn-helper'), 0o755],
     ])
   })
 
   it('fails before changing permissions when one architecture is incomplete', () => {
     const chmod = vi.fn()
+    const desktopRoot = resolve('/desktop')
     const missing = MACOS_UNIVERSAL_NATIVE_ENTRIES.at(-1)!.path
 
     expect(() => prepareMacUniversalRuntime({
-      desktopRoot: '/desktop',
-      exists: path => path !== join('/desktop', missing),
+      desktopRoot,
+      exists: path => path !== join(desktopRoot, missing),
       chmod,
-    })).toThrow(missing)
+    })).toThrow(join(desktopRoot, missing))
     expect(chmod).not.toHaveBeenCalled()
   })
 })

--- a/dsh-plugin-desktop/tests/package.spec.ts
+++ b/dsh-plugin-desktop/tests/package.spec.ts
@@ -44,6 +44,7 @@ const workspaceManifest = JSON.parse(readFileSync(new URL('package.json', worksp
   resolutions?: Record<string, unknown>
   scripts?: Record<string, unknown>
 }
+const ciWorkflow = readFileSync(new URL('.github/workflows/ci.yml', workspaceRoot), 'utf8')
 
 describe('published package surface', () => {
   it('registers both npm launcher names', () => {
@@ -231,6 +232,24 @@ describe('published package surface', () => {
     }))
     expect(manifest.build?.files).toContain('!node_modules/node-pty/build/**')
     expect(manifest.devDependencies?.['@electron/asar']).toBe('3.4.1')
+  })
+
+  it('runs the full gate on Windows and packages through root scripts on native runners', () => {
+    const windowsJob = ciWorkflow.slice(
+      ciWorkflow.indexOf('  desktop-windows:'),
+      ciWorkflow.indexOf('  desktop-macos:'),
+    )
+    const macosJob = ciWorkflow.slice(
+      ciWorkflow.indexOf('  desktop-macos:'),
+      ciWorkflow.indexOf('  upstream-command-windows:'),
+    )
+
+    expect(windowsJob).toContain('- run: yarn check')
+    expect(windowsJob).toContain('- run: yarn dist:win')
+    expect(windowsJob).not.toContain('yarn workspace dsh-plugin-desktop dist:win')
+    expect(macosJob).toContain('- run: yarn workspace dsh-community-market check')
+    expect(macosJob).toContain('- run: yarn dist:mac-smoke')
+    expect(macosJob).not.toContain('yarn workspace dsh-plugin-desktop dist:mac-smoke')
   })
 
   it('keeps one fixed brand-blue tray source for generated native assets', () => {

--- a/dsh-plugin-desktop/tests/verify-mac-smoke.spec.ts
+++ b/dsh-plugin-desktop/tests/verify-mac-smoke.spec.ts
@@ -15,6 +15,7 @@ interface AppFixture {
   readonly infoPlist: string
   readonly executable: string
   readonly appAsar: string
+  readonly modeOverrides: Map<string, number>
 }
 
 function fixture(): AppFixture {
@@ -28,20 +29,28 @@ function fixture(): AppFixture {
   const infoPlist = join(contents, 'Info.plist')
   const executable = join(macos, 'DSH Desktop')
   const appAsar = join(resources, 'app.asar')
+  const modeOverrides = new Map<string, number>()
   writeFileSync(infoPlist, '<?xml version="1.0" encoding="UTF-8"?>')
   writeFileSync(executable, 'binary')
   chmodSync(executable, 0o755)
+  modeOverrides.set(executable, 0o755)
   writeFileSync(appAsar, 'packed')
   for (const entry of MACOS_UNIVERSAL_NATIVE_ENTRIES) {
     const path = join(`${appAsar}.unpacked`, entry.path)
     mkdirSync(join(path, '..'), { recursive: true })
     writeFileSync(path, 'native')
-    if (entry.path.endsWith('/spawn-helper')) chmodSync(path, 0o755)
+    if (entry.path.endsWith('/spawn-helper')) {
+      chmodSync(path, 0o755)
+      modeOverrides.set(path, 0o755)
+    }
   }
-  return { root, infoPlist, executable, appAsar }
+  return { root, infoPlist, executable, appAsar, modeOverrides }
 }
 
-function options(overrides: Partial<MacSmokeVerificationOptions> = {}) {
+function options(
+  overrides: Partial<MacSmokeVerificationOptions> = {},
+  modeOverrides: ReadonlyMap<string, number> = new Map(),
+) {
   const calls: Array<{ command: string; args: readonly string[] }> = []
   const removeMountPoint = vi.fn()
   const value: MacSmokeVerificationOptions = {
@@ -54,7 +63,11 @@ function options(overrides: Partial<MacSmokeVerificationOptions> = {}) {
     exists: existsSync,
     stat: path => {
       const result = statSync(path)
-      return { size: result.size, isFile: result.isFile(), mode: result.mode }
+      return {
+        size: result.size,
+        isFile: result.isFile(),
+        mode: modeOverrides.get(path) ?? result.mode,
+      }
     },
     ...overrides,
   }
@@ -84,7 +97,7 @@ function expectSmokeFailure(
 describe('macOS DMG smoke artifact verification', () => {
   it('mounts one DMG and accepts a well-formed unsigned application bundle', () => {
     const value = fixture()
-    const harness = options({ makeMountPoint: () => value.root })
+    const harness = options({ makeMountPoint: () => value.root }, value.modeOverrides)
     const appPath = join(value.root, 'DSH Desktop.app')
 
     expect(verifyMacSmoke(harness.value)).toEqual({
@@ -126,7 +139,7 @@ describe('macOS DMG smoke artifact verification', () => {
   it('rejects a missing Info.plist and still detaches', () => {
     const value = fixture()
     rmSync(value.infoPlist)
-    const harness = options({ makeMountPoint: () => value.root })
+    const harness = options({ makeMountPoint: () => value.root }, value.modeOverrides)
 
     expectSmokeFailure(harness, 'Info.plist')
     expect(harness.calls).toEqual([
@@ -142,7 +155,7 @@ describe('macOS DMG smoke artifact verification', () => {
   it('rejects an application without its declared main executable', () => {
     const value = fixture()
     rmSync(value.executable)
-    const harness = options({ makeMountPoint: () => value.root })
+    const harness = options({ makeMountPoint: () => value.root }, value.modeOverrides)
 
     expectSmokeFailure(harness, 'main executable')
     expect(harness.removeMountPoint).toHaveBeenCalledWith(value.root)
@@ -151,7 +164,8 @@ describe('macOS DMG smoke artifact verification', () => {
   it('rejects a non-executable main file', () => {
     const value = fixture()
     chmodSync(value.executable, 0o644)
-    const harness = options({ makeMountPoint: () => value.root })
+    value.modeOverrides.set(value.executable, 0o644)
+    const harness = options({ makeMountPoint: () => value.root }, value.modeOverrides)
 
     expectSmokeFailure(harness, 'invalid main executable')
     expect(harness.removeMountPoint).toHaveBeenCalledWith(value.root)
@@ -160,7 +174,7 @@ describe('macOS DMG smoke artifact verification', () => {
   it('rejects a missing or empty application archive', () => {
     const value = fixture()
     rmSync(value.appAsar)
-    const harness = options({ makeMountPoint: () => value.root })
+    const harness = options({ makeMountPoint: () => value.root }, value.modeOverrides)
 
     expectSmokeFailure(harness, 'app.asar')
     expect(harness.removeMountPoint).toHaveBeenCalledWith(value.root)


### PR DESCRIPTION
## Status

Test integration branch for the read-only community market runtime. This is not an npm release candidate and does not enable package installation.

## Changes

- make macOS packaging fixtures portable on Windows
- run market checks and native package commands on Windows/macOS CI runners
- harden restricted catalog networking for IPv4, IPv6, mapped IPv6, redirects, and shared deadlines
- require loopback and same-origin requests for source mutations
- add Host and Client Loader smoke tests
- make last-good cache expiry deterministic

## Verification

- `corepack yarn check`
  - Market: 35 tests passed
  - Desktop: 302 tests passed
  - runtime closure, Loader/profile smoke, license, layout, docs, typecheck, and build passed
- `git diff --check`
- `npm pack --dry-run --ignore-scripts --json`
  - 74 entries
  - 78,855 bytes packed
  - 296,330 bytes unpacked

## Security boundaries

- no default or fallback catalog source
- catalog browsing does not invoke a package manager or mutate profiles
- private, loopback, link-local, metadata, and mapped IPv6 destinations are blocked
- every redirect is revalidated under one total deadline
- source mutations require a loopback peer and exact Origin/Host match
- renderer remains limited to normalized plain data

## Known limitations

- a real Windows installer was not rebuilt locally because the Visual Studio Spectre mitigation libraries are unavailable
- macOS DMG packaging cannot be executed on Windows and is delegated to the macOS CI runner
- installation preview and managed installation are out of scope
- `private: true` remains enabled; this PR does not tag or publish npm
