### PR TITLE
fix: preserve streamed tool call identity

### DIFF
--- a/dsh-plugin-desktop/tests/deepseek-streaming-tool-call.spec.ts
+++ b/dsh-plugin-desktop/tests/deepseek-streaming-tool-call.spec.ts
@@ -1,0 +1,100 @@
+import type { AnonymousUserId } from '@deepseek-ai/dsh-anonymous-user-id'
+import { MessageId, type StreamChunk } from '@deepseek-ai/dsh-llm'
+import {
+  DeepSeekAdapter,
+  resolveAdapterOptions,
+} from '@deepseek-ai/dsh-llm-deepseek'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+function sseResponse(payloads: readonly unknown[]): Response {
+  const body = payloads
+    .map(payload => `data: ${typeof payload === 'string' ? payload : JSON.stringify(payload)}\n\n`)
+    .join('')
+  return new Response(body, {
+    status: 200,
+    headers: { 'content-type': 'text/event-stream' },
+  })
+}
+
+describe('DeepSeek streaming tool calls', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('keeps the first non-empty id and name when continuation deltas contain empty strings', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => sseResponse([
+      {
+        choices: [{
+          delta: {
+            tool_calls: [{
+              index: 0,
+              id: 'call_web_search',
+              type: 'function',
+              function: { name: 'web_search', arguments: '{"query":' },
+            }],
+          },
+        }],
+      },
+      {
+        choices: [{
+          delta: {
+            tool_calls: [{
+              index: 0,
+              id: '',
+              function: { name: '', arguments: '"AI news today"}' },
+            }],
+          },
+        }],
+      },
+      {
+        choices: [{ delta: {}, finish_reason: 'tool_calls' }],
+        usage: { prompt_tokens: 10, completion_tokens: 5, total_tokens: 15 },
+      },
+      '[DONE]',
+    ])))
+
+    const connection = resolveAdapterOptions({
+      baseURL: 'https://example.test/v1',
+      thinking: 'disabled',
+    })
+    const adapter = new DeepSeekAdapter({
+      options: () => connection,
+      resolveApiKey: async () => 'test-key',
+      resolveUserId: () => 'test-user' as AnonymousUserId,
+    })
+    const chunks: StreamChunk[] = []
+
+    for await (const chunk of adapter.stream({
+      provider: 'deepseek-official',
+      model: 'deepseek-v4-pro',
+      messages: [{
+        id: MessageId('message-user'),
+        role: 'user',
+        content: [{ type: 'text', text: 'Search today AI news' }],
+        source: { kind: 'user' },
+      }],
+      tools: [{
+        name: 'web_search',
+        description: 'Search the web',
+        parameters: {
+          type: 'object',
+          properties: { query: { type: 'string' } },
+          required: ['query'],
+        },
+      }],
+    })) chunks.push(chunk)
+
+    expect(chunks.find(chunk => chunk.type === 'block-end')).toMatchObject({
+      block: {
+        type: 'tool-call',
+        id: 'call_web_search',
+        name: 'web_search',
+        arguments: '{"query":"AI news today"}',
+      },
+    })
+    expect(chunks.at(-1)).toMatchObject({
+      type: 'finish',
+      reason: { kind: 'tool-calls' },
+    })
+  })
+})

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   ],
   "resolutions": {
     "app-builder-lib@npm:26.15.3": "patch:app-builder-lib@npm%3A26.15.3#./patches/app-builder-lib@26.15.3.patch",
+    "@deepseek-ai/dsh-llm-deepseek@npm:^0.1.0-rc.7": "patch:@deepseek-ai/dsh-llm-deepseek@npm%3A0.1.0-rc.7#./patches/dsh-llm-deepseek@0.1.0-rc.7.patch",
     "@deepseek-ai/dsh-sandbox-windows-acl@npm:0.1.0-rc.7": "patch:@deepseek-ai/dsh-sandbox-windows-acl@npm%3A0.1.0-rc.7#./patches/dsh-sandbox-windows-acl@0.1.0-rc.7.patch",
     "@deepseek-ai/dsh-sandbox-windows-acl@npm:^0.1.0-rc.7": "patch:@deepseek-ai/dsh-sandbox-windows-acl@npm%3A0.1.0-rc.7#./patches/dsh-sandbox-windows-acl@0.1.0-rc.7.patch",
     "@deepseek-ai/dsh-client-ui-directory-picker-browse@npm:0.1.0-rc.7": "patch:@deepseek-ai/dsh-client-ui-directory-picker-browse@npm%3A0.1.0-rc.7#./patches/dsh-client-ui-directory-picker-browse@0.1.0-rc.7.patch",

--- a/patches/dsh-llm-deepseek@0.1.0-rc.7.patch
+++ b/patches/dsh-llm-deepseek@0.1.0-rc.7.patch
@@ -1,0 +1,9 @@
+diff --git a/lib/index.js b/lib/index.js
+index 85201f297e55b3fcbd81b9258eca232f00eaa522..ee79a72a0d23121ec373aa510651f067e45aa735 100644
+--- a/lib/index.js
++++ b/lib/index.js
+@@ -321,2 +321,2 @@ async function* translate(response, request) {
+-				if (call.id !== void 0) block.callId = call.id;
+-				if (call.function?.name !== void 0) block.name = call.function.name;
++				if (call.id) block.callId = call.id;
++				if (call.function?.name) block.name = call.function.name;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2188,7 +2188,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@deepseek-ai/dsh-llm-deepseek@npm:^0.1.0-rc.7":
+"@deepseek-ai/dsh-llm-deepseek@npm:0.1.0-rc.7":
   version: 0.1.0-rc.7
   resolution: "@deepseek-ai/dsh-llm-deepseek@npm:0.1.0-rc.7"
   dependencies:
@@ -2204,6 +2204,25 @@ __metadata:
     "@deepseek-ai/dsh-settings": ^0.1.0-rc.7
     "@deepseek-ai/dsh-timeout": ^0.1.0-rc.7
   checksum: 10c0/413775c94085048b4ba06f418292af525c33af0a5d069e1a638ebe49d3e57eba05edb33a6d7e314bd1a7b750eacf431daafcc4470fe2c7a13394fcac06567164
+  languageName: node
+  linkType: hard
+
+"@deepseek-ai/dsh-llm-deepseek@patch:@deepseek-ai/dsh-llm-deepseek@npm%3A0.1.0-rc.7#./patches/dsh-llm-deepseek@0.1.0-rc.7.patch::locator=deepseek-harness-desktop%40workspace%3A.":
+  version: 0.1.0-rc.7
+  resolution: "@deepseek-ai/dsh-llm-deepseek@patch:@deepseek-ai/dsh-llm-deepseek@npm%3A0.1.0-rc.7#./patches/dsh-llm-deepseek@0.1.0-rc.7.patch::version=0.1.0-rc.7&hash=da7817&locator=deepseek-harness-desktop%40workspace%3A."
+  dependencies:
+    "@deepseek-ai/schemastery": "npm:^3.18.1"
+    eventsource-parser: "npm:^3.1.0"
+  peerDependencies:
+    "@deepseek-ai/cordis": ^4.0.1
+    "@deepseek-ai/dsh-anonymous-user-id": ^0.1.0-rc.7
+    "@deepseek-ai/dsh-credentials": ^0.1.0-rc.7
+    "@deepseek-ai/dsh-invariants": ^0.1.0-rc.7
+    "@deepseek-ai/dsh-launch-environment": ^0.1.0-rc.7
+    "@deepseek-ai/dsh-llm": ^0.1.0-rc.7
+    "@deepseek-ai/dsh-settings": ^0.1.0-rc.7
+    "@deepseek-ai/dsh-timeout": ^0.1.0-rc.7
+  checksum: 10c0/9047159ef40ac7453c1d3d44737e111c5a32a2bda9922b5071f8492b5266593ec57fc614381c76523f24ddf2d27d4e1aba581b13a77484d0e4074cf65d406c0e
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

- preserve the first non-empty streamed tool-call ID and function name
- keep concatenating argument fragments when continuation deltas carry empty identity fields
- apply the fix to the currently pinned `@deepseek-ai/dsh-llm-deepseek@0.1.0-rc.7`
- cover the real `DeepSeekAdapter.stream()` SSE boundary with a regression test

## Verification

- reproduced before the patch: final tool call contained `id: ""` and `name: ""`
- focused streaming regression test passes
- live DeepSeek API tool-call smoke passes
- `corepack yarn check` passes (421 passed, 9 skipped)

Supersedes #207.
Fixes #197.