### PR TITLE
feat(repo): add structured issue forms

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,152 @@
+name: Bug report / 问题反馈
+description: Report a reproducible problem with DSH Desktop / 反馈可复现的 DSH Desktop 问题
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for helping improve DSH Desktop. Every report is welcome. Reports with exact versions, reproduction steps, and error evidence are usually easier to reproduce and prioritize. You do not need to understand the code or provide a patch.
+
+        感谢你帮助改进 DSH Desktop。所有反馈都会被查看；版本、复现步骤、错误日志等信息越完整，通常越容易被优先复现和处理。你不需要懂代码，也不需要提供补丁。无法获取某项信息时，请填写“Unknown / 不知道”。
+
+        Please remove API keys, tokens, account details, and other sensitive data before attaching logs or screenshots.
+
+  - type: checkboxes
+    id: duplicate_check
+    attributes:
+      label: Existing reports / 提交前查重
+      description: Search open and closed issues before submitting / 请先搜索已打开和已关闭的 Issue
+      options:
+        - label: I searched existing issues and did not find the same problem / 我已搜索现有 Issue，没有发现相同问题
+          required: true
+
+  - type: dropdown
+    id: area
+    attributes:
+      label: Affected area / 涉及区域
+      options:
+        - Startup or installation / 启动或安装
+        - Updates / 更新
+        - Profiles or plugins / Profile 或插件
+        - Conversations, models, or tools / 会话、模型或工具
+        - Terminal / 终端
+        - Window, tray, or interface / 窗口、托盘或界面
+        - Other or unknown / 其他或不确定
+    validations:
+      required: true
+
+  - type: dropdown
+    id: operating_system
+    attributes:
+      label: Operating system / 操作系统
+      options:
+        - Windows 11 x64
+        - Windows 10 x64
+        - macOS Apple Silicon
+        - Other or unsupported / 其他或未支持平台
+    validations:
+      required: true
+
+  - type: dropdown
+    id: installation_method
+    attributes:
+      label: Installation method / 安装方式
+      options:
+        - Windows installer / Windows 安装包
+        - macOS DMG
+        - Built from source / 源码运行
+        - Other or unknown / 其他或不确定
+    validations:
+      required: true
+
+  - type: input
+    id: desktop_version
+    attributes:
+      label: DSH Desktop version / DSH Desktop 版本
+      description: Use the installed version when the app cannot start / 无法启动时填写已安装版本
+      placeholder: "For example: 2.0.1; or Unknown / 不知道"
+    validations:
+      required: true
+
+  - type: input
+    id: dsh_version
+    attributes:
+      label: DSH runtime version / DSH 运行时版本
+      description: If a separate CLI is installed, run `dsh --version` / 如另装了 CLI，可运行 `dsh --version`
+      placeholder: "For example: 0.1.0-rc.7; or Unknown / 不知道"
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual_behavior
+    attributes:
+      label: What happened? / 实际发生了什么？
+      description: Include the exact error text when possible / 尽量包含准确的错误文字
+      placeholder: Describe what you saw and when it happened / 描述现象及发生时机
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduction_steps
+    attributes:
+      label: Reproduction steps / 复现步骤
+      description: Start from a normal app launch or installation / 从正常启动或安装开始描述
+      placeholder: |
+        1. Open ... / 打开……
+        2. Click ... / 点击……
+        3. Observe ... / 看到……
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected_behavior
+    attributes:
+      label: Expected behavior / 预期结果
+      placeholder: What should have happened? / 正常情况下应该发生什么？
+    validations:
+      required: true
+
+  - type: dropdown
+    id: frequency
+    attributes:
+      label: Reproduction frequency / 复现频率
+      options:
+        - Every time / 每次都能复现
+        - Often / 经常出现
+        - Sometimes / 偶尔出现
+        - Once / 只出现过一次
+        - Unknown / 不确定
+    validations:
+      required: true
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs or error details / 日志或错误信息
+      description: Paste the relevant lines or attach a log file. This is especially useful for startup failures / 可粘贴错误附近内容或上传日志文件，启动失败时尤其有帮助
+      placeholder: Optional, but complete evidence usually speeds up diagnosis / 选填；完整证据通常能加快定位
+
+  - type: textarea
+    id: screenshots
+    attributes:
+      label: Screenshots or recordings / 截图或录屏
+      description: Useful for visible interface problems; not required for background errors / 界面问题建议提供，后台错误不强制
+
+  - type: input
+    id: last_working_version
+    attributes:
+      label: Last known working version / 最后正常版本
+      description: Leave blank if this never worked or you are unsure / 从未正常或不确定时可留空
+
+  - type: textarea
+    id: additional_context
+    attributes:
+      label: Additional context / 补充信息
+      description: Recent updates, installed plugins, profile name, workarounds, or anything else that may matter / 最近更新、已装插件、Profile、临时解决办法等
+
+  - type: checkboxes
+    id: privacy_check
+    attributes:
+      label: Sensitive information / 敏感信息
+      options:
+        - label: I removed API keys, tokens, account details, and other sensitive data from my attachments / 我已从附件中移除 API Key、Token、账号信息等敏感内容
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Questions and community help / 使用交流与求助
+    url: https://github.com/anywhere-labs/deepseek-harness-desktop/discussions
+    about: Ask usage questions or discuss ideas that are not yet ready for a tracked issue / 询问使用方法，或讨论尚未形成明确 Issue 的想法
+  - name: Troubleshooting guide / 故障排查指南
+    url: https://github.com/anywhere-labs/deepseek-harness-desktop/blob/master/docs/user-guide.md#排查
+    about: Check common startup, update, profile, and plugin problems before reporting / 提交前查看常见启动、更新、Profile 和插件问题

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,82 @@
+name: Feature request / 功能建议
+description: Suggest an improvement to DSH Desktop / 提议改进 DSH Desktop
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for sharing an idea. Clear use cases and expected outcomes help maintainers understand and prioritize a request.
+
+        感谢你的建议。请重点说明使用场景、当前困难和期望结果；信息越具体，越容易被理解和评估。不要求提供实现方案或代码。
+
+  - type: checkboxes
+    id: duplicate_check
+    attributes:
+      label: Existing requests / 提交前查重
+      description: Search open and closed issues and Discussions first / 请先搜索已打开、已关闭的 Issue 和 Discussions
+      options:
+        - label: I searched existing requests and did not find the same proposal / 我已搜索现有内容，没有发现相同建议
+          required: true
+
+  - type: dropdown
+    id: area
+    attributes:
+      label: Affected area / 涉及区域
+      options:
+        - Startup or installation / 启动或安装
+        - Updates / 更新
+        - Profiles or plugins / Profile 或插件
+        - Conversations, models, or tools / 会话、模型或工具
+        - Terminal / 终端
+        - Window, tray, or interface / 窗口、托盘或界面
+        - Documentation or community / 文档或社区
+        - Other or unknown / 其他或不确定
+    validations:
+      required: true
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem or use case / 问题或使用场景
+      description: Explain what is difficult today and who is affected / 说明当前哪里不方便、哪些用户会遇到
+      placeholder: When I try to ..., I have to ... / 当我想……时，目前必须……
+    validations:
+      required: true
+
+  - type: textarea
+    id: desired_outcome
+    attributes:
+      label: Desired outcome / 期望结果
+      description: Describe the user-visible result, not necessarily the implementation / 描述用户最终能做到什么，不必设计技术实现
+      placeholder: I would like DSH Desktop to ... / 希望 DSH Desktop 能够……
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Current alternatives / 当前替代方案
+      description: Workarounds or other tools you currently use / 当前使用的临时办法或其他工具
+
+  - type: dropdown
+    id: operating_system
+    attributes:
+      label: Relevant operating systems / 相关操作系统
+      options:
+        - All supported platforms / 所有已支持平台
+        - Windows only / 仅 Windows
+        - macOS only / 仅 macOS
+        - Unknown or not platform-specific / 不确定或与平台无关
+    validations:
+      required: true
+
+  - type: textarea
+    id: examples
+    attributes:
+      label: Examples or references / 示例或参考
+      description: Screenshots, recordings, links, or examples from other products are optional / 可选填截图、录屏、链接或其他产品中的例子
+
+  - type: textarea
+    id: additional_context
+    attributes:
+      label: Additional context / 补充信息


### PR DESCRIPTION
## Summary

- add a bilingual bug report form focused on reproducible user evidence
- add a feature request form focused on use cases and desired outcomes
- route general support to Discussions and disable blank issues
- keep bug classification maintainer-owned instead of applying the `bug` label before reproduction

## Reporting policy

Complete reports are explicitly encouraged because exact versions, reproduction steps, and error evidence make them easier to prioritize. Screenshots, code references, and patches remain optional so ordinary users and startup-crash reporters can still submit valid issues.

## Verification

- validated both forms against the public GitHub Issue Forms JSON Schema
- validated `config.yml` against the public GitHub Issue Config JSON Schema
- `git diff --check`
- `corepack yarn check:layout`