### PR TITLE
feat(desktop): add headless diagnostics export

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -122,8 +122,8 @@ body:
     id: logs
     attributes:
       label: Logs or error details / 日志或错误信息
-      description: Paste the relevant lines or attach a log file. This is especially useful for startup failures / 可粘贴错误附近内容或上传日志文件，启动失败时尤其有帮助
-      placeholder: Optional, but complete evidence usually speeds up diagnosis / 选填；完整证据通常能加快定位
+      description: Attach the diagnostics ZIP from the tray. If the app cannot stay open, run the installed executable with `--export-diagnostics`. Review the archive before public upload / 请附上托盘导出的诊断 ZIP；如果应用持续闪退，请用 `--export-diagnostics` 运行安装后的程序。公开上传前请检查内容
+      placeholder: Paste relevant lines or attach diagnostics-*.zip; complete evidence usually speeds up diagnosis / 粘贴相关内容或附上 diagnostics-*.zip；完整证据通常能加快定位
 
   - type: textarea
     id: screenshots

--- a/docs/user-guide.en.md
+++ b/docs/user-guide.en.md
@@ -59,6 +59,15 @@ After confirmation, the app requests the fixed platform download URL. macOS open
 
 ## Troubleshooting
 
+- **The application reaches the tray**: right-click the tray icon and choose **Export Diagnostics…**. After the privacy confirmation, Desktop creates a `diagnostics-*.zip` archive and reveals it in the file manager.
+- **The application crashes repeatedly before the tray appears**: run the installed executable directly with the recovery option. The default Windows installation command is below; replace the path if you selected another installation directory.
+
+  ```powershell
+  & "$env:LOCALAPPDATA\Programs\DSH Desktop\DSH Desktop.exe" --export-diagnostics
+  ```
+
+  If the npm desktop launcher is installed, `dsh-desktop --export-diagnostics` provides the same archive. This command does not start Host, profiles, plugins, or a window. It prints the absolute diagnostics ZIP path when complete.
+- **Diagnostic archive contents**: recent application logs, local Crashpad `.dmp` files, the active-run marker, and `system-info.txt`. System information records Desktop, Electron, Node, platform, and architecture versions. Recognized credentials are masked in logs, but local paths, workspace IDs, session IDs, and crash-time memory fragments may remain. Review the archive before public upload and send sensitive dumps only through a trusted channel.
 - **The window disappeared**: check the system tray; closing the window is not quitting.
 - **A plugin is missing**: confirm the command targeted the intended profile and restart the application.
 - **A terminal command is missing**: open a fresh Desktop terminal from the tray; Desktop does not modify the global PATH.

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -59,6 +59,15 @@ dsh plugin update
 
 ## 排查
 
+- **应用能够进入托盘**：右键托盘图标，选择 **导出诊断信息…**。确认隐私提示后，Desktop 会生成 `diagnostics-*.zip` 并在文件管理器中显示它。
+- **应用持续闪退，无法进入托盘**：在 PowerShell 中直接运行安装后的程序并加上恢复参数。默认安装位置的命令如下；如果安装时修改过目录，请替换为实际的 EXE 路径。
+
+  ```powershell
+  & "$env:LOCALAPPDATA\Programs\DSH Desktop\DSH Desktop.exe" --export-diagnostics
+  ```
+
+  通过 npm 安装过桌面启动器时，也可以运行 `dsh-desktop --export-diagnostics`。这个命令不会启动 Host、profile、插件或窗口；完成后会在终端输出诊断 ZIP 的绝对路径。
+- **诊断包内容**：包含最近的应用日志、本地 Crashpad `.dmp`、当前运行标记和 `system-info.txt`。系统信息会记录 Desktop、Electron、Node、平台和架构版本。日志会对可识别的认证凭据脱敏，但本地路径、工作区 ID、会话 ID 和崩溃时的内存片段仍可能存在。公开上传前必须检查；不适合公开的 dump 应通过可信渠道提供。
 - **窗口消失了**：先检查系统托盘，关闭窗口不是退出。
 - **插件没有出现**：确认命令作用于目标 profile，并重启应用。
 - **终端命令找不到**：从托盘重新打开 Desktop 终端；系统 shell 的全局 PATH 不会被 Desktop 修改。

