### PR TITLE
fix(desktop): add native edit context menu

### DIFF
--- a/dsh-plugin-desktop/package.json
+++ b/dsh-plugin-desktop/package.json
@@ -98,7 +98,7 @@
     "verify:licenses": "node scripts/verify-licenses.mjs",
     "verify:notices": "node scripts/verify-licenses.mjs --notices THIRD_PARTY_NOTICES.md",
     "check": "yarn run build && yarn run typecheck && yarn run test && yarn run verify:closure && yarn run verify:cli && yarn run verify:loader && yarn run verify:profile && yarn run verify:licenses",
-    "check:win-package": "yarn run build && yarn run typecheck && vitest run tests/package.spec.ts tests/package-win.spec.ts tests/update-checker.spec.ts tests/update-download.spec.ts tests/verify-win-installer.spec.ts tests/verify-packaged-runtime.spec.ts tests/windows-pwsh-sandbox.spec.ts tests/windows-volume-diagnostics.spec.ts tests/window-options.spec.ts && yarn run verify:closure",
+    "check:win-package": "yarn run build && yarn run typecheck && vitest run tests/electron-runtime.spec.ts tests/package.spec.ts tests/package-win.spec.ts tests/update-checker.spec.ts tests/update-download.spec.ts tests/verify-win-installer.spec.ts tests/verify-packaged-runtime.spec.ts tests/windows-pwsh-sandbox.spec.ts tests/windows-volume-diagnostics.spec.ts tests/window-options.spec.ts && yarn run verify:closure",
     "check:mac-package": "yarn run -T check",
     "start": "node lib/bin.js",
     "dev": "yarn run build && node lib/bin.js",

--- a/dsh-plugin-desktop/src/electron-runtime.ts
+++ b/dsh-plugin-desktop/src/electron-runtime.ts
@@ -527,10 +527,34 @@ export class ElectronDesktopRuntime implements DesktopRuntime {
       }
       if (targetOrigin !== origin) event.preventDefault()
     }
+    const showEditContextMenu = (_event: Electron.Event, params: Electron.ContextMenuParams): void => {
+      const template: Electron.MenuItemConstructorOptions[] = []
+      if (params.isEditable) {
+        template.push(
+          { role: 'cut', enabled: params.editFlags.canCut },
+          { role: 'copy', enabled: params.editFlags.canCopy },
+          { role: 'paste', enabled: params.editFlags.canPaste },
+          { type: 'separator' },
+          { role: 'selectAll', enabled: params.editFlags.canSelectAll },
+        )
+      } else if (params.editFlags.canCopy) {
+        template.push({ role: 'copy' })
+      }
+      if (template.length === 0) return
+
+      Menu.buildFromTemplate(template).popup({
+        window,
+        ...(params.frame === null ? {} : { frame: params.frame }),
+        x: params.x,
+        y: params.y,
+        sourceType: params.menuSourceType,
+      })
+    }
 
     app.on('activate', show)
     window.on('close', close)
     window.on('page-title-updated', preserveBlankTitle)
