### PR TITLE
fix(desktop): ignore browser pages without desktop markers

### DIFF
--- a/dsh-plugin-desktop/src/client/environment.ts
+++ b/dsh-plugin-desktop/src/client/environment.ts
@@ -18,12 +18,13 @@ const PLATFORMS = new Set<DesktopClientPlatform>(['darwin', 'win32', 'linux'])
 /**
  * Validate the Electron-owned query marker before any desktop client effects run.
  * @param search - URL search string, including or omitting the leading question mark.
- * @returns the validated desktop renderer environment.
+ * @returns the validated desktop renderer environment, or undefined outside the desktop shell.
  */
-export function parseDesktopClientEnvironment(search: string): DesktopClientEnvironment {
+export function parseDesktopClientEnvironment(search: string): DesktopClientEnvironment | undefined {
   const params = new URLSearchParams(search)
   const mode = params.get('dsh-desktop-mode')
   const platform = params.get('dsh-desktop-platform')
+  if (mode === null && platform === null) return undefined
   if (!MODES.has(mode as DesktopClientMode)) {
     throw new Error(`dsh-plugin-desktop: invalid or missing dsh-desktop-mode ${JSON.stringify(mode)}`)
   }

--- a/dsh-plugin-desktop/src/client/index.ts
+++ b/dsh-plugin-desktop/src/client/index.ts
@@ -30,6 +30,7 @@ export const inject = [
 /** Register desktop-owned client surfaces for the current BrowserWindow mode. @param ctx - browser Cordis context. */
 export function apply(ctx: ClientContext): void {
   const environment = parseDesktopClientEnvironment(window.location.search)
+  if (!environment) return
   ctx.effect(
     () => startRendererBootReporter(ctx.loader),
     'dsh-plugin-desktop: renderer boot health report',

--- a/dsh-plugin-desktop/tests/client-environment.spec.ts
+++ b/dsh-plugin-desktop/tests/client-environment.spec.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from 'vitest'
 import type { ClientContext } from '@deepseek-ai/dsh-client-runtime/client'
+import { apply } from '../src/client/index.ts'
 import { provideDesktopLayout } from '../src/client/layout-service.ts'
 import { parseDesktopClientEnvironment } from '../src/client/environment.ts'
 import {
@@ -15,6 +16,20 @@ import {
 } from '../src/window-chrome.ts'
 
 describe('desktop client environment', () => {
+  it('does not activate desktop effects for an ordinary browser URL', () => {
+    vi.stubGlobal('window', { location: { search: '' } })
+    const effect = vi.fn()
+
+    try {
+      expect(parseDesktopClientEnvironment('')).toBeUndefined()
+      apply({ effect } as unknown as ClientContext)
+      expect(effect).not.toHaveBeenCalled()
+    }
+    finally {
+      vi.unstubAllGlobals()
+    }
+  })
+
   it('accepts the Electron-owned kebab query markers', () => {
     expect(parseDesktopClientEnvironment('?dsh-desktop-mode=advanced&dsh-desktop-platform=darwin'))
       .toEqual({ mode: 'advanced', platform: 'darwin' })
@@ -23,9 +38,9 @@ describe('desktop client environment', () => {
   })
 
   it.each([
-    ['', 'dsh-desktop-mode'],
     ['?dsh-desktop-mode=glass&dsh-desktop-platform=darwin', 'dsh-desktop-mode'],
     ['?dsh-desktop-mode=advanced', 'dsh-desktop-platform'],
+    ['?dsh-desktop-platform=darwin', 'dsh-desktop-mode'],
     ['?dsh-desktop-mode=advanced&dsh-desktop-platform=android', 'dsh-desktop-platform'],
   ])('fails loud for malformed marker %s', (search, field) => {
     expect(() => parseDesktopClientEnvironment(search)).toThrow(field)


### PR DESCRIPTION
## Summary

- treat URLs without either desktop query marker as ordinary browser pages
- skip desktop client effects for those pages
- keep partial and invalid desktop marker combinations fail-loud

Fixes #88
Fixes #234

## Verification

- `corepack yarn workspace dsh-plugin-desktop typecheck`
- `corepack yarn workspace dsh-plugin-desktop test` (45 files, 406 passed, 9 skipped)