### PR TITLE
fix(desktop): recover stray pnpm runtime entries

### DIFF
--- a/dsh-plugin-desktop/src/desktop-runtime-environment.ts
+++ b/dsh-plugin-desktop/src/desktop-runtime-environment.ts
@@ -135,6 +135,27 @@ function assertOwnedDirectoryEntries(directory: string, allowed: readonly string
   }
 }
 
+/** Remove one stray command entry without recursively deleting unknown data. */
+function removeUnexpectedEntry(directory: string, entry: string): void {
+  const filename = join(directory, entry)
+  if (lstatSync(filename).isDirectory()) {
+    throw new Error(
+      `dsh-plugin-desktop: command runtime contains an unexpected directory: ${entry}`,
+    )
+  }
+  process.stderr.write(
+    `dsh-plugin-desktop: removing unexpected command runtime entry ${JSON.stringify(entry)}\n`,
+  )
+  unlinkSync(filename)
+}
+
+/** Recover an app-owned command directory to this generation's exact contents. */
+function reconcileOwnedDirectoryEntries(directory: string, allowed: readonly string[]): void {
+  for (const entry of readdirSync(directory)) {
+    if (!allowed.includes(entry)) removeUnexpectedEntry(directory, entry)
+  }
+}
+
 /** Remove only stale atomic-write files generated for one exact target name. */
 function removeStaleTemporaryFiles(directory: string, targetName: string): void {
   const prefix = `.${targetName}.`
@@ -388,8 +409,8 @@ export function installDesktopPnpmRuntime(options: DesktopPnpmRuntimeOptions): D
   removeStaleTemporaryFiles(pathDir, pnpmShimName)
   removeStaleTemporaryFiles(nodeBinDir, nodeShimName)
   removeStaleTemporaryFiles(privateDir, 'clear-env.mjs')
-  assertOwnedDirectoryEntries(pathDir, [pnpmShimName])
-  assertOwnedDirectoryEntries(nodeBinDir, [nodeShimName])
+  reconcileOwnedDirectoryEntries(pathDir, [pnpmShimName])
+  reconcileOwnedDirectoryEntries(nodeBinDir, [nodeShimName])
   const pnpmShimPath = join(pathDir, pnpmShimName)
   const nodeShimPath = join(nodeBinDir, nodeShimName)
   const clearEnvironmentPath = join(privateDir, 'clear-env.mjs')

--- a/dsh-plugin-desktop/src/desktop-runtime-environment.ts
+++ b/dsh-plugin-desktop/src/desktop-runtime-environment.ts
@@ -38,6 +38,8 @@ export interface DesktopPnpmRuntimeOptions {
   stateDir: string
   /** Parent environment whose PATH is updated; defaults to `process.env`. */
   environment?: NodeJS.ProcessEnv
+  /** Best-effort observer for each successfully removed unexpected command entry. */
+  onRecovery?: (message: string) => void
 }
 
 /** Files and reversible PATH update created for the Host runtime. */
@@ -135,24 +137,40 @@ function assertOwnedDirectoryEntries(directory: string, allowed: readonly string
   }
 }
 
