### PR TITLE
feat(desktop): add Windows portable ZIP packaging

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
       - run: yarn install --immutable
       - run: yarn check
 
-  # Windows-only logic and an unsigned NSIS build on a real Windows runner:
+  # Windows-only logic and unsigned NSIS/portable builds on a real Windows runner:
   # updates, window options, pwsh sandbox, volume diagnostics, and packaging.
   desktop-windows:
     runs-on: windows-latest
@@ -63,6 +63,7 @@ jobs:
       - run: yarn install --immutable
       - run: yarn check
       - run: yarn dist:win
+      - run: yarn dist:win-portable
 
   # macOS-only universal packaging smoke on a real macOS runner: the signed
   # release is built manually on a credentialed machine, so an unsigned DMG

--- a/dsh-plugin-desktop/README.md
+++ b/dsh-plugin-desktop/README.md
@@ -203,6 +203,16 @@ Python and Visual Studio C++ Build Tools are not required. The Windows command u
 
 This local command deliberately strips Windows certificate variables and sets `signExecutable=false`. Its output is installable for testing but has no Authenticode publisher, so Windows can display an Unknown publisher or SmartScreen warning. A signed Windows release, certificate verification, installer upgrade/uninstall testing, and native UI/sandbox smoke remain separate release gates.
 
+### Windows x64 portable ZIP
+
+Use `yarn dist:win-portable` on a native Windows x64 machine to create an unsigned portable ZIP:
+
+```powershell
+corepack.cmd yarn dist:win-portable
+```
+
+The output is `dsh-plugin-desktop\\dist\\DSH-Desktop-2.0.1-x64-Portable.zip`. Extract it to any writable directory and launch `DSH Desktop.exe` without an installer, administrator access, Start Menu registration, or uninstall step. The application still keeps its profiles, logs, and caches in the normal Windows user-data directory, so this is portable distribution rather than a self-contained data sandbox. Portable archives are not handed to the NSIS updater and must be replaced manually when a new version is released. Local builds are unsigned and may trigger an Unknown publisher or SmartScreen warning; signed portable artifacts remain a release gate.
+
 ### macOS DMG smoke
 
 `yarn dist:mac-smoke` builds one unsigned universal DMG on a native macOS host. The same package runs natively on Intel and Apple Silicon Macs. The command refuses non-macOS hosts and runs the complete product gate before packaging: repository layout and community-contract checks, the Market build and check, then the Desktop build, every TypeScript compiler face, the full unit-test suite, runtime-closure verification, CLI/Loader/profile headless smokes, and the license audit. This includes the real login-shell tests for each supported shell installed on the macOS runner. It then packages without code-signing material, mounts the DMG, and verifies the property list, executable bit, both `x86_64` and `arm64` slices, and `app.asar`. It mirrors `dist:win`'s secret discipline by stripping every Electron Builder macOS signing and notarization variable, sets `CSC_IDENTITY_AUTO_DISCOVERY=false`, disables notarization, and never publishes. The artifact has no Developer ID signature, so Gatekeeper will block it on other machines; it exists so packaging regressions fail in CI before a manual release. The signed and notarized universal release remains `yarn dist:mac` on a credentialed macOS machine and writes its artifact to `dsh-plugin-desktop/dist/mac-release/`.

--- a/dsh-plugin-desktop/README.zh.md
+++ b/dsh-plugin-desktop/README.zh.md
@@ -203,6 +203,16 @@ corepack.cmd yarn dist:win
 
 该本地命令会主动移除 Windows 证书变量，并设置 `signExecutable=false`。产物可以安装测试，但没有 Authenticode publisher，因此 Windows 可能显示 Unknown publisher 或 SmartScreen 警告。签名后的 Windows release、证书校验、安装器升级与卸载测试，以及原生 UI 和 sandbox smoke 仍是独立的发布 gate。
 