--- a/dsh-plugin-desktop/scripts/verify-packaged-runtime.ts
+++ b/dsh-plugin-desktop/scripts/verify-packaged-runtime.ts
@@ -132,6 +132,7 @@ export type PackageResolver = (specifier: string) => string
 export interface PackagedDiagnosticWorkerData {
   readonly logsDir: string
   readonly userDataDir: string
+  readonly appVersion: string
   readonly maxEvidenceBytes: number
   readonly crashDumpsDir: string
 }
@@ -209,7 +210,7 @@ export async function smokePackagedDiagnosticWorker(
   try {
     const output = await launch(
       join(unpackedRoot, 'lib', 'diagnostic-export-worker.js'),
-      { logsDir, userDataDir, maxEvidenceBytes: 1024, crashDumpsDir },
+      { logsDir, userDataDir, appVersion: 'packaged-smoke', maxEvidenceBytes: 1024, crashDumpsDir },
     )
     if (!existsSync(output)) {
       throw new Error(`dsh-plugin-desktop: packaged diagnostic worker produced no archive at ${output}`)

--- a/dsh-plugin-desktop/src/bin.ts
+++ b/dsh-plugin-desktop/src/bin.ts
@@ -2,11 +2,13 @@
 
 import { spawn } from 'node:child_process'
 import { readFileSync } from 'node:fs'
-import { resolve } from 'node:path'
+import { homedir } from 'node:os'
+import { posix, resolve, win32 } from 'node:path'
 import { fileURLToPath } from 'node:url'
+import { exportDesktopDiagnostics } from './diagnostic-export.ts'
 
 /** Parsed launcher action. */
-export type DesktopCliAction = 'help' | 'version' | 'launch'
+export type DesktopCliAction = 'export-diagnostics' | 'help' | 'version' | 'launch'
 
 /** Human-readable launcher help. */
 export const DESKTOP_CLI_HELP = `Usage: dsh-plugin-desktop [options]
@@ -14,8 +16,9 @@ export const DESKTOP_CLI_HELP = `Usage: dsh-plugin-desktop [options]
 Launch DSH Desktop with the selected Web-capable profile.
 
 Options:
-  -h, --help     display help
-  -V, --version  display version
+  --export-diagnostics  export logs and crash evidence without launching the app
+  -h, --help            display help
+  -V, --version         display version
 `
 
 /**
@@ -25,6 +28,7 @@ Options:
  */
 export function parseDesktopCli(argv: readonly string[]): DesktopCliAction {
   if (argv.length === 0) return 'launch'
+  if (argv.length === 1 && argv[0] === '--export-diagnostics') return 'export-diagnostics'
   if (argv.length === 1 && (argv[0] === '--help' || argv[0] === '-h')) return 'help'
   if (argv.length === 1 && (argv[0] === '--version' || argv[0] === '-V')) return 'version'
   throw new Error(`unknown arguments: ${argv.join(' ')}`)
@@ -35,6 +39,30 @@ function packageVersion(): string {
   const manifest = JSON.parse(readFileSync(new URL('../package.json', import.meta.url), 'utf8')) as { version?: unknown }
   if (typeof manifest.version !== 'string') throw new Error('package.json has no string version')
   return manifest.version
+}
+
+/** Resolve the Electron user-data location without importing Electron. */
+export function defaultDesktopUserDataDirectory(
+  platform: NodeJS.Platform = process.platform,
+  environment: NodeJS.ProcessEnv = process.env,
+  homeDirectory: string = homedir(),
+): string {
+  const path = platform === 'win32' ? win32 : posix
+  if (platform === 'win32') {
+    const appData = environment.APPDATA
+    if (appData === undefined || appData.length === 0) {
+      throw new Error('APPDATA is unavailable; cannot locate DSH Desktop diagnostics')
+    }
+    return path.join(appData, 'DSH Desktop')
+  }
+  if (platform === 'darwin') return path.join(homeDirectory, 'Library', 'Application Support', 'DSH Desktop')
+  const config = environment.XDG_CONFIG_HOME
+  return path.join(config === undefined || config.length === 0 ? path.join(homeDirectory, '.config') : config, 'DSH Desktop')
+}
+
+export interface DesktopCliOptions {
+  /** Override used by focused tests and recovery tooling with a non-default data root. */
+  readonly userDataDir?: string
 }
 
 /** Launch Electron and mirror its terminal exit status. */
@@ -73,7 +101,10 @@ async function launchElectron(): Promise<number> {
  * @param argv - arguments after the executable and script path.
  * @returns process exit code.
  */
-export async function runDesktopCli(argv: readonly string[]): Promise<number> {
+export async function runDesktopCli(
+  argv: readonly string[],
+  options: DesktopCliOptions = {},
+): Promise<number> {
   let action: DesktopCliAction
   try {
     action = parseDesktopCli(argv)
@@ -88,6 +119,14 @@ export async function runDesktopCli(argv: readonly string[]): Promise<number> {
   }
   if (action === 'version') {
     process.stdout.write(`${packageVersion()}\n`)
+    return 0
+  }
+  if (action === 'export-diagnostics') {
+    const path = await exportDesktopDiagnostics(
+      options.userDataDir ?? defaultDesktopUserDataDirectory(),
+      { appVersion: packageVersion() },
+    )
+    process.stdout.write(`${path}\n`)
     return 0
   }
   return launchElectron()

--- a/dsh-plugin-desktop/src/diagnostic-export-worker.ts
+++ b/dsh-plugin-desktop/src/diagnostic-export-worker.ts
@@ -26,8 +26,10 @@ const SKIPPABLE_FILE_ERRORS = new Set(['EACCES', 'EBUSY', 'ELOOP', 'ENOENT', 'EN
 interface DiagnosticExportWorkerData {
   readonly logsDir: string
   readonly userDataDir: string
+  readonly appVersion: string
   readonly maxEvidenceBytes: number
   readonly crashDumpsDir?: string
+  readonly runStatePath?: string
 }
 
 export type DiagnosticExportWorkerResult =
@@ -50,6 +52,16 @@ function skippableFileError(cause: unknown): boolean {
 function regularLogEntry(logsDir: string, name: string): LogEntry | undefined {
   if (!isDesktopLogFileName(name)) return undefined
   const path = join(logsDir, name)
+  try {
+    const stats = lstatSync(path)
+    return !stats.isSymbolicLink() && stats.isFile() ? { name, path, stats } : undefined
+  } catch (cause) {
+    if (skippableFileError(cause)) return undefined
+    throw cause
+  }
+}
+
+function regularEvidenceEntry(path: string, name: string): LogEntry | undefined {
   try {
     const stats = lstatSync(path)
     return !stats.isSymbolicLink() && stats.isFile() ? { name, path, stats } : undefined
@@ -147,24 +159,32 @@ async function createDiagnosticsArchive(data: DiagnosticExportWorkerData): Promi
     .sort((a, b) => b.stats.mtimeMs - a.stats.mtimeMs || b.name.localeCompare(a.name, 'en'))
   const crashCandidates = crashDumpEntries(data.crashDumpsDir)
     .sort((a, b) => b.stats.mtimeMs - a.stats.mtimeMs || b.name.localeCompare(a.name, 'en'))
+  const runStateCandidate = data.runStatePath === undefined
+    ? undefined
+    : regularEvidenceEntry(data.runStatePath, 'crash-evidence/active-run.json')
   const zip = new AdmZip()
   let includedBytes = 0
   let omittedFiles = 0
   let includedCrashDumps = 0
   let omittedCrashDumps = 0
-  for (const entry of [...crashCandidates, ...candidates]) {
+  let includedActiveRunMarker = false
+  let omittedActiveRunMarker = false
+  for (const entry of [...(runStateCandidate === undefined ? [] : [runStateCandidate]), ...crashCandidates, ...candidates]) {
     const content = readStableLog(entry, data.maxEvidenceBytes - includedBytes)
     if (content === undefined) {
       if (entry.name.startsWith('crash-dumps/')) omittedCrashDumps += 1
+      else if (entry.name === 'crash-evidence/active-run.json') omittedActiveRunMarker = true
       else omittedFiles += 1
       continue
     }
     zip.addFile(entry.name, content)
     includedBytes += content.byteLength
     if (entry.name.startsWith('crash-dumps/')) includedCrashDumps += 1
+    else if (entry.name === 'crash-evidence/active-run.json') includedActiveRunMarker = true
   }
   const info = [
     'app: dsh-plugin-desktop',
+    `desktop-version: ${data.appVersion}`,
     `platform: ${process.platform}`,
     `arch: ${process.arch}`,
     `node: ${process.version}`,
@@ -175,6 +195,8 @@ async function createDiagnosticsArchive(data: DiagnosticExportWorkerData): Promi
     `omitted-log-files: ${String(omittedFiles)}`,
     `included-crash-dumps: ${String(includedCrashDumps)}`,
     `omitted-crash-dumps: ${String(omittedCrashDumps)}`,
+    `included-active-run-marker: ${String(includedActiveRunMarker)}`,
+    `omitted-active-run-marker: ${String(omittedActiveRunMarker)}`,
     `evidence-byte-limit: ${String(data.maxEvidenceBytes)}`,
     'privacy: logs may contain local paths, workspace IDs, and session IDs; crash dumps may contain process memory',
   ].join('\n')

--- a/dsh-plugin-desktop/src/diagnostic-export.ts
+++ b/dsh-plugin-desktop/src/diagnostic-export.ts
@@ -1,5 +1,7 @@
 /** Bundle recent logs and system information without blocking Electron's main thread. */
 
+import { mkdirSync } from 'node:fs'
+import { join } from 'node:path'
 import { Worker } from 'node:worker_threads'
 import type { DiagnosticExportWorkerResult } from './diagnostic-export-worker.ts'
 
@@ -10,10 +12,21 @@ export const MAX_DIAGNOSTIC_EVIDENCE_BYTES = 50 * 1024 * 1024
 export const DIAGNOSTIC_EXPORT_TIMEOUT_MS = 60_000
 
 export interface DiagnosticExportOptions {
+  /** Installed Desktop package version recorded in system-info.txt. */
+  readonly appVersion: string
   /** Override used by focused tests; production logs and dumps share the 50 MB cap. */
   readonly maxEvidenceBytes?: number
   /** Electron Crashpad directory whose local minidumps should be included. */
   readonly crashDumpsDir?: string
+  /** Active-run marker used to identify a launch that did not shut down cleanly. */
+  readonly runStatePath?: string
+}
+
+export interface DesktopDiagnosticExportOptions {
+  readonly appVersion: string
+  /** Exact Electron Crashpad directory; defaults to the conventional user-data location. */
+  readonly crashDumpsDir?: string
+  readonly maxEvidenceBytes?: number
 }
 
 function workerEntryUrl(): URL {
@@ -64,17 +77,42 @@ export function waitForDiagnosticExportWorker(
 export function exportDiagnosticsZip(
   logsDir: string,
   userDataDir: string,
-  options: DiagnosticExportOptions = {},
+  options: DiagnosticExportOptions,
 ): Promise<string> {
   const maxEvidenceBytes = options.maxEvidenceBytes ?? MAX_DIAGNOSTIC_EVIDENCE_BYTES
   if (!Number.isSafeInteger(maxEvidenceBytes) || maxEvidenceBytes <= 0) {
     return Promise.reject(new Error('dsh-plugin-desktop: diagnostic evidence byte limit must be a positive integer'))
   }
+  if (options.appVersion.length === 0 || options.appVersion.length > 512 || /[\0\r\n]/u.test(options.appVersion)) {
+    return Promise.reject(new Error('dsh-plugin-desktop: diagnostic app version must be a single non-empty line'))
+  }
 
   const worker = new Worker(workerEntryUrl(), {
     name: 'dsh-diagnostic-export',
-    workerData: { logsDir, userDataDir, maxEvidenceBytes, crashDumpsDir: options.crashDumpsDir },
+    workerData: {
+      logsDir,
+      userDataDir,
+      appVersion: options.appVersion,
+      maxEvidenceBytes,
+      ...(options.crashDumpsDir === undefined ? {} : { crashDumpsDir: options.crashDumpsDir }),
+      ...(options.runStatePath === undefined ? {} : { runStatePath: options.runStatePath }),
+    },
     resourceLimits: { maxOldGenerationSizeMb: 256 },
   })
   return waitForDiagnosticExportWorker(worker)
+}
+
+/** Export diagnostics directly from Desktop user data without booting Host, profiles, or a window. */
+export function exportDesktopDiagnostics(
+  userDataDir: string,
+  options: DesktopDiagnosticExportOptions,
+): Promise<string> {
+  const logsDir = join(userDataDir, 'logs')
+  mkdirSync(logsDir, { recursive: true })
+  return exportDiagnosticsZip(logsDir, userDataDir, {
+    appVersion: options.appVersion,
+    crashDumpsDir: options.crashDumpsDir ?? join(userDataDir, 'Crashpad'),
+    runStatePath: join(userDataDir, 'crash-evidence', 'active-run.json'),
+    ...(options.maxEvidenceBytes === undefined ? {} : { maxEvidenceBytes: options.maxEvidenceBytes }),
+  })
 }

--- a/dsh-plugin-desktop/src/electron-runtime.ts
+++ b/dsh-plugin-desktop/src/electron-runtime.ts
@@ -33,7 +33,7 @@ import type {
 } from './runtime.ts'
 import type { RendererBootReport } from './renderer-boot-contract.ts'
 import { formatDesktopExitCode, type DesktopLogger } from './desktop-logger.ts'
-import { exportDiagnosticsZip } from './diagnostic-export.ts'
+import { exportDesktopDiagnostics } from './diagnostic-export.ts'
 import { prepareTrayIcon } from './tray-icons.ts'
 import {
   desktopDiagnosticsPrivacyCopy,
@@ -265,11 +265,10 @@ export class ElectronDesktopRuntime implements DesktopRuntime {
         noLink: true,
       })
       if (confirmation.response !== 0) return
-      const path = await exportDiagnosticsZip(
-        join(app.getPath('userData'), 'logs'),
-        app.getPath('userData'),
-        { crashDumpsDir: app.getPath('crashDumps') },
-      )
+      const path = await exportDesktopDiagnostics(app.getPath('userData'), {
+        appVersion: PRODUCT_VERSION,
+        crashDumpsDir: app.getPath('crashDumps'),
+      })
       shell.showItemInFolder(path)
     } catch (cause) {
       this.reportDiagnosticExportError(cause)

--- a/dsh-plugin-desktop/src/main.ts
+++ b/dsh-plugin-desktop/src/main.ts
@@ -29,6 +29,7 @@ import {
   startDesktopCrashReporting,
   type DesktopRun,
 } from './crash-evidence.ts'
+import { exportDesktopDiagnostics } from './diagnostic-export.ts'
 import { FileExporter } from './file-exporter.ts'
 import { DESKTOP_SETTINGS_NAMESPACE, type DesktopSettings } from './index.ts'
 import { LogFileSink } from './log-files.ts'
@@ -116,7 +117,6 @@ function notifyWindowsVolumeConcerns(
 
 /** Start one Electron process and leave lifetime to the mounted desktop plugin. */
 async function start(): Promise<void> {
-  app.setName(PRODUCT_NAME)
   if (!app.requestSingleInstanceLock()) {
     app.quit()
     return
@@ -413,4 +413,32 @@ async function start(): Promise<void> {
   }
 }
 
-void start()
+async function run(): Promise<void> {
+  app.setName(PRODUCT_NAME)
+  if (process.argv.includes('--export-diagnostics')) {
+    try {
+      await app.whenReady()
+      const path = await exportDesktopDiagnostics(app.getPath('userData'), {
+        appVersion: desktopProductVersion(),
+        crashDumpsDir: app.getPath('crashDumps'),
+      })
+      await new Promise<void>((resolve, reject) => {
+        process.stdout.write(`${path}\n`, error => {
+          if (error === undefined || error === null) resolve()
+          else reject(error)
+        })
+      })
+      app.exit(0)
+    } catch (cause) {
+      const message = `dsh-plugin-desktop: failed to export diagnostics: ${cause instanceof Error ? cause.stack ?? cause.message : String(cause)}\n`
+      await new Promise<void>(resolve => {
+        process.stderr.write(message, () => { resolve() })
+      })
+      app.exit(1)
+    }
+    return
+  }
+  await start()
+}
+
+void run()

--- a/dsh-plugin-desktop/tests/bin.spec.ts
+++ b/dsh-plugin-desktop/tests/bin.spec.ts
@@ -1,5 +1,14 @@
+import { existsSync, mkdtempSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
 import { describe, expect, it, vi } from 'vitest'
-import { DESKTOP_CLI_HELP, parseDesktopCli, runDesktopCli } from '../src/bin.ts'
+import AdmZip from 'adm-zip'
+import {
+  defaultDesktopUserDataDirectory,
+  DESKTOP_CLI_HELP,
+  parseDesktopCli,
+  runDesktopCli,
+} from '../src/bin.ts'
 
 vi.mock('electron', () => ({ default: undefined }))
 
@@ -13,6 +22,7 @@ describe('desktop npm launcher', () => {
     ['-h', 'help'],
     ['--version', 'version'],
     ['-V', 'version'],
+    ['--export-diagnostics', 'export-diagnostics'],
   ] as const)('parses %s', (argument, action) => {
     expect(parseDesktopCli([argument])).toBe(action)
   })
@@ -24,6 +34,27 @@ describe('desktop npm launcher', () => {
   it('names the installed product and selected profile behavior', () => {
     expect(DESKTOP_CLI_HELP).toContain('DSH Desktop')
     expect(DESKTOP_CLI_HELP).toContain('selected Web-capable profile')
+    expect(DESKTOP_CLI_HELP).toContain('--export-diagnostics')
+  })
+
+  it('resolves the packaged Desktop user-data directory without Electron', () => {
+    expect(defaultDesktopUserDataDirectory('win32', { APPDATA: 'C:\\Users\\Example\\AppData\\Roaming' }, 'ignored'))
+      .toBe('C:\\Users\\Example\\AppData\\Roaming\\DSH Desktop')
+    expect(defaultDesktopUserDataDirectory('darwin', {}, '/Users/example'))
+      .toBe('/Users/example/Library/Application Support/DSH Desktop')
+  })
+
+  it('exports diagnostics without launching Electron', async () => {
+    const userDataDir = mkdtempSync(join(tmpdir(), 'dsh-cli-diagnostics-'))
+    const write = vi.spyOn(process.stdout, 'write').mockImplementation(() => true)
+    try {
+      await expect(runDesktopCli(['--export-diagnostics'], { userDataDir })).resolves.toBe(0)
+      const output = String(write.mock.calls.at(-1)?.[0]).trim()
+      expect(existsSync(output)).toBe(true)
+      expect(new AdmZip(output).readAsText('system-info.txt')).toMatch(/desktop-version: \d/u)
+    } finally {
+      write.mockRestore()
+    }
   })
 
   it('reports a clear message when electron is missing', async () => {

--- a/dsh-plugin-desktop/tests/diagnostic-export.spec.ts
+++ b/dsh-plugin-desktop/tests/diagnostic-export.spec.ts
@@ -14,9 +14,12 @@ import { Worker } from 'node:worker_threads'
 import { describe, expect, it } from 'vitest'
 import AdmZip from 'adm-zip'
 import {
+  exportDesktopDiagnostics,
   exportDiagnosticsZip,
   waitForDiagnosticExportWorker,
 } from '../src/diagnostic-export.ts'
+
+const APP_VERSION = '2.0.1-test'
 
 describe('exportDiagnosticsZip', () => {
   it('terminates a diagnostic Worker that does not respond before its deadline', async () => {
@@ -35,7 +38,7 @@ describe('exportDiagnosticsZip', () => {
   it('produces a zip containing the log files and system info', async () => {
     const dir = mkdtempSync(join(tmpdir(), 'dsh-dx-'))
     writeFileSync(join(dir, 'dsh-2026-08-16.log'), 'hello\n')
-    const out = await exportDiagnosticsZip(dir, dir)
+    const out = await exportDiagnosticsZip(dir, dir, { appVersion: APP_VERSION })
     expect(existsSync(out)).toBe(true)
     expect(out.endsWith('.zip')).toBe(true)
 
@@ -45,6 +48,21 @@ describe('exportDiagnosticsZip', () => {
     expect(names).toContain('system-info.txt')
     expect(zip.readAsText('dsh-2026-08-16.log')).toBe('hello\n')
     expect(zip.readAsText('system-info.txt')).toContain('platform:')
+    expect(zip.readAsText('system-info.txt')).toContain(`desktop-version: ${APP_VERSION}`)
+  })
+
+  it('exports recovery evidence even when the application never created a log directory', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'dsh-dx-recovery-'))
+    const crashEvidence = join(root, 'crash-evidence')
+    mkdirSync(crashEvidence)
+    writeFileSync(join(crashEvidence, 'active-run.json'), '{"version":"2.0.1"}\n')
+
+    const out = await exportDesktopDiagnostics(root, { appVersion: APP_VERSION })
+
+    const zip = new AdmZip(out)
+    expect(zip.readAsText('crash-evidence/active-run.json')).toBe('{"version":"2.0.1"}\n')
+    expect(zip.readAsText('system-info.txt')).toContain('included-active-run-marker: true')
+    expect(existsSync(join(root, 'logs'))).toBe(true)
   })
 
   it('includes local Crashpad minidumps but excludes unrelated crash files', async () => {
@@ -58,7 +76,10 @@ describe('exportDiagnosticsZip', () => {
     writeFileSync(join(reports, 'crash-id.dmp'), 'minidump')
     writeFileSync(join(reports, 'metadata.json'), '{"secret":"ignored"}')
 
-    const out = await exportDiagnosticsZip(logs, root, { crashDumpsDir: crashes })
+    const out = await exportDiagnosticsZip(logs, root, {
+      appVersion: APP_VERSION,
+      crashDumpsDir: crashes,
+    })
 
     const zip = new AdmZip(out)
     const names = zip.getEntries().map(entry => entry.entryName).sort()
@@ -77,6 +98,7 @@ describe('exportDiagnosticsZip', () => {
     writeFileSync(join(crashes, 'latest.dmp'), 'eight888')
 
     const out = await exportDiagnosticsZip(logs, root, {
+      appVersion: APP_VERSION,
       crashDumpsDir: crashes,
       maxEvidenceBytes: 10,
     })
@@ -99,7 +121,10 @@ describe('exportDiagnosticsZip', () => {
     writeFileSync(join(target, 'crash.dmp'), 'minidump')
     symlinkSync(target, crashes, process.platform === 'win32' ? 'junction' : 'dir')
 
-    await expect(exportDiagnosticsZip(logs, root, { crashDumpsDir: crashes }))
+    await expect(exportDiagnosticsZip(logs, root, {
+      appVersion: APP_VERSION,
+      crashDumpsDir: crashes,
+    }))
       .rejects.toThrow(/linked crash dump directory/u)
   })
 
@@ -109,7 +134,7 @@ describe('exportDiagnosticsZip', () => {
     writeFileSync(join(dir, 'notes.txt'), 'foreign\n')
     mkdirSync(join(dir, 'dsh-2020-01-01.log'))
 
-    const out = await exportDiagnosticsZip(dir, dir)
+    const out = await exportDiagnosticsZip(dir, dir, { appVersion: APP_VERSION })
 
     const names = new AdmZip(out).getEntries().map(entry => entry.entryName).sort()
     expect(names).toEqual(['dsh-2026-08-16.error.log', 'system-info.txt'])
@@ -124,7 +149,8 @@ describe('exportDiagnosticsZip', () => {
     writeFileSync(join(logs, 'dsh-2026-08-16.log'), 'owned\n')
     symlinkSync(target, join(root, 'diagnostics'), process.platform === 'win32' ? 'junction' : 'dir')
 
-    await expect(exportDiagnosticsZip(logs, root)).rejects.toThrow(/linked diagnostics directory/u)
+    await expect(exportDiagnosticsZip(logs, root, { appVersion: APP_VERSION }))
+      .rejects.toThrow(/linked diagnostics directory/u)
   })
 
   it('rejects a linked log directory', async () => {
@@ -135,7 +161,8 @@ describe('exportDiagnosticsZip', () => {
     writeFileSync(join(target, 'dsh-2026-08-16.log'), 'owned\n')
     symlinkSync(target, logs, process.platform === 'win32' ? 'junction' : 'dir')
 
-    await expect(exportDiagnosticsZip(logs, root)).rejects.toThrow(/linked log directory/u)
+    await expect(exportDiagnosticsZip(logs, root, { appVersion: APP_VERSION }))
+      .rejects.toThrow(/linked log directory/u)
   })
 
   it('retains only the three newest diagnostics archives', async () => {
@@ -152,7 +179,7 @@ describe('exportDiagnosticsZip', () => {
       utimesSync(path, modified, modified)
     }
 
-    await exportDiagnosticsZip(logs, root)
+    await exportDiagnosticsZip(logs, root, { appVersion: APP_VERSION })
 
     const archives = readdirSync(diagnostics).filter(name => name.endsWith('.zip')).sort()
     expect(archives).toHaveLength(3)
@@ -173,7 +200,10 @@ describe('exportDiagnosticsZip', () => {
     utimesSync(middle, new Date('2026-08-15T00:00:00Z'), new Date('2026-08-15T00:00:00Z'))
     utimesSync(newest, new Date('2026-08-16T00:00:00Z'), new Date('2026-08-16T00:00:00Z'))
 
-    const out = await exportDiagnosticsZip(logs, root, { maxEvidenceBytes: 11 })
+    const out = await exportDiagnosticsZip(logs, root, {
+      appVersion: APP_VERSION,
+      maxEvidenceBytes: 11,
+    })
 
     const zip = new AdmZip(out)
     const names = zip.getEntries().map(entry => entry.entryName).sort()

--- a/dsh-plugin-desktop/tests/electron-runtime.spec.ts
+++ b/dsh-plugin-desktop/tests/electron-runtime.spec.ts
@@ -37,7 +37,7 @@ vi.mock('../src/desktop-terminal.ts', async (importOriginal) => ({
 }))
 
 vi.mock('../src/diagnostic-export.ts', () => ({
-  exportDiagnosticsZip: diagnostics.export,
+  exportDesktopDiagnostics: diagnostics.export,
 }))
 
 vi.mock('../src/update-download.ts', () => ({
@@ -623,9 +623,11 @@ describe('Electron compatibility runtime', () => {
 
     expect(diagnostics.export).toHaveBeenCalledOnce()
     expect(diagnostics.export).toHaveBeenCalledWith(
-      join('/tmp/dsh-desktop-user-data', 'logs'),
       '/tmp/dsh-desktop-user-data',
-      { crashDumpsDir: '/tmp/dsh-desktop-user-data/Crashpad' },
+      {
+        appVersion: '2.0.1',
+        crashDumpsDir: '/tmp/dsh-desktop-user-data/Crashpad',
+      },
     )
     expect(electron.shell.showItemInFolder).toHaveBeenCalledOnce()
     expect(electron.shell.showItemInFolder).toHaveBeenCalledWith('C:\\Users\\Example\\diagnostics.zip')

--- a/dsh-plugin-desktop/tests/verify-packaged-runtime.spec.ts
+++ b/dsh-plugin-desktop/tests/verify-packaged-runtime.spec.ts
@@ -69,6 +69,7 @@ describe('packaged desktop runtime verification', () => {
         expect(workerPath).toBe(join(unpackedRoot, 'lib', 'diagnostic-export-worker.js'))
         expect(readFileSync(join(workerData.logsDir, 'dsh-2000-01-01.log'), 'utf8'))
           .toBe('packaged worker smoke\n')
+        expect(workerData.appVersion).toBe('packaged-smoke')
         expect(workerData.maxEvidenceBytes).toBe(1024)
         const crashDump = readFileSync(join(workerData.crashDumpsDir, 'pending', 'packaged-smoke.dmp'))
         expect(crashDump.toString('utf8')).toBe('packaged crash dump smoke\n')


### PR DESCRIPTION
## Summary

- add `--export-diagnostics` recovery entry points for the packaged app and npm launcher
- export logs, Crashpad dumps, the active-run marker, and versioned system information without booting Host, profiles, plugins, or a window
- document the crash-recovery command and diagnostic privacy guidance in the user guides and bug report form

## Verification

- `corepack yarn workspace dsh-plugin-desktop check`
- 45 test files passed; 410 tests passed; 9 skipped
- real Windows Electron recovery invocation exited 0 and produced a diagnostics ZIP
- generated `system-info.txt` recorded Desktop 2.0.1, Electron 43.4.0, Node, platform, and architecture