### PR TITLE
feat(linux): package for Linux and support the tray terminal there

### DIFF
--- a/dsh-plugin-desktop/package.json
+++ b/dsh-plugin-desktop/package.json
@@ -114,6 +114,7 @@
     "dist:mac": "node scripts/release-mac.ts",
     "dist:mac-smoke": "node scripts/package-mac.ts",
     "dist:win": "node scripts/package-win.ts",
+    "dist:linux": "yarn run build && electron-builder --linux",
     "prepack": "yarn run check"
   },
   "dependencies": {
@@ -308,9 +309,22 @@
     },
     "linux": {
       "target": [
+        {
+          "target": "AppImage",
+          "arch": [
+            "x64"
+          ]
+        },
         "dir"
       ],
-      "icon": "build/app-icon.png"
+      "icon": "build/app-icon.png",
+      "category": "Development",
+      "synopsis": "Desktop shell for the DeepSeek Harness plugin ecosystem",
+      "desktop": {
+        "entry": {
+          "StartupWMClass": "DSH Desktop"
+        }
+      }
     }
   }
 }

--- a/dsh-plugin-desktop/src/desktop-terminal.ts
+++ b/dsh-plugin-desktop/src/desktop-terminal.ts
@@ -11,7 +11,7 @@ import {
   writeFileSync,
 } from 'node:fs'
 import { createHash, randomUUID } from 'node:crypto'
-import { basename, dirname, join, win32 } from 'node:path'
+import { basename, dirname, join, posix, win32 } from 'node:path'
 import { assertDesktopProfileName } from './profile-manager.ts'
 
 const RUN_AS_NODE = 'ELECTRON_RUN_AS_NODE'
@@ -47,9 +47,28 @@ const PRIVATE_FILE_MODE = 0o600
 const WINDOWS_SHELL_COMMANDS = ['pwsh.exe', 'powershell.exe', 'cmd.exe'] as const
 const WINDOWS_TERMINAL_COMMAND = 'wt.exe'
 const ELECTRON_HEADERS_URL = 'https://electronjs.org/headers'
+/**
+ * Linux terminal emulators probed in order, with the flag each one uses to take a
+ * program to run. There is no `open -a Terminal` equivalent on Linux and no single
+ * emulator is guaranteed present, so discovery walks PATH. `x-terminal-emulator`
+ * comes first because it is the Debian alternatives symlink pointing at whatever the
+ * user actually chose.
+ */
+const LINUX_TERMINAL_COMMANDS = [
+  { command: 'x-terminal-emulator', argument: '-e' },
+  { command: 'gnome-terminal', argument: '--' },
+  { command: 'konsole', argument: '-e' },
+  { command: 'xfce4-terminal', argument: '-x' },
+  { command: 'tilix', argument: '-e' },
+  { command: 'alacritty', argument: '-e' },
+  { command: 'kitty', argument: undefined },
+  { command: 'xterm', argument: '-e' },
+] as const
+/** Environment variables naming a preferred terminal, checked before PATH discovery. */
+const LINUX_TERMINAL_ENVIRONMENT_KEYS = ['DSH_TERMINAL', 'TERMINAL'] as const
 
 /** Platforms with a native terminal launch contract owned by DSH Desktop. */