+### Windows x64 绿色 ZIP 版
+
+在原生 Windows x64 电脑上执行 `yarn dist:win-portable`，生成未签名的单文件绿色版：
+
+```powershell
+corepack.cmd yarn dist:win-portable
+```
+
+产物为 `dsh-plugin-desktop\\dist\\DSH-Desktop-2.0.1-x64-Portable.zip`。用户解压到任意可写目录后运行其中的 `DSH Desktop.exe`，不需要安装器、管理员权限、开始菜单注册或卸载步骤。它仍会把 profile、日志和缓存写入 Windows 默认用户数据目录，因此这是便携分发方式，不是把数据完全封装在 exe 旁边的自包含沙箱。绿色 ZIP 不会交给 NSIS 自动更新流程，新版本需要手动替换并重新解压。本地构建没有签名，Windows 可能显示 Unknown publisher 或 SmartScreen 警告；签名后的绿色版仍属于正式发布 gate。
+
 ### macOS DMG 冒烟构建
 
 `yarn dist:mac-smoke` 会在原生 macOS 宿主机上构建一个未签名的 universal DMG，同一个安装包可以在 Intel 和 Apple Silicon Mac 上原生运行。该命令拒绝非 macOS 宿主，并在打包前运行完整产品 gate：仓库布局与社区契约检查、Market 的 build 与 check，然后再运行 Desktop build、全部 TypeScript compiler face、完整 unit-test suite、runtime-closure 验证、CLI/Loader/profile headless smoke 与 license audit；其中包括对 macOS runner 上已安装的每种受支持 shell 执行真实 login-shell 测试。随后它会在不接触任何签名材料的情况下打包，挂载 DMG，并检查属性列表、主程序执行权限、`x86_64` 与 `arm64` 两个架构切片，以及 `app.asar`。该命令与 `dist:win` 的密钥纪律一致：剥离 Electron Builder 能识别的全部 macOS 签名与公证变量、设置 `CSC_IDENTITY_AUTO_DISCOVERY=false`、关闭 notarization，且从不发布。产物没有 Developer ID 签名，因此 Gatekeeper 会在其他机器上拦截它；它的存在是为了让打包回归在人工发布之前就在 CI 中失败。签名并公证的 universal 正式发布仍是在持有凭证的 macOS 机器上执行 `yarn dist:mac`，产物写入 `dsh-plugin-desktop/dist/mac-release/`。

--- a/dsh-plugin-desktop/package.json
+++ b/dsh-plugin-desktop/package.json
@@ -106,7 +106,7 @@
     "verify:licenses": "node scripts/verify-licenses.mjs",
     "verify:notices": "node scripts/verify-licenses.mjs --notices THIRD_PARTY_NOTICES.md",
     "check": "yarn run build && yarn run typecheck && yarn run test && yarn run verify:closure && yarn run verify:cli && yarn run verify:loader && yarn run verify:profile && yarn run verify:licenses",
-    "check:win-package": "yarn run build && yarn run typecheck && vitest run tests/package.spec.ts tests/package-win.spec.ts tests/update-checker.spec.ts tests/update-download.spec.ts tests/verify-win-installer.spec.ts tests/verify-packaged-runtime.spec.ts tests/windows-agent-presets.spec.ts tests/windows-pwsh-sandbox.spec.ts tests/windows-volume-diagnostics.spec.ts tests/window-options.spec.ts && yarn run verify:closure",
+    "check:win-package": "yarn run build && yarn run typecheck && vitest run tests/package.spec.ts tests/package-win.spec.ts tests/update-checker.spec.ts tests/update-download.spec.ts tests/verify-win-installer.spec.ts tests/verify-win-portable.spec.ts tests/verify-packaged-runtime.spec.ts tests/windows-agent-presets.spec.ts tests/windows-pwsh-sandbox.spec.ts tests/windows-volume-diagnostics.spec.ts tests/window-options.spec.ts && yarn run verify:closure",
     "check:mac-package": "yarn run -T check",
     "start": "node lib/bin.js",
     "dev": "yarn run build && node lib/bin.js",
@@ -114,6 +114,7 @@
     "dist:mac": "node scripts/release-mac.ts",
     "dist:mac-smoke": "node scripts/package-mac.ts",
     "dist:win": "node scripts/package-win.ts",
+    "dist:win-portable": "node scripts/package-win-portable.ts",
     "prepack": "yarn run check"
   },
   "dependencies": {
@@ -291,6 +292,7 @@
           ]
         }
       ],
+      "artifactName": "DSH-Desktop-${version}-${arch}-Portable.${ext}",
       "icon": "build/app-icon.png"
     },
     "nsis": {

--- a/dsh-plugin-desktop/scripts/package-win-portable.ts
+++ b/dsh-plugin-desktop/scripts/package-win-portable.ts
@@ -1,0 +1,21 @@
+/** Build an unsigned Windows x64 portable ZIP archive on a native Windows host. */
+
+import { fileURLToPath } from 'node:url'
+import {
+  createWindowsPackageOptions,
+  packageWindowsArtifact,
+} from './package-win.ts'
+
+const invokedPath = process.argv[1]
+if (invokedPath !== undefined && invokedPath === fileURLToPath(import.meta.url)) {
+  try {
+    packageWindowsArtifact(
+      createWindowsPackageOptions('./verify-win-portable.ts'),
+      'zip',
+      'portable archive',
+    )
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error))
+    process.exitCode = 1
+  }
+}