-/** Remove one stray command entry without recursively deleting unknown data. */
-function removeUnexpectedEntry(directory: string, entry: string): void {
-  const filename = join(directory, entry)
-  if (lstatSync(filename).isDirectory()) {
-    throw new Error(
-      `dsh-plugin-desktop: command runtime contains an unexpected directory: ${entry}`,
-    )
-  }
-  process.stderr.write(
-    `dsh-plugin-desktop: removing unexpected command runtime entry ${JSON.stringify(entry)}\n`,
-  )
-  unlinkSync(filename)
+/** Preflight recoverable entries without deleting unknown directories or special files. */
+function recoverableUnexpectedEntries(directory: string, allowed: readonly string[]): string[] {
+  return readdirSync(directory)
+    .filter(entry => !allowed.includes(entry))
+    .map((entry) => {
+      const filename = join(directory, entry)
+      const stat = lstatSync(filename)
+      if (!stat.isFile() && !stat.isSymbolicLink()) {
+        const kind = stat.isDirectory() ? 'directory' : 'non-file entry'
+        throw new Error(
+          `dsh-plugin-desktop: command runtime contains an unexpected ${kind}: ${JSON.stringify(filename)}`,
+        )
+      }
+      return filename
+    })
 }
 
-/** Recover an app-owned command directory to this generation's exact contents. */
-function reconcileOwnedDirectoryEntries(directory: string, allowed: readonly string[]): void {
-  for (const entry of readdirSync(directory)) {
-    if (!allowed.includes(entry)) removeUnexpectedEntry(directory, entry)
+/** Remove preflighted command entries before exposing their directory through PATH. */
+function removeUnexpectedEntries(
+  filenames: readonly string[],
+  onRecovery: DesktopPnpmRuntimeOptions['onRecovery'],
+): void {
+  for (const filename of filenames) {
+    unlinkSync(filename)
+    const message = `dsh-plugin-desktop: removed unexpected pnpm runtime entry ${JSON.stringify(filename)}`
+    if (onRecovery === undefined) {
+      process.stderr.write(`${message}\n`)
+      continue
+    }
+    try {
+      onRecovery(message)
+    } catch {
+      process.stderr.write(`${message}\n`)
+    }
   }
 }
 
@@ -409,8 +427,11 @@ export function installDesktopPnpmRuntime(options: DesktopPnpmRuntimeOptions): D
   removeStaleTemporaryFiles(pathDir, pnpmShimName)
   removeStaleTemporaryFiles(nodeBinDir, nodeShimName)
   removeStaleTemporaryFiles(privateDir, 'clear-env.mjs')
-  reconcileOwnedDirectoryEntries(pathDir, [pnpmShimName])
-  reconcileOwnedDirectoryEntries(nodeBinDir, [nodeShimName])
+  const unexpectedEntries = [
+    ...recoverableUnexpectedEntries(pathDir, [pnpmShimName]),
+    ...recoverableUnexpectedEntries(nodeBinDir, [nodeShimName]),
+  ]
+  removeUnexpectedEntries(unexpectedEntries, options.onRecovery)
   const pnpmShimPath = join(pathDir, pnpmShimName)
   const nodeShimPath = join(nodeBinDir, nodeShimName)
   const clearEnvironmentPath = join(privateDir, 'clear-env.mjs')

--- a/dsh-plugin-desktop/src/main.ts
+++ b/dsh-plugin-desktop/src/main.ts
@@ -282,6 +282,7 @@ async function start(): Promise<void> {
       electronVersion,
       stateDir: join(app.getPath('userData'), 'runtime-commands'),
       environment: process.env,
+      onRecovery: message => electronLogger.error(message),
     })
     const releasePnpmRuntime = (): void => { pnpmRuntime.dispose() }
     disposePnpmRuntime = releasePnpmRuntime

--- a/dsh-plugin-desktop/tests/desktop-runtime-environment.spec.ts
+++ b/dsh-plugin-desktop/tests/desktop-runtime-environment.spec.ts
@@ -12,7 +12,7 @@ import {
 import { tmpdir } from 'node:os'
 import { delimiter as pathDelimiter, join } from 'node:path'
 import { pathToFileURL } from 'node:url'
-import { afterEach, describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import {
   installDesktopDshRuntime,
   installDesktopPnpmRuntime,
@@ -47,6 +47,7 @@ function options(
 }
 
 afterEach(() => {
+  vi.restoreAllMocks()
   for (const directory of temporaryDirectories.splice(0)) {
     rmSync(directory, { recursive: true, force: true })
   }
@@ -299,16 +300,54 @@ describe('desktop Host pnpm runtime', () => {
     expect(environment).toEqual({ PATH: '/usr/bin' })
   })
 
-  it('rejects unexpected public commands before changing PATH', () => {
+  it('recovers from stray command files instead of failing startup', () => {
+    const root = temporaryDirectory()
+    const stateDir = join(root, 'runtime')
+    const pathDir = join(stateDir, 'bin')
+    const nodeBinDir = join(stateDir, 'private', 'node-bin')
+    mkdirSync(pathDir, { recursive: true })
+    mkdirSync(nodeBinDir, { recursive: true })
+    writeFileSync(join(pathDir, 'dsh'), 'stray')
+    writeFileSync(join(nodeBinDir, 'dsh'), 'stray')
+    const environment: NodeJS.ProcessEnv = { PATH: '/usr/bin' }
+    const stderr = vi.spyOn(process.stderr, 'write').mockImplementation(() => true)
+
+    const installation = installDesktopPnpmRuntime(options(stateDir, 'linux', environment))
+
+    expect(readdirSync(pathDir)).toEqual(['pnpm'])
+    expect(readdirSync(nodeBinDir)).toEqual(['node'])
+    expect(environment.PATH).toBe(`${pathDir}:/usr/bin`)
+    expect(stderr).toHaveBeenCalledTimes(2)
+    installation.dispose()
+  })
+
+  it('removes stray symlinks without touching their targets', () => {
     const root = temporaryDirectory()
     const stateDir = join(root, 'runtime')
     const pathDir = join(stateDir, 'bin')
     mkdirSync(pathDir, { recursive: true })
-    writeFileSync(join(pathDir, 'node'), 'unexpected')
+    const target = join(root, 'outside')
+    writeFileSync(target, 'outside')
+    symlinkSync(target, join(pathDir, 'dsh'))
+    const stderr = vi.spyOn(process.stderr, 'write').mockImplementation(() => true)
+
+    const installation = installDesktopPnpmRuntime(options(stateDir, 'linux', { PATH: '/usr/bin' }))
+
+    expect(readdirSync(pathDir)).toEqual(['pnpm'])
+    expect(readFileSync(target, 'utf8')).toBe('outside')
+    expect(stderr).toHaveBeenCalledOnce()
+    installation.dispose()
+  })
+
+  it('refuses an unexpected directory in the public command directory', () => {
+    const root = temporaryDirectory()
+    const stateDir = join(root, 'runtime')
+    const pathDir = join(stateDir, 'bin')
+    mkdirSync(join(pathDir, 'dsh'), { recursive: true })
     const environment: NodeJS.ProcessEnv = { PATH: '/usr/bin' }
 
     expect(() => installDesktopPnpmRuntime(options(stateDir, 'linux', environment)))
-      .toThrow('directory contains unexpected entries: node')
+      .toThrow('contains an unexpected directory: dsh')
     expect(environment).toEqual({ PATH: '/usr/bin' })
   })
 

--- a/dsh-plugin-desktop/tests/desktop-runtime-environment.spec.ts
+++ b/dsh-plugin-desktop/tests/desktop-runtime-environment.spec.ts
@@ -1,5 +1,6 @@
 import { spawnSync } from 'node:child_process'
 import {
+  existsSync,
   lstatSync,
   mkdirSync,
   mkdtempSync,
@@ -310,14 +311,28 @@ describe('desktop Host pnpm runtime', () => {
     writeFileSync(join(pathDir, 'dsh'), 'stray')
     writeFileSync(join(nodeBinDir, 'dsh'), 'stray')
     const environment: NodeJS.ProcessEnv = { PATH: '/usr/bin' }
-    const stderr = vi.spyOn(process.stderr, 'write').mockImplementation(() => true)
+    const recovered = [join(pathDir, 'dsh'), join(nodeBinDir, 'dsh')]
+    const onRecovery = vi.fn((message: string) => {
+      const filename = recovered.find(candidate => message.includes(JSON.stringify(candidate)))
+      expect(filename).toBeDefined()
+      expect(existsSync(filename ?? '')).toBe(false)
+    })
 
-    const installation = installDesktopPnpmRuntime(options(stateDir, 'linux', environment))
+    const installation = installDesktopPnpmRuntime({
+      ...options(stateDir, 'linux', environment),
+      onRecovery,
+    })
 
     expect(readdirSync(pathDir)).toEqual(['pnpm'])
     expect(readdirSync(nodeBinDir)).toEqual(['node'])
     expect(environment.PATH).toBe(`${pathDir}:/usr/bin`)
-    expect(stderr).toHaveBeenCalledTimes(2)
+    expect(onRecovery).toHaveBeenCalledTimes(2)
+    expect(onRecovery).toHaveBeenCalledWith(
+      `dsh-plugin-desktop: removed unexpected pnpm runtime entry ${JSON.stringify(join(pathDir, 'dsh'))}`,
+    )
+    expect(onRecovery).toHaveBeenCalledWith(
+      `dsh-plugin-desktop: removed unexpected pnpm runtime entry ${JSON.stringify(join(nodeBinDir, 'dsh'))}`,
+    )
     installation.dispose()
   })
 
@@ -325,29 +340,122 @@ describe('desktop Host pnpm runtime', () => {
     const root = temporaryDirectory()
     const stateDir = join(root, 'runtime')
     const pathDir = join(stateDir, 'bin')
+    const nodeBinDir = join(stateDir, 'private', 'node-bin')
     mkdirSync(pathDir, { recursive: true })
-    const target = join(root, 'outside')
-    writeFileSync(target, 'outside')
-    symlinkSync(target, join(pathDir, 'dsh'))
-    const stderr = vi.spyOn(process.stderr, 'write').mockImplementation(() => true)
+    mkdirSync(nodeBinDir, { recursive: true })
+    const publicTarget = join(root, 'public-outside')
+    const privateTarget = join(root, 'private-outside')
+    const publicLink = join(pathDir, 'dsh')
+    const privateLink = join(nodeBinDir, 'dsh')
+    writeFileSync(publicTarget, 'public outside')
+    writeFileSync(privateTarget, 'private outside')
+    symlinkSync(publicTarget, publicLink)
+    symlinkSync(privateTarget, privateLink)
+    const onRecovery = vi.fn()
 
-    const installation = installDesktopPnpmRuntime(options(stateDir, 'linux', { PATH: '/usr/bin' }))
+    const installation = installDesktopPnpmRuntime({
+      ...options(stateDir, 'linux', { PATH: '/usr/bin' }),
+      onRecovery,
+    })
 
     expect(readdirSync(pathDir)).toEqual(['pnpm'])
-    expect(readFileSync(target, 'utf8')).toBe('outside')
-    expect(stderr).toHaveBeenCalledOnce()
+    expect(readdirSync(nodeBinDir)).toEqual(['node'])
+    expect(readFileSync(publicTarget, 'utf8')).toBe('public outside')
+    expect(readFileSync(privateTarget, 'utf8')).toBe('private outside')
+    expect(existsSync(publicLink)).toBe(false)
+    expect(existsSync(privateLink)).toBe(false)
+    expect(onRecovery).toHaveBeenCalledTimes(2)
     installation.dispose()
   })
 
-  it('refuses an unexpected directory in the public command directory', () => {
+  it('recovers Windows command directories without widening their allowlists', () => {
     const root = temporaryDirectory()
     const stateDir = join(root, 'runtime')
     const pathDir = join(stateDir, 'bin')
-    mkdirSync(join(pathDir, 'dsh'), { recursive: true })
-    const environment: NodeJS.ProcessEnv = { PATH: '/usr/bin' }
+    const nodeBinDir = join(stateDir, 'private', 'node-bin')
+    mkdirSync(pathDir, { recursive: true })
+    mkdirSync(nodeBinDir, { recursive: true })
+    writeFileSync(join(pathDir, 'dsh'), 'stray')
+    writeFileSync(join(nodeBinDir, 'node'), 'legacy')
+    const environment: NodeJS.ProcessEnv = { Path: 'C:\\Windows' }
+    const onRecovery = vi.fn()
 
-    expect(() => installDesktopPnpmRuntime(options(stateDir, 'linux', environment)))
-      .toThrow('contains an unexpected directory: dsh')
+    const installation = installDesktopPnpmRuntime({
+      ...options(stateDir, 'win32', environment),
+      onRecovery,
+    })
+
+    expect(readdirSync(pathDir)).toEqual(['pnpm.cmd'])
+    expect(readdirSync(nodeBinDir)).toEqual(['node.cmd'])
+    expect(environment.Path).toBe(`${pathDir};C:\\Windows`)
+    expect(onRecovery).toHaveBeenCalledTimes(2)
+    installation.dispose()
+  })
+
+  it('keeps recovery logging failures from blocking startup', () => {
+    const root = temporaryDirectory()
+    const stateDir = join(root, 'runtime')
+    const pathDir = join(stateDir, 'bin')
+    mkdirSync(pathDir, { recursive: true })
+    writeFileSync(join(pathDir, 'dsh'), 'stray')
+    const environment: NodeJS.ProcessEnv = { PATH: '/usr/bin' }
+    const stderr = vi.spyOn(process.stderr, 'write').mockImplementation(() => true)
+
+    const installation = installDesktopPnpmRuntime({
+      ...options(stateDir, 'linux', environment),
+      onRecovery: () => { throw new Error('logger unavailable') },
+    })
+
+    expect(readdirSync(pathDir)).toEqual(['pnpm'])
+    expect(environment.PATH).toBe(`${pathDir}:/usr/bin`)
+    expect(stderr).toHaveBeenCalledWith(expect.stringContaining('removed unexpected pnpm runtime entry'))
+    installation.dispose()
+  })
+
+  it('preflights both command directories before removing unexpected entries', () => {
+    const root = temporaryDirectory()
+    const stateDir = join(root, 'runtime')
+    const pathDir = join(stateDir, 'bin')
+    const nodeBinDir = join(stateDir, 'private', 'node-bin')
+    const stray = join(pathDir, 'dsh')
+    const blocked = join(nodeBinDir, 'blocked')
+    mkdirSync(pathDir, { recursive: true })
+    mkdirSync(blocked, { recursive: true })
+    writeFileSync(stray, 'stray')
+    const environment: NodeJS.ProcessEnv = { PATH: '/usr/bin' }
+    const onRecovery = vi.fn()
+
+    expect(() => installDesktopPnpmRuntime({
+      ...options(stateDir, 'linux', environment),
+      onRecovery,
+    })).toThrow(`contains an unexpected directory: ${JSON.stringify(blocked)}`)
+    expect(readFileSync(stray, 'utf8')).toBe('stray')
+    expect(lstatSync(blocked).isDirectory()).toBe(true)
+    expect(onRecovery).not.toHaveBeenCalled()
+    expect(environment).toEqual({ PATH: '/usr/bin' })
+  })
+
+  it.runIf(process.platform !== 'win32')('refuses special entries without partially removing files', () => {
+    const root = temporaryDirectory()
+    const stateDir = join(root, 'runtime')
+    const pathDir = join(stateDir, 'bin')
+    const stray = join(pathDir, 'dsh')
+    const fifo = join(pathDir, 'blocked-fifo')
+    mkdirSync(pathDir, { recursive: true })
+    writeFileSync(stray, 'stray')
+    const created = spawnSync('mkfifo', [fifo], { encoding: 'utf8' })
+    expect(created.error).toBeUndefined()
+    expect(created.status, created.stderr).toBe(0)
+    const environment: NodeJS.ProcessEnv = { PATH: '/usr/bin' }
+    const onRecovery = vi.fn()
+
+    expect(() => installDesktopPnpmRuntime({
+      ...options(stateDir, 'linux', environment),
+      onRecovery,
+    })).toThrow(`contains an unexpected non-file entry: ${JSON.stringify(fifo)}`)
+    expect(readFileSync(stray, 'utf8')).toBe('stray')
+    expect(lstatSync(fifo).isFIFO()).toBe(true)
+    expect(onRecovery).not.toHaveBeenCalled()
     expect(environment).toEqual({ PATH: '/usr/bin' })
   })
 
@@ -378,6 +486,29 @@ describe('desktop Host pnpm runtime', () => {
 })
 
 describe('desktop Host dsh runtime', () => {
+  it('keeps unexpected Host commands fail-loud', () => {
+    const root = temporaryDirectory()
+    const stateDir = join(root, 'runtime')
+    const pathDir = join(stateDir, 'bin')
+    const unexpected = join(pathDir, 'foreign.cmd')
+    mkdirSync(pathDir, { recursive: true })
+    writeFileSync(unexpected, 'unexpected')
+    const environment: NodeJS.ProcessEnv = { Path: 'C:\\Windows' }
+
+    expect(() => installDesktopDshRuntime({
+      platform: 'win32',
+      appExecutable: 'C:\\Program Files\\DSH Desktop\\DSH Desktop.exe',
+      dshBootstrapPath: 'C:\\Program Files\\DSH Desktop\\resources\\app.asar\\lib\\desktop-cli.js',
+      profileName: 'web',
+      homeDir: 'C:\\Users\\user\\.dsh',
+      stateDir,
+      environment,
+    })).toThrow('directory contains unexpected entries: foreign.cmd')
+    expect(readFileSync(unexpected, 'utf8')).toBe('unexpected')
+    expect(readdirSync(pathDir)).toEqual(['foreign.cmd'])
+    expect(environment).toEqual({ Path: 'C:\\Windows' })
+  })
+
   it.runIf(process.platform === 'win32')('makes the active profile available to Host plugin child processes', () => {
     const root = temporaryDirectory()
     const stateDir = join(root, 'runtime')

--- a/dsh-plugin-desktop/tests/package.spec.ts
+++ b/dsh-plugin-desktop/tests/package.spec.ts
@@ -182,6 +182,7 @@ describe('published package surface', () => {
     expect(boot).toBeGreaterThan(installDsh)
     expect(main).toContain("'dsh-plugin-desktop: packaged pnpm runtime PATH'")
     expect(main).toContain("'dsh-plugin-desktop: packaged dsh runtime PATH'")
+    expect(main).toContain('onRecovery: message => electronLogger.error(message)')
     expect(main).toContain("args: ['--host', '127.0.0.1', '--port', String(prepared.port)]")
     expect(main).not.toContain("'--port', '0'")
     expect(main).toContain('disposePnpmRuntime?.()')


### PR DESCRIPTION
## Summary

- remove unexpected regular files and symlinks from the app-owned pnpm public and private command directories before they enter PATH
- preflight both directories so an unexpected directory or special file fails without partially deleting other stray entries
- keep the profile-scoped Windows dsh command directory strict
- persist successful recovery events through the Electron logger while retaining a stderr fallback

Unexpected directories and special files remain fail-loud. The runtime is rebuilt to its exact owned contents: public `pnpm` or `pnpm.cmd`, and private `node` or `node.cmd`.

## Verification

- `corepack yarn workspace dsh-plugin-desktop test tests/desktop-runtime-environment.spec.ts tests/package.spec.ts`
- `corepack yarn workspace dsh-plugin-desktop typecheck`
- `corepack yarn check`

The complete headless gate passed with 434 Desktop tests passing and 3 platform skips.

Addresses #103.

This refreshes and supersedes #113. It preserves the refreshed recovery commit authored by @Qiuner and credits @icatw for the original investigation and implementation direction.