-export type DesktopTerminalPlatform = 'darwin' | 'win32'
+export type DesktopTerminalPlatform = 'darwin' | 'linux' | 'win32'
 
 /** Process launcher injected by the Electron adapter. */
 export type DesktopTerminalSpawn = (
@@ -108,6 +127,10 @@ export interface DesktopTerminalOptions {
   windowsExecutableExists?: DesktopTerminalExecutableExists
   /** Windows executable resolver; defaults to a trusted PATH/SystemRoot lookup. */
   windowsExecutableResolver?: DesktopTerminalExecutableResolver
+  /** Linux executable existence probe; defaults to `existsSync`. */
+  linuxExecutableExists?: DesktopTerminalExecutableExists
+  /** Linux executable resolver; defaults to a PATH lookup. */
+  linuxExecutableResolver?: DesktopTerminalExecutableResolver
   /** Reporter attached before the platform launcher can emit an asynchronous failure. */
   onLaunchError?: (cause: Error) => void
 }
@@ -427,7 +450,7 @@ function windowsCmdWelcome(): string {
 
 /** Create command shims and the interactive welcome script. */
 function prepareDesktopTerminalFiles(options: DesktopTerminalOptions): DesktopTerminalFiles {
-  if (options.platform !== 'darwin' && options.platform !== 'win32') {
+  if (options.platform !== 'darwin' && options.platform !== 'linux' && options.platform !== 'win32') {
     throw new Error(`dsh-plugin-desktop: terminal is unsupported on ${options.platform}`)
   }
   assertDesktopProfileName(options.profileName)
@@ -445,13 +468,19 @@ function prepareDesktopTerminalFiles(options: DesktopTerminalOptions): DesktopTe
   prepareStateDirectory(options.stateDir)
   const shimDir = join(options.stateDir, 'bin')
   prepareStateDirectory(shimDir)
-  if (options.platform === 'darwin') {
+  // The generated shims and rc files are plain POSIX sh, so macOS and Linux share them
+  // verbatim; only the welcome script's extension differs, because `.command` is a
+  // macOS double-click convention that means nothing on Linux.
+  if (options.platform === 'darwin' || options.platform === 'linux') {
     const files: DesktopTerminalFiles = {
       shimDir,
       dshShimPath: join(shimDir, 'dsh'),
       pnpmShimPath: join(shimDir, 'pnpm'),
       nodeShimPath: join(shimDir, 'node'),
-      welcomePath: join(options.stateDir, 'welcome.command'),
+      welcomePath: join(
+        options.stateDir,
+        options.platform === 'darwin' ? 'welcome.command' : 'welcome.sh',
+      ),
     }
     const bashRcPath = join(options.stateDir, 'bashrc')
     replacePrivateFile(files.dshShimPath, macDshShim(options), EXECUTABLE_FILE_MODE)
@@ -564,6 +593,65 @@ interface ResolvedWindowsShell {
 }
 
 /** Resolve the preferred Windows Terminal host, preserving an explicit adapter. */
+/**
+ * Resolve one executable by walking PATH. Linux has no equivalent of `open -a`, so the
+ * launcher must find a concrete emulator binary itself.
+ * @param command - bare command name, or an absolute path to probe directly.
+ * @param environment - environment supplying PATH.
+ * @param exists - filesystem probe; production passes `existsSync`.
+ * @returns the resolved path, or `undefined` when the command is not on PATH.
+ */
+function defaultLinuxExecutableResolver(
+  command: string,
+  environment: Readonly<NodeJS.ProcessEnv>,
+  exists: DesktopTerminalExecutableExists,
+): string | undefined {
+  if (command.includes('/')) return exists(command) ? command : undefined
+  const search = environment[PATH]
+  if (search === undefined) return undefined
+  for (const directory of search.split(':')) {
+    if (directory === '') continue
+    const candidate = posix.join(directory, command)
+    if (exists(candidate)) return candidate
+  }
+  return undefined
+}
+
+/**
+ * Pick the terminal emulator used to host one desktop terminal session.
+ *
+ * `DSH_TERMINAL` and `TERMINAL` win when set, because a user who names an emulator
+ * has already answered the question better than discovery can. Otherwise the known
+ * emulators are probed in order. Each entry carries its own "run this program" flag;
+ * they are not interchangeable.
+ * @param options - launch options carrying the injectable probes.
+ * @param environment - environment supplying PATH and the override keys.
+ * @returns the emulator and the flag preceding the program, or `undefined` when none is installed.
+ */
+function resolveLinuxTerminal(
+  options: DesktopTerminalOptions,
+  environment: Readonly<NodeJS.ProcessEnv>,
+): { executable: string, argument?: string | undefined } | undefined {
+  const exists = options.linuxExecutableExists ?? existsSync
+  const resolve = options.linuxExecutableResolver ?? defaultLinuxExecutableResolver
+  for (const key of LINUX_TERMINAL_ENVIRONMENT_KEYS) {
+    const preferred = environment[key]
+    if (preferred === undefined || preferred === '') continue
+    const executable = resolve(preferred, environment, exists)
+    if (executable === undefined) continue
+    assertScriptValue(`${key} executable`, executable)
+    const known = LINUX_TERMINAL_COMMANDS.find(entry => entry.command === basename(preferred))
+    return { executable, argument: known?.argument ?? '-e' }
+  }
+  for (const entry of LINUX_TERMINAL_COMMANDS) {
+    const executable = resolve(entry.command, environment, exists)
+    if (executable === undefined) continue
+    assertScriptValue(`${entry.command} executable`, executable)
+    return { executable, argument: entry.argument }
+  }
+  return undefined
+}
+
 function resolveWindowsTerminal(
   options: DesktopTerminalOptions,
   environment: Readonly<NodeJS.ProcessEnv>,
@@ -694,6 +782,20 @@ export function openDesktopTerminal(options: DesktopTerminalOptions): DesktopTer
   if (options.platform === 'darwin') {
     command = '/usr/bin/open'
     args = ['-a', 'Terminal', files.welcomePath]
+  } else if (options.platform === 'linux') {
+    const terminal = resolveLinuxTerminal(options, env)
+    if (terminal === undefined) {
+      throw new Error(
+        'dsh-plugin-desktop: no terminal emulator found on PATH; '
+        + 'install one of x-terminal-emulator, gnome-terminal, konsole, xfce4-terminal, '
+        + 'tilix, alacritty, kitty or xterm, or set DSH_TERMINAL to the one you use',
+      )
+    }
+    command = terminal.executable
+    // kitty and friends take the program directly; the rest need their own flag first.
+    args = terminal.argument === undefined
+      ? [files.welcomePath]
+      : [terminal.argument, files.welcomePath]
   } else {
     const shell = resolveWindowsShell(options, env)
     const shellArgs = windowsShellArgv(shell, files)

--- a/dsh-plugin-desktop/src/terminal.ts
+++ b/dsh-plugin-desktop/src/terminal.ts
@@ -15,9 +15,6 @@ export const inject = ['desktopRuntime']
  * @param ctx - Host context carrying the Electron adapter.
  */
 export function apply(ctx: Context): void {
-  if (ctx.desktopRuntime.platform === 'linux') {
-    throw new Error('dsh-plugin-desktop: the packaged terminal is supported on macOS and Windows')
-  }
   ctx.effect(() => {
     const registration = ctx.desktopRuntime.registerTrayItem({
       group: 'tools',

--- a/dsh-plugin-desktop/tests/desktop-terminal.spec.ts
+++ b/dsh-plugin-desktop/tests/desktop-terminal.spec.ts
@@ -456,12 +456,57 @@ describe('desktop terminal environment', () => {
     }))
   })
 
+  it('discovers a Linux terminal emulator on PATH and hands it the welcome script', () => {
+    const harness = spawnHarness()
+    const options = macOptions(temporaryDirectory(), harness.spawn)
+    options.platform = 'linux'
+    // Only konsole exists here, so discovery must skip the higher-priority names
+    // rather than assuming the first candidate is installed.
+    options.linuxExecutableExists = (candidate: string) => candidate === '/usr/bin/konsole'
+
+    openDesktopTerminal(options)
+
+    expect(harness.calls).toHaveLength(1)
+    expect(harness.calls[0]?.command).toBe('/usr/bin/konsole')
+    expect(harness.calls[0]?.args).toEqual(['-e', join(options.stateDir, 'welcome.sh')])
+  })
+
+  it('prefers the emulator named by DSH_TERMINAL over PATH discovery', () => {
+    const harness = spawnHarness()
+    const options = macOptions(temporaryDirectory(), harness.spawn)
+    options.platform = 'linux'
+    options.environment = { ...options.environment, DSH_TERMINAL: 'alacritty' }
+    // xterm is present too; the explicit preference must still win.
+    options.linuxExecutableExists = (candidate: string) =>
+      candidate === '/usr/bin/alacritty' || candidate === '/usr/bin/xterm'
+
+    openDesktopTerminal(options)
+
+    expect(harness.calls[0]?.command).toBe('/usr/bin/alacritty')
+    expect(harness.calls[0]?.args[0]).toBe('-e')
+  })
+
+  it('names the installable emulators when Linux has none on PATH', () => {
+    const harness = spawnHarness()
+    const options = macOptions(temporaryDirectory(), harness.spawn)
+    options.platform = 'linux'
+    options.linuxExecutableExists = () => false
+
+    // A bare "launch failed" would leave the user guessing; the message has to say
+    // what to install or which variable to set.
+    expect(() => openDesktopTerminal(options)).toThrow(/no terminal emulator found on PATH/)
+    expect(() => openDesktopTerminal(options)).toThrow(/DSH_TERMINAL/)
+    expect(harness.calls).toHaveLength(0)
+  })
+
   it('accepts localized macOS profile names and rejects path escapes before writing state', () => {
     const root = temporaryDirectory()
     const harness = spawnHarness()
     const unsupported = macOptions(join(root, 'unsupported'), harness.spawn)
-    unsupported.platform = 'linux'
-    expect(() => openDesktopTerminal(unsupported)).toThrow('terminal is unsupported on linux')
+    // Linux is supported now, so the unsupported-platform guard is exercised with a
+    // platform the launcher genuinely has no contract for.
+    unsupported.platform = 'freebsd' as DesktopTerminalOptions['platform']
+    expect(() => openDesktopTerminal(unsupported)).toThrow('terminal is unsupported on freebsd')
     expect(() => lstatSync(unsupported.stateDir)).toThrow()
 
     const unsafe = macOptions(join(root, 'unsafe'), harness.spawn)

--- a/dsh-plugin-desktop/tests/terminal.spec.ts
+++ b/dsh-plugin-desktop/tests/terminal.spec.ts
@@ -42,11 +42,22 @@ describe('desktop terminal Host plugin', () => {
     expect(disposeRegistration).toHaveBeenCalledOnce()
   })
 
-  it('fails loud if a Linux profile activates the unsupported terminal row', () => {
+  it('registers the tray command on Linux like the other desktop platforms', () => {
+    let registered = false
     const ctx = {
-      desktopRuntime: { platform: 'linux' },
+      desktopRuntime: {
+        platform: 'linux',
+        locale: 'en',
+        registerTrayItem: () => {
+          registered = true
+          return { dispose: () => {} }
+        },
+        openTerminal: () => {},
+      },
+      effect: (factory: () => () => void) => { factory() },
     } as unknown as Context
 
-    expect(() => apply(ctx)).toThrow('supported on macOS and Windows')
+    expect(() => apply(ctx)).not.toThrow()
+    expect(registered).toBe(true)
   })
 })

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "dist:mac": "yarn workspace dsh-community-market build && yarn workspace dsh-plugin-desktop dist:mac",
     "dist:mac-smoke": "yarn workspace dsh-community-market build && yarn workspace dsh-plugin-desktop dist:mac-smoke",
     "dist:win": "yarn workspace dsh-community-market build && yarn workspace dsh-plugin-desktop dist:win",
+    "dist:linux": "yarn workspace dsh-community-market build && yarn workspace dsh-plugin-desktop dist:linux",
     "upstream:version": "cd deepseek-harness && corepack pnpm --version",
     "upstream:install": "cd deepseek-harness && corepack pnpm install --frozen-lockfile",
     "upstream:build": "cd deepseek-harness && corepack pnpm run build"


### PR DESCRIPTION
## What this does

DSH Desktop already treats Linux as a first-class runtime platform — the `DesktopPlatform` union, the renderer's platform whitelist, and the whole of `desktop-runtime-environment.ts` handle it — but there was no way to ship a Linux build, and the tray terminal refused to start on it. This adds both.

### Packaging

- `build.linux` gains an AppImage target alongside the existing `dir`, plus the category and `StartupWMClass` a desktop entry needs.
- New `dist:linux` script in both the workspace root and the plugin, mirroring `dist:mac` / `dist:win`.
- That script runs `build` first. Without it the packaged `app.asar` is missing every `lib/*.js` and `verify-packaged-runtime` rejects the pack — worth knowing for anyone adding a target later.
- **deb is deliberately left out.** It requires a maintainer identity (`author.email`) that belongs to the project rather than to this patch. It is one field away for whoever wants it.

### Terminal

`src/terminal.ts` threw on Linux, so the tray command could never register.

- The generated shims and rc files are already plain POSIX sh, so Linux reuses the macOS ones verbatim. Only the welcome script's extension differs, because `.command` is a macOS double-click convention.
- Linux has no `open -a Terminal` equivalent and no emulator that is guaranteed present, so the launcher resolves one itself: `DSH_TERMINAL` and `TERMINAL` win when set, otherwise a known list is probed on PATH. `x-terminal-emulator` comes first because on Debian it points at whatever the user actually chose. Each emulator carries its own "run this program" flag; they are not interchangeable.
- When nothing is found, the error names the emulators to install and the variable to set, instead of failing as an opaque launch error.
- Discovery probes are injectable (`linuxExecutableExists`, `linuxExecutableResolver`) following the existing Windows pattern, so they are testable off-platform.

### Tests

The two cases that asserted Linux was unsupported now assert the new behaviour, with the unsupported-platform guard exercised through `freebsd` instead. Three new cases cover PATH discovery skipping absent emulators, the `DSH_TERMINAL` override winning over discovery, and the actionable error when no emulator exists.

## What I verified, and what I did not

Verified on Ubuntu 24.04 / x64:

- `yarn dist:linux` completes and produces a 180 MB AppImage plus `linux-unpacked`.
- `yarn typecheck` clean.
- Full suite green: 48 files, 430 passed, 4 skipped.

**Not verified: the packaged app actually launching.** On my machine every Electron GUI start ends in `SIGTRAP` with no log output. That is not caused by this patch — the same binary crashes identically when pointed at a two-line hello-world Electron app, with `chrome-sandbox` correctly `root:4755` and all shared libraries present. I could not isolate it further and did not want to hide it behind a plausible-sounding guess. If a maintainer with a working Linux Electron environment can smoke-test the artifact, that is the one gap in this change.

## Out of scope

- **Auto-update on Linux.** `update-download.ts` hardcodes `dmg`/`exe` with no `else` branch, so it would fetch a `-windows.exe`. Fixing it needs published Linux artifacts and a download endpoint, which is a project decision rather than a patch.
- **`advanced` shell mode.** Still gated off on Linux. `compatibility` mode — the one that loads the official DSH Web UI — works, and enabling native chrome customization on a platform upstream has never run it on seemed like the wrong thing to do from the outside.