+    window.webContents.on('context-menu', showEditContextMenu)
     window.webContents.on('will-frame-navigate', navigate)
     window.webContents.on('will-redirect', navigate)
     window.webContents.setWindowOpenHandler(({ url }) => {
@@ -580,6 +604,7 @@ export class ElectronDesktopRuntime implements DesktopRuntime {
       app.off('activate', show)
       window.off('close', close)
       window.off('page-title-updated', preserveBlankTitle)
+      window.webContents.off('context-menu', showEditContextMenu)
       window.webContents.off('will-frame-navigate', navigate)
       window.webContents.off('will-redirect', navigate)
       mountedTray.off('click', show)

--- a/dsh-plugin-desktop/tests/electron-runtime.spec.ts
+++ b/dsh-plugin-desktop/tests/electron-runtime.spec.ts
@@ -48,6 +48,7 @@ const electron = vi.hoisted(() => {
   const browserWindowOn = vi.fn()
   const browserWindowOff = vi.fn()
   const loadURL = vi.fn(async (_url: string) => {})
+  const menuPopup = vi.fn()
   const menuTemplates: unknown[][] = []
   const notifications: Notification[] = []
   const dialog = {
@@ -151,9 +152,10 @@ const electron = vi.hoisted(() => {
     Menu: {
       buildFromTemplate: vi.fn((template: unknown[]) => {
         menuTemplates.push(template)
-        return {}
+        return { popup: menuPopup }
       }),
     },
+    menuPopup,
     menuTemplates,
     nativeImage: { createFromPath },
     nativeTheme,
@@ -345,6 +347,104 @@ describe('Electron compatibility runtime', () => {
       ]))
 
     await release()
+  })
+
+  it('shows native edit roles only for editable fields or copied selections', async () => {
+    vi.spyOn(process, 'platform', 'get').mockReturnValue('win32')
+    const { ElectronDesktopRuntime } = await import('../src/electron-runtime.ts')
+    const runtime = new ElectronDesktopRuntime(async () => {})
+    const release = runtime.schedule(spec)
+
+    await runtime.mountScheduled()
+
+    type ContextMenuListener = (event: unknown, params: {
+      frame: unknown | null
+      x: number
+      y: number
+      isEditable: boolean
+      menuSourceType: 'mouse' | 'keyboard'
+      editFlags: {
+        canCut: boolean
+        canCopy: boolean
+        canPaste: boolean
+        canSelectAll: boolean
+      }
+    }) => void
+    const webContents = electron.browserWindows[0]?.webContents
+    const contextMenu = webContents?.on.mock.calls
+      .find(([event]) => event === 'context-menu')?.[1] as ContextMenuListener | undefined
+    expect(contextMenu).toEqual(expect.any(Function))
+
+    const frame = {}
+    contextMenu?.({}, {
+      frame,
+      x: 24,
+      y: 32,
+      isEditable: true,
+      menuSourceType: 'mouse',
+      editFlags: {
+        canCut: false,
+        canCopy: true,
+        canPaste: true,
+        canSelectAll: true,
+      },
+    })
+    expect(electron.menuTemplates.at(-1)).toEqual([
+      { role: 'cut', enabled: false },
+      { role: 'copy', enabled: true },
+      { role: 'paste', enabled: true },
+      { type: 'separator' },
+      { role: 'selectAll', enabled: true },
+    ])
+    expect(electron.menuPopup).toHaveBeenLastCalledWith({
+      window: electron.browserWindows[0],
+      frame,
+      x: 24,
+      y: 32,
+      sourceType: 'mouse',
+    })
+
+    contextMenu?.({}, {
+      frame: null,
+      x: 40,
+      y: 48,
+      isEditable: false,
+      menuSourceType: 'keyboard',
+      editFlags: {
+        canCut: false,
+        canCopy: true,
+        canPaste: false,
+        canSelectAll: false,
+      },
+    })
+    expect(electron.menuTemplates.at(-1)).toEqual([{ role: 'copy' }])
+    expect(electron.menuPopup).toHaveBeenLastCalledWith({
+      window: electron.browserWindows[0],
+      x: 40,
+      y: 48,
+      sourceType: 'keyboard',
+    })
+
+    const templateCount = electron.menuTemplates.length
+    const popupCount = electron.menuPopup.mock.calls.length
+    contextMenu?.({}, {
+      frame: null,
+      x: 56,
+      y: 64,
+      isEditable: false,
+      menuSourceType: 'mouse',
+      editFlags: {
+        canCut: false,
+        canCopy: false,
+        canPaste: false,
+        canSelectAll: false,
+      },
+    })
+    expect(electron.menuTemplates).toHaveLength(templateCount)
+    expect(electron.menuPopup).toHaveBeenCalledTimes(popupCount)
+
+    await release()
+    expect(webContents?.off).toHaveBeenCalledWith('context-menu', contextMenu)
   })
 
   it('does not mount a registration disposed before Host boot settles', async () => {

--- a/dsh-plugin-desktop/tests/package.spec.ts
+++ b/dsh-plugin-desktop/tests/package.spec.ts
@@ -222,6 +222,7 @@ describe('published package surface', () => {
     expect(manifest.scripts?.['dist:win']).toBe('node scripts/package-win.ts')
     expect(manifest.scripts?.['check:win-package']).toContain('yarn run build')
     expect(manifest.scripts?.['check:win-package']).toContain('yarn run typecheck')
+    expect(manifest.scripts?.['check:win-package']).toContain('tests/electron-runtime.spec.ts')
     expect(manifest.scripts?.['check:win-package']).toContain('tests/package-win.spec.ts')
     expect(manifest.scripts?.['check:win-package']).toContain('tests/update-checker.spec.ts')
     expect(manifest.scripts?.['check:win-package']).toContain('tests/update-download.spec.ts')


### PR DESCRIPTION
## What changed

- add a generation-scoped Electron `context-menu` handler to the Desktop BrowserWindow
- expose native Cut, Copy, Paste, and Select All roles for editable fields
- expose only Copy for selected read-only text and keep unrelated page backgrounds silent
- clean up the listener with the window generation and include the runtime test in the Windows package gate

## Why

Electron does not provide a default web context menu. DSH Desktop removed the Windows application menu but did not replace the browser's edit context menu, so mouse users could not copy selected output or paste into the composer even though keyboard shortcuts worked.

The fix uses Electron's built-in edit roles and Chromium-provided `editFlags`. It does not add preload or IPC access, read clipboard contents, or change `sandbox`, `contextIsolation`, `nodeIntegration`, or `webSecurity`.

## Verification

- `corepack yarn workspace dsh-plugin-desktop check:win-package` (10 files, 139 tests passed; runtime closure verified across 197 first-party nodes)
- focused runtime and package specs (2 files, 39 tests passed)
- real Windows Electron smoke: an editable field showed Cut/Copy/Paste/Select All; selected read-only text showed Copy only

Fixes #12

Supersedes #17, which targets the retired `apps/desktop` architecture and no longer merges cleanly.