--- a/dsh-plugin-desktop/scripts/package-win.ts
+++ b/dsh-plugin-desktop/scripts/package-win.ts
@@ -1,4 +1,4 @@
-/** Build an unsigned Windows x64 NSIS installer on a native Windows host. */
+/** Build an unsigned Windows x64 artifact on a native Windows host. */
 
 import { spawnSync } from 'node:child_process'
 import { createRequire } from 'node:module'
@@ -76,7 +76,8 @@ function run(
   }
 }
 
-function defaultOptions(): WindowsPackageOptions {
+/** Create the native packaging options for a verifier entry point. */
+export function createWindowsPackageOptions(verifier = './verify-win-installer.ts'): WindowsPackageOptions {
   const desktopRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..')
   const workspaceRoot = resolve(desktopRoot, '..')
   const require = createRequire(import.meta.url)
@@ -92,37 +93,41 @@ function defaultOptions(): WindowsPackageOptions {
       ? 'cmd.exe'
       : join(windowsRoot, 'System32', 'cmd.exe'),
     builderCli: require.resolve('electron-builder/cli.js'),
-    verifier: fileURLToPath(new URL('./verify-win-installer.ts', import.meta.url)),
+    verifier: fileURLToPath(new URL(verifier, import.meta.url)),
     nodeExecutable: process.execPath,
     run,
     log: message => console.log(message),
   }
 }
 
-/**
- * Run the headless release gates and package one unsigned x64 NSIS installer.
- * @param options - Injectable process and command boundaries.
- */
-export function packageWindowsInstaller(
-  options: WindowsPackageOptions = defaultOptions(),
-): void {
+/** Run the shared host and Node release gates before packaging. */
+function assertWindowsPackageHost(options: WindowsPackageOptions, artifact: string): void {
   if (options.platform !== 'win32') {
-    throw new Error('Windows installer must be built on a native Windows host')
+    throw new Error(`Windows ${artifact} must be built on a native Windows host`)
   }
   if (options.arch !== 'x64') {
-    throw new Error(`Windows installer requires x64 Node; received ${options.arch}`)
+    throw new Error(`Windows ${artifact} requires x64 Node; received ${options.arch}`)
   }
   const versionMatch = /^(\d+)\.(\d+)\./u.exec(options.nodeVersion)
   const major = Number(versionMatch?.[1])
   const minor = Number(versionMatch?.[2])
   if (!((major === 22 && minor >= 19) || major === 24)) {
     throw new Error(
-      `Windows installer requires Node 22.19+ or Node 24.x with bundled Corepack; received ${options.nodeVersion}`,
+      `Windows ${artifact} requires Node 22.19+ or Node 24.x with bundled Corepack; received ${options.nodeVersion}`,
     )
   }
+}
+
+/** Run the gates and package one unsigned x64 Windows artifact. */
+export function packageWindowsArtifact(
+  options: WindowsPackageOptions,
+  target: 'nsis' | 'zip',
+  artifact: 'installer' | 'portable archive',
+): void {
+  assertWindowsPackageHost(options, artifact)
 
   const cleanEnvironment = withoutWindowsSigningSecrets(options.env)
-  options.log('Building an unsigned Windows x64 installer; Authenticode is a separate release step.')
+  options.log(`Building an unsigned Windows x64 ${artifact}; Authenticode is a separate release step.`)
   options.run(
     options.commandShell,
     [
@@ -139,7 +144,7 @@ export function packageWindowsInstaller(
     [
       options.builderCli,
       '--win',
-      'nsis',
+      target,
       '--x64',
       '--publish',
       'never',
@@ -158,6 +163,13 @@ export function packageWindowsInstaller(
     options.desktopRoot,
     cleanEnvironment,
   )
+}
+
+/** Run the headless release gates and package one unsigned x64 NSIS installer. */
+export function packageWindowsInstaller(
+  options: WindowsPackageOptions = createWindowsPackageOptions(),
+): void {
+  packageWindowsArtifact(options, 'nsis', 'installer')
 }
 
 const invokedPath = process.argv[1]

--- a/dsh-plugin-desktop/scripts/verify-win-installer.ts
+++ b/dsh-plugin-desktop/scripts/verify-win-installer.ts
@@ -4,6 +4,20 @@ import { closeSync, openSync, readFileSync, readSync, statSync } from 'node:fs'
 import { dirname, join, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
+/** Verify a complete in-memory Windows PE image. */
+export function assertPortableExecutableBuffer(data: Buffer, label: string, source: string): void {
+  if (data.byteLength < 68 || data.subarray(0, 2).toString('ascii') !== 'MZ') {
+    throw new Error(`${label} does not have a Windows PE header: ${source}`)
+  }
+  const peOffset = data.readUInt32LE(0x3c)
+  if (peOffset > data.byteLength - 4) {
+    throw new Error(`${label} has an invalid Windows PE offset: ${source}`)
+  }
+  if (!data.subarray(peOffset, peOffset + 4).equals(Buffer.from('PE\0\0'))) {
+    throw new Error(`${label} does not have a Windows PE signature: ${source}`)
+  }
+}
+
 /** Paths returned after Windows installer verification succeeds. */
 export interface WindowsInstallerArtifacts {
   /** NSIS installer path. */
@@ -30,7 +44,8 @@ function readVersion(desktopRoot: string): string {
   return manifest.version
 }
 
-function assertPortableExecutable(path: string, label: string): void {
+/** Verify that a generated Windows artifact has a valid PE header. */
+export function assertPortableExecutable(path: string, label: string): void {
   const stat = statSync(path)
   if (!stat.isFile() || stat.size < 68) {
     throw new Error(`${label} is not a non-empty regular file: ${path}`)

--- a/dsh-plugin-desktop/scripts/verify-win-portable.ts
+++ b/dsh-plugin-desktop/scripts/verify-win-portable.ts
@@ -1,0 +1,69 @@
+/** Verify the unsigned Windows x64 portable ZIP archive. */
+
+import { readFileSync, statSync } from 'node:fs'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import AdmZip from 'adm-zip'
+import { assertPortableExecutableBuffer } from './verify-win-installer.ts'
+
+export interface WindowsPortableVerificationOptions {
+  /** Desktop package root containing package.json and dist. */
+  readonly desktopRoot: string
+  /** Product version embedded in the expected artifact name. */
+  readonly version: string
+}
+
+function readVersion(desktopRoot: string): string {
+  const manifest = JSON.parse(readFileSync(join(desktopRoot, 'package.json'), 'utf8')) as {
+    version?: unknown
+  }
+  if (typeof manifest.version !== 'string' || manifest.version.length === 0) {
+    throw new Error(`desktop package at ${desktopRoot} has no valid version`)
+  }
+  return manifest.version
+}
+
+function defaultOptions(): WindowsPortableVerificationOptions {
+  const desktopRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..')
+  return { desktopRoot, version: readVersion(desktopRoot) }
+}
+
+/** Verify the exact versioned portable archive and its application entry. */
+export function verifyWindowsPortable(
+  options: WindowsPortableVerificationOptions = defaultOptions(),
+): string {
+  const portablePath = join(
+    options.desktopRoot,
+    'dist',
+    `DSH-Desktop-${options.version}-x64-Portable.zip`,
+  )
+  const stat = statSync(portablePath)
+  if (!stat.isFile() || stat.size === 0) {
+    throw new Error(`Windows portable archive is not a non-empty regular file: ${portablePath}`)
+  }
+  const archive = new AdmZip(portablePath)
+  const entries = archive.getEntries().filter(entry => !entry.isDirectory)
+  const executable = entries.find(entry => entry.entryName.replaceAll('\\', '/') === 'DSH Desktop.exe')
+  if (executable === undefined) {
+    throw new Error(`Windows portable archive is missing DSH Desktop.exe: ${portablePath}`)
+  }
+  if (!entries.some(entry => entry.entryName.replaceAll('\\', '/') === 'resources/app.asar')) {
+    throw new Error(`Windows portable archive is missing resources/app.asar: ${portablePath}`)
+  }
+  assertPortableExecutableBuffer(
+    executable.getData(),
+    'Windows portable application',
+    `${portablePath}:DSH Desktop.exe`,
+  )
+  return portablePath
+}
+
+const invokedPath = process.argv[1]
+if (invokedPath !== undefined && resolve(invokedPath) === fileURLToPath(import.meta.url)) {
+  try {
+    console.log(`Windows portable verification passed: ${verifyWindowsPortable()}`)
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error))
+    process.exitCode = 1
+  }
+}

--- a/dsh-plugin-desktop/tests/package-win.spec.ts
+++ b/dsh-plugin-desktop/tests/package-win.spec.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import {
+  packageWindowsArtifact,
   packageWindowsInstaller,
   type WindowsPackageOptions,
 } from '../scripts/package-win.ts'
@@ -83,6 +84,34 @@ describe('Windows x64 installer packaging', () => {
     })
     expect(logs).toEqual([
       'Building an unsigned Windows x64 installer; Authenticode is a separate release step.',
+    ])
+  })
+
+  it('checks without credentials, builds an unsigned portable ZIP target, then verifies it', () => {
+    const calls: CommandCall[] = []
+    const logs: string[] = []
+    const value = {
+      ...options(calls, logs),
+      verifier: 'C:\\repo\\dsh-plugin-desktop\\scripts\\verify-win-portable.ts',
+    }
+
+    packageWindowsArtifact(value, 'zip', 'portable archive')
+
+    expect(calls[1]?.args).toEqual([
+      'C:\\repo\\node_modules\\electron-builder\\cli.js',
+      '--win',
+      'zip',
+      '--x64',
+      '--publish',
+      'never',
+      '--config.win.signExecutable=false',
+      '--config.npmRebuild=false',
+    ])
+    expect(calls[2]?.args).toEqual([
+      'C:\\repo\\dsh-plugin-desktop\\scripts\\verify-win-portable.ts',
+    ])
+    expect(logs).toEqual([
+      'Building an unsigned Windows x64 portable archive; Authenticode is a separate release step.',
     ])
   })
 

--- a/dsh-plugin-desktop/tests/package.spec.ts
+++ b/dsh-plugin-desktop/tests/package.spec.ts
@@ -30,8 +30,9 @@ const manifest = JSON.parse(readFileSync(new URL('package.json', packageRoot), '
       target?: unknown
       x64ArchFiles?: unknown
     }
-    win?: { icon?: unknown; target?: unknown }
+    win?: { icon?: unknown; target?: unknown; artifactName?: unknown }
     nsis?: Record<string, unknown>
+    portable?: Record<string, unknown>
     linux?: { icon?: unknown }
   }
   dependencies?: Record<string, unknown>
@@ -252,6 +253,7 @@ describe('published package surface', () => {
       target: 'nsis',
       arch: ['x64'],
     }])
+    expect(manifest.build?.win?.artifactName).toBe('DSH-Desktop-${version}-${arch}-Portable.${ext}')
     expect(manifest.build?.nsis).toEqual({
       license: 'THIRD_PARTY_NOTICES.md',
       oneClick: false,
@@ -277,9 +279,11 @@ describe('published package surface', () => {
     expect(manifest.scripts?.['dist:mac']).toBe('node scripts/release-mac.ts')
     expect(manifest.scripts?.['dist:mac-smoke']).toBe('node scripts/package-mac.ts')
     expect(manifest.scripts?.['dist:win']).toBe('node scripts/package-win.ts')
+    expect(manifest.scripts?.['dist:win-portable']).toBe('node scripts/package-win-portable.ts')
     expect(manifest.scripts?.['check:win-package']).toContain('yarn run build')
     expect(manifest.scripts?.['check:win-package']).toContain('yarn run typecheck')
     expect(manifest.scripts?.['check:win-package']).toContain('tests/package-win.spec.ts')
+    expect(manifest.scripts?.['check:win-package']).toContain('tests/verify-win-portable.spec.ts')
     expect(manifest.scripts?.['check:win-package']).toContain('tests/update-checker.spec.ts')
     expect(manifest.scripts?.['check:win-package']).toContain('tests/update-download.spec.ts')
     expect(manifest.scripts?.['check:win-package']).toContain('tests/windows-volume-diagnostics.spec.ts')
@@ -293,6 +297,8 @@ describe('published package surface', () => {
       .toBe('yarn workspace dsh-community-market build && yarn workspace dsh-plugin-desktop dist:mac-smoke')
     expect(workspaceManifest.scripts?.['dist:win'])
       .toBe('yarn workspace dsh-community-market build && yarn workspace dsh-plugin-desktop dist:win')
+    expect(workspaceManifest.scripts?.['dist:win-portable'])
+      .toBe('yarn workspace dsh-community-market build && yarn workspace dsh-plugin-desktop dist:win-portable')
     expect(manifest.build?.afterPack).toBe('./scripts/verify-packaged-runtime.ts')
     expect(manifest.build?.mac).toEqual(expect.objectContaining({
       hardenedRuntime: true,
@@ -317,6 +323,7 @@ describe('published package surface', () => {
 
     expect(windowsJob).toContain('- run: yarn check')
     expect(windowsJob).toContain('- run: yarn dist:win')
+    expect(windowsJob).toContain('- run: yarn dist:win-portable')
     expect(windowsJob).not.toContain('yarn workspace dsh-plugin-desktop dist:win')
     expect(macosJob).toContain('- run: yarn workspace dsh-community-market check')
     expect(macosJob).toContain('- run: yarn dist:mac-smoke')

--- a/dsh-plugin-desktop/tests/verify-win-portable.spec.ts
+++ b/dsh-plugin-desktop/tests/verify-win-portable.spec.ts
@@ -1,0 +1,61 @@
+import { mkdirSync, mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import AdmZip from 'adm-zip'
+import { afterEach, describe, expect, it } from 'vitest'
+import { verifyWindowsPortable } from '../scripts/verify-win-portable.ts'
+
+const temporaryRoots: string[] = []
+
+function portableExecutable(): Buffer {
+  const executable = Buffer.alloc(132)
+  executable.write('MZ', 0, 'ascii')
+  executable.writeUInt32LE(128, 0x3c)
+  executable.write('PE\0\0', 128, 'binary')
+  return executable
+}
+
+function fixture(version = '2.0.0'): { readonly root: string; readonly portable: string } {
+  const root = mkdtempSync(join(tmpdir(), 'dsh-win-portable-'))
+  temporaryRoots.push(root)
+  const dist = join(root, 'dist')
+  mkdirSync(dist, { recursive: true })
+  const portable = join(dist, `DSH-Desktop-${version}-x64-Portable.zip`)
+  const archive = new AdmZip()
+  archive.addFile('DSH Desktop.exe', portableExecutable())
+  archive.addFile('resources/app.asar', Buffer.from('asar'))
+  archive.writeZip(portable)
+  return { root, portable }
+}
+
+afterEach(() => {
+  for (const root of temporaryRoots.splice(0)) rmSync(root, { recursive: true, force: true })
+})
+
+describe('Windows portable artifact verification', () => {
+  it('accepts the exact versioned portable ZIP archive', () => {
+    const value = fixture()
+
+    expect(verifyWindowsPortable({ desktopRoot: value.root, version: '2.0.0' })).toBe(value.portable)
+  })
+
+  it('rejects a stale portable archive from a different version', () => {
+    const value = fixture('1.9.0')
+
+    expect(() => verifyWindowsPortable({ desktopRoot: value.root, version: '2.0.0' }))
+      .toThrow('DSH-Desktop-2.0.0-x64-Portable.zip')
+  })
+
+  it('rejects an application entry without a Windows PE header', () => {
+    const value = fixture()
+    const invalid = portableExecutable()
+    invalid.write('NO', 0, 'ascii')
+    const archive = new AdmZip()
+    archive.addFile('DSH Desktop.exe', invalid)
+    archive.addFile('resources/app.asar', Buffer.from('asar'))
+    archive.writeZip(value.portable)
+
+    expect(() => verifyWindowsPortable({ desktopRoot: value.root, version: '2.0.0' }))
+      .toThrow('does not have a Windows PE header')
+  })
+})

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "dist:mac": "yarn workspace dsh-community-market build && yarn workspace dsh-plugin-desktop dist:mac",
     "dist:mac-smoke": "yarn workspace dsh-community-market build && yarn workspace dsh-plugin-desktop dist:mac-smoke",
     "dist:win": "yarn workspace dsh-community-market build && yarn workspace dsh-plugin-desktop dist:win",
+    "dist:win-portable": "yarn workspace dsh-community-market build && yarn workspace dsh-plugin-desktop dist:win-portable",
     "upstream:version": "cd deepseek-harness && corepack pnpm --version",
     "upstream:install": "cd deepseek-harness && corepack pnpm install --frozen-lockfile",
     "upstream:build": "cd deepseek-harness && corepack pnpm run build"


### PR DESCRIPTION
## Summary\n- add a Windows portable ZIP artifact that runs after extraction without an installer\n- verify the portable package contents in the desktop package checks\n- document build and usage instructions\n\n## Validation\n- corepack yarn workspace dsh-plugin-desktop check:win-package\n- desktop workspace typecheck\n- manual extraction and launch of DSH Desktop.exe on Windows\n\nThe resulting artifact is DSH-Desktop-2.0.1-x64-Portable.zip.