### PR TITLE
test(repo): cover market client contracts

### DIFF
--- a/dsh-community-market/tests/client-index.spec.ts
+++ b/dsh-community-market/tests/client-index.spec.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('@deepseek-ai/dsh-client-ui-primitives', () => {
+  const component = () => null
+  return {
+    Button: component,
+    Input: component,
+    Modal: component,
+    Tooltip: component,
+    IconCheckOutline16: component,
+    IconCloseOutline16: component,
+    IconCordisPluginOutline14: component,
+    IconDataOutline16: component,
+    IconGlobeOutline14: component,
+    IconLoadingOutline16: component,
+    IconPlusOutline16: component,
+    IconRefreshOutline16: component,
+    IconRightUpOutline16: component,
+    IconSearchOutline16: component,
+    IconSettingsOutline16: component,
+    IconTrashOutline16: component,
+    IconWarningOutline16: component,
+  }
+})
+
+import { apply, inject, NS } from '../src/client/index.js'
+
+interface TestContext {
+  readonly effects: Array<{ effect: () => unknown; label: string }>
+  readonly injections: Array<{ name: string; factory: () => unknown }>
+  readonly registrations: Array<{ spec: Record<string, unknown>; component: unknown }>
+  readonly context: Parameters<typeof apply>[0]
+}
+
+function testContext(): TestContext {
+  const effects: TestContext['effects'] = []
+  const injections: TestContext['injections'] = []
+  const registrations: TestContext['registrations'] = []
+  const context = {
+    effect: (effect: () => unknown, label: string) => { effects.push({ effect, label }) },
+    locale: {
+      register: vi.fn(),
+      bind: vi.fn(() => vi.fn()),
+      getLocale: vi.fn(() => ({ active: 'en' })),
+    },
+    slots: {
+      inject: (name: string, factory: () => unknown) => { injections.push({ name, factory }) },
+      register: (spec: Record<string, unknown>, component: unknown) => {
+        registrations.push({ spec, component })
+        return spec
+      },
+    },
+  } as unknown as Parameters<typeof apply>[0]
+  return { effects, injections, registrations, context }
+}
+
+describe('community market client registration', () => {
+  it('publishes the expected Loader dependency contract', () => {
+    expect(inject).toEqual(['slots', 'locale'])
+    expect(NS).toBe('community-market')
+  })
+
+  it('registers locale, styles, sidebar launcher, and shell overlay effects', () => {
+    const test = testContext()
+
+    apply(test.context)
+
+    expect(test.effects.map(value => value.label)).toEqual([
+      'community-market: dictionaries',
+      'community-market: styles',
+    ])
+    expect(test.injections.map(value => value.name)).toEqual([
+      'sidebar.footer.action',
+      'shell.overlay',
+    ])
+  })
+
+  it('projects both slot registrations with the market identity and locale', () => {
+    const test = testContext()
+
+    apply(test.context)
+    test.injections.forEach(value => { value.factory() })
+
+    expect(test.registrations).toHaveLength(2)
+    expect(test.registrations.map(value => value.spec)).toEqual([
+      expect.objectContaining({
+        name: 'sidebar.footer.action',
+        id: 'community-market',
+        order: 10,
+        locale: NS,
+      }),
+      expect.objectContaining({
+        name: 'shell.overlay',
+        id: 'community-market',
+        order: 10,
+        locale: NS,
+      }),
+    ])
+    expect(test.registrations.every(value => typeof value.spec.inject === 'function')).toBe(true)
+  })
+})

--- a/dsh-plugin-desktop/tests/package.spec.ts
+++ b/dsh-plugin-desktop/tests/package.spec.ts
@@ -47,6 +47,11 @@ const workspaceManifest = JSON.parse(readFileSync(new URL('package.json', worksp
 const ciWorkflow = readFileSync(new URL('.github/workflows/ci.yml', workspaceRoot), 'utf8')
 
 describe('published package surface', () => {
+  it('runs desktop and community market typechecks from the root command', () => {
+    expect(workspaceManifest.scripts?.typecheck)
+      .toBe('yarn workspace dsh-plugin-desktop typecheck && yarn workspace dsh-community-market typecheck')
+  })
+
   it('registers both npm launcher names', () => {
     expect(manifest.name).toBe('dsh-plugin-desktop')
     expect(manifest.bin).toEqual({

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
   },
   "scripts": {
     "build": "yarn workspace dsh-community-market build && yarn workspace dsh-plugin-desktop build",
-    "typecheck": "yarn workspace dsh-plugin-desktop typecheck",
+    "typecheck": "yarn workspace dsh-plugin-desktop typecheck && yarn workspace dsh-community-market typecheck",
     "test": "yarn workspace dsh-plugin-desktop test",
     "check:layout": "node scripts/verify-layout.mjs",
     "check": "yarn check:layout && yarn workspace dsh-community-fabric check && yarn workspace dsh-community-market check && yarn workspace dsh-plugin-desktop check",


### PR DESCRIPTION
## Summary
- include the community market workspace in the root typecheck command
- cover community market Loader registration and slot contracts

## Verification
- corepack yarn typecheck
- corepack yarn workspace dsh-community-market vitest run
- corepack yarn workspace dsh-plugin-desktop vitest run tests/package.spec.ts