### PR TITLE
feat: use Korean locale fork of deepseek-harness submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "deepseek-harness"]
 	path = deepseek-harness
-	url = https://github.com/deepseek-ai/deepseek-harness.git
+	url = https://github.com/kimyeongrae23/deepseek-harness.git


### PR DESCRIPTION
## Summary

Point the `deepseek-harness` submodule to a fork that includes complete Korean (`ko`) locale support.

## What this does

The upstream `deepseek-ai/deepseek-harness` repository currently only supports `zh` and `en` locales. This change repoints the submodule to `kimyeongrae23/deepseek-harness` on the `feat/korean-locale` branch, which adds Korean translations for all 25 client UI packages (~700 translation keys).

## Changes

- `.gitmodules`: submodule URL changed to `kimyeongrae23/deepseek-harness`
- `deepseek-harness` submodule: updated to commit `4c29cac` (`feat/korean-locale` branch)

## Affected UI packages (Korean translations added)

conversation, workspace, settings-models, agent-preset, commands, deliverables, goal, input-trigger, jobs, message-feedback, model-selection, plan, permission-presets, settings-general, settings-plugin-inventory, settings-plugins, sidebar, skill, subagent, theme, trajectory, user-questions, workflow-run, ui-cordis, session-log-export

## Note

Once the upstream `deepseek-ai/deepseek-harness` merges the Korean locale PR, this submodule URL can be reverted to the official repo.