### PR TITLE
test(desktop): stabilize cross-platform profile checks

### DIFF
--- a/dsh-plugin-desktop/tests/profile.spec.ts
+++ b/dsh-plugin-desktop/tests/profile.spec.ts
@@ -1,4 +1,4 @@
-import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { mkdirSync, mkdtempSync, readFileSync, realpathSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { dirname, join } from 'node:path'
 import { fileURLToPath, pathToFileURL } from 'node:url'
@@ -80,7 +80,7 @@ describe('desktop profile composition', () => {
     const moduleUrl = pathToFileURL(join(resources, 'app.asar', 'lib', 'profile.js')).href
     const resolvedRoot = shippedPresetRoot(moduleUrl)
 
-    expect(resolvedRoot).toBe(physicalPresetRoot)
+    expect(resolvedRoot).toBe(realpathSync(physicalPresetRoot))
     expect(readFileSync(join(
       resolvedRoot,
       'cordis',

--- a/dsh-plugin-desktop/tests/profile.spec.ts
+++ b/dsh-plugin-desktop/tests/profile.spec.ts
@@ -47,7 +47,9 @@ afterEach(() => {
   for (const home of homes.splice(0)) rmSync(home, { recursive: true, force: true })
 })
 
-describe('desktop profile composition', () => {
+describe('desktop profile composition', {
+  timeout: process.platform === 'win32' ? 10_000 : 5_000,
+}, () => {
   it('reads packaged Cordis skills from the physical unpacked preset root', () => {
     const home = temporaryHome()
     const resources = join(home, 'resources')


### PR DESCRIPTION
## Summary

- compare the packaged preset fixture against its canonical filesystem path so macOS `/var` and `/private/var` aliases do not produce a false failure
- allow the real-filesystem desktop profile integration suite up to 10 seconds on Windows runners while retaining the 5-second budget elsewhere

## Diagnosis

The macOS runner resolved the fixture through `/private/var` while the expected path retained the equivalent `/var` alias. The Windows runner completed the profile suite in 23.8 seconds under parallel CI load and one real profile composition crossed Vitest's default 5-second timeout; the same test repeatedly completes in about 1.0-1.2 seconds locally and has no assertion failure.

## Verification

- `corepack yarn vitest run tests/profile.spec.ts --reporter=verbose`
- `corepack yarn typecheck`
- `corepack yarn check`