### PR TITLE
fix(profile): reject duplicate loader entry ids

### DIFF
--- a/dsh-plugin-desktop/src/profile.ts
+++ b/dsh-plugin-desktop/src/profile.ts
@@ -265,6 +265,22 @@ function rowDisabledOnPlatform(row: EntryOptions, platform: NodeJS.Platform): bo
   return Boolean(evaluate({ process: scopedProcess }, row.disabled.__jsExpr))
 }
 
+/** Reject duplicate entries before the Loader turns them into a startup crash. */
+function assertUniqueEntryIds(rows: readonly EntryOptions[]): void {
+  const seen = new Set<string>()
+  for (const row of rows) {
+    if (typeof row.id === 'string') {
+      if (seen.has(row.id)) {
+        throw new Error(`${BIN_NAME}: duplicate loader entry id "${row.id}" in the composed profile`)
+      }
+      seen.add(row.id)
+    }
+    if (row.group === true && Array.isArray(row.config)) {
+      assertUniqueEntryIds(row.config)
+    }
+  }
+}
+
 /** Find one package manifest using the selected profile's dependency graph. */
 function packageManifestFromProfile(name: string, profilePackageUrl: string): string | undefined {
   try {
@@ -370,8 +386,10 @@ export function prepareDesktopProfile(
     ...profile.patches,
     ...homePatches,
   ]
+  const composedRows = composeEntries([patches])
+  assertUniqueEntryIds(composedRows)
   const rows = new Map<string, EntryOptions>()
-  for (const row of composeEntries([patches])) {
+  for (const row of composedRows) {
     if (typeof row.id === 'string') rows.set(row.id, row)
   }
   const settings = rows.get('settings')

--- a/dsh-plugin-desktop/tests/profile.spec.ts
+++ b/dsh-plugin-desktop/tests/profile.spec.ts
@@ -44,6 +44,16 @@ function installWebClient(
   return webDir
 }
 
+function installBundle(home: string, packageName: string, patch: string): void {
+  const bundleDir = join(home, 'profiles', 'desktop', 'node_modules', packageName)
+  mkdirSync(bundleDir, { recursive: true })
+  writeFileSync(join(bundleDir, 'package.json'), JSON.stringify({
+    name: packageName,
+    dsh: { bundle: { patch: './cordis.patch.yml' } },
+  }) + '\n')
+  writeFileSync(join(bundleDir, 'cordis.patch.yml'), patch)
+}
+
 afterEach(() => {
   for (const home of homes.splice(0)) rmSync(home, { recursive: true, force: true })
 })
@@ -390,6 +400,35 @@ describe('desktop profile composition', {
       disabled: { __jsExpr: "process.platform !== 'win32'" },
       config: { cwd: 'C:\\workspace' },
     }))
+  })
+
+  it('rejects a bundle and user patch that register the same loader entry id', () => {
+    const home = temporaryHome()
+    const packageName = 'dsh-usage-stats'
+    const bundlePatch = [
+      '- insert:',
+      '    - id: usage-stats',
+      `      name: '${packageName}'`,
+      '',
+    ].join('\n')
+    installBundle(home, packageName, bundlePatch)
+    const profileDir = join(home, 'profiles', 'desktop')
+    writeFileSync(join(profileDir, 'package.json'), JSON.stringify({
+      name: 'dsh-profile-desktop',
+      private: true,
+      dependencies: {},
+      dsh: { profile: { bundles: ['@deepseek-ai/dsh-base', '@deepseek-ai/dsh-web-app', packageName] } },
+    }) + '\n')
+    writeFileSync(join(home, 'cordis.patch.yml'), [
+      '- insert:',
+      '    - id: usage-stats',
+      `      name: '${packageName}'`,
+      '',
+    ].join('\n'))
+
+    expect(() => prepareDesktopProfile(undefined, home, 'win32')).toThrow(
+      'duplicate loader entry id "usage-stats" in the composed profile',
+    )
   })
 
   it('keeps a Web Client in its owning profile and omits it from desktop', () => {


### PR DESCRIPTION
## Summary

- validate composed desktop profile entry IDs before Loader startup
- report the conflicting ID with a desktop-owned diagnostic
- cover duplicate registration across a bundle and user cordis.patch.yml

Fixes #179

## Verification

- corepack yarn vitest run tests/profile.spec.ts
- corepack yarn tsc -p tsconfig.json --noEmit
- git diff --check