### PR TITLE
test(repo): include market workspace in root test

### DIFF
--- a/dsh-plugin-desktop/tests/package.spec.ts
+++ b/dsh-plugin-desktop/tests/package.spec.ts
@@ -52,6 +52,11 @@ describe('published package surface', () => {
       .toBe('yarn workspace dsh-plugin-desktop typecheck && yarn workspace dsh-community-market typecheck')
   })
 
+  it('runs desktop and community market tests from the root command', () => {
+    expect(workspaceManifest.scripts?.test)
+      .toBe('yarn workspace dsh-plugin-desktop test && yarn workspace dsh-community-market test')
+  })
+
   it('registers both npm launcher names', () => {
     expect(manifest.name).toBe('dsh-plugin-desktop')
     expect(manifest.bin).toEqual({

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
   "scripts": {
     "build": "yarn workspace dsh-community-market build && yarn workspace dsh-plugin-desktop build",
     "typecheck": "yarn workspace dsh-plugin-desktop typecheck && yarn workspace dsh-community-market typecheck",
-    "test": "yarn workspace dsh-plugin-desktop test",
+    "test": "yarn workspace dsh-plugin-desktop test && yarn workspace dsh-community-market test",
     "check:layout": "node scripts/verify-layout.mjs",
     "check": "yarn check:layout && yarn workspace dsh-community-fabric check && yarn workspace dsh-community-market check && yarn workspace dsh-plugin-desktop check",
     "dev": "yarn workspace dsh-community-market build && yarn workspace dsh-plugin-desktop dev",


### PR DESCRIPTION
## Summary
- run desktop and community-market tests from the root yarn test command
- add a package contract assertion for the root test wiring

## Verification
- corepack yarn test
- corepack yarn workspace dsh-plugin-desktop typecheck