### PR TITLE
fix(desktop): run the Windows ACL runner in a vendored Node, not RunAsNode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@ node_modules/
 dsh-plugin-desktop/dist/
 dsh-plugin-desktop/lib/
 dsh-community-market/lib/
+
+# Vendored Windows Node runtime (fetched by vendor:node:win at build time)
+/dsh-plugin-desktop/vendor/node/

--- a/dsh-plugin-desktop/THIRD_PARTY_NOTICES.md
+++ b/dsh-plugin-desktop/THIRD_PARTY_NOTICES.md
@@ -530,4 +530,5 @@ the package names, versions, and licenses for transparency.
 | zod-to-json-schema | 3.25.2 | ISC |
 | zustand | 4.4.7 | MIT |
 | zwitch | 2.0.4 | MIT |
+| Node.js (vendored runtime for the Windows ACL runner) | 22.23.2 | MIT (see resources/node-license/LICENSE) |
 > Notice-required licenses in use: LGPL-3.0-or-later. Their license texts ship inside node_modules; see the package LICENSE files for the full terms.

--- a/dsh-plugin-desktop/package.json
+++ b/dsh-plugin-desktop/package.json
@@ -110,7 +110,7 @@
     "verify:licenses": "node scripts/verify-licenses.mjs",
     "verify:notices": "node scripts/verify-licenses.mjs --notices THIRD_PARTY_NOTICES.md",
     "check": "yarn run build && yarn run typecheck && yarn run test && yarn run verify:closure && yarn run verify:cli && yarn run verify:loader && yarn run verify:profile && yarn run verify:licenses",
-    "check:win-package": "yarn run build && yarn run typecheck && vitest run tests/package.spec.ts tests/package-win.spec.ts tests/update-checker.spec.ts tests/update-download.spec.ts tests/verify-win-installer.spec.ts tests/verify-win-portable.spec.ts tests/verify-packaged-runtime.spec.ts tests/windows-agent-presets.spec.ts tests/windows-pwsh-sandbox.spec.ts tests/windows-volume-diagnostics.spec.ts tests/window-options.spec.ts && yarn run verify:closure",
+    "check:win-package": "yarn run vendor:node:win && yarn run build && yarn run typecheck && vitest run tests/package.spec.ts tests/package-win.spec.ts tests/update-checker.spec.ts tests/update-download.spec.ts tests/verify-win-installer.spec.ts tests/verify-win-portable.spec.ts tests/verify-packaged-runtime.spec.ts tests/windows-agent-presets.spec.ts tests/windows-pwsh-sandbox.spec.ts tests/windows-volume-diagnostics.spec.ts tests/window-options.spec.ts && yarn run verify:closure",
     "check:mac-package": "yarn run -T check",
     "start": "node lib/bin.js",
     "dev": "yarn run build && node lib/bin.js",
@@ -119,7 +119,8 @@
     "dist:mac-smoke": "node scripts/package-mac.ts",
     "dist:win": "node scripts/package-win.ts",
     "dist:win-portable": "node scripts/package-win-portable.ts",
-    "prepack": "yarn run check"
+    "prepack": "yarn run check",
+    "vendor:node:win": "node scripts/vendor-node-win.mjs"
   },
   "dependencies": {
     "@deepseek-ai/cordis": "4.0.1",
@@ -297,7 +298,17 @@
         }
       ],
       "artifactName": "DSH-Desktop-${version}-${arch}-Portable.${ext}",
-      "icon": "build/app-icon.png"
+      "icon": "build/app-icon.png",
+      "extraResources": [
+        {
+          "from": "vendor/node/node.exe",
+          "to": "node.exe"
+        },
+        {
+          "from": "vendor/node/LICENSE",
+          "to": "node-license/LICENSE"
+        }
+      ]
     },
     "nsis": {
       "license": "THIRD_PARTY_NOTICES.md",

--- a/dsh-plugin-desktop/scripts/vendor-node-win.mjs
+++ b/dsh-plugin-desktop/scripts/vendor-node-win.mjs
@@ -1,0 +1,116 @@
+/** Fetch the vendored Windows Node executable and its LICENSE for the ACL runner. */
+
+import { existsSync, mkdirSync, readFileSync, renameSync, rmSync, writeFileSync } from 'node:fs'
+import { createHash } from 'node:crypto'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { execFileSync } from 'node:child_process'
+
+const NODE_VERSION = '22.23.2'
+const VENDOR_DIR = join(dirname(fileURLToPath(import.meta.url)), '..', 'vendor', 'node')
+const EXECUTABLE = join(VENDOR_DIR, 'node.exe')
+const LICENSE_FILE = join(VENDOR_DIR, 'LICENSE')
+// SHA-256 of the extracted node.exe from the official win-x64 zip.
+const NODE_EXE_SHA256 = '0d0f5e39f9f3d9587bc19f73eab3c2c9c4903fd02d6dbf9c853dd81b3d95fad4'
+const FETCH_TIMEOUT_MS = 120_000
+
+const SOURCES = [
+  `https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-win-x64.zip`,
+  `https://npmmirror.com/mirrors/node/v${NODE_VERSION}/node-v${NODE_VERSION}-win-x64.zip`,
+]
+
+function fail(message) {
+  console.error(`[vendor-node-win] ${message}`)
+  process.exitCode = 1
+}
+
+function sha256Of(file) {
+  return createHash('sha256').update(readFileSync(file)).digest('hex')
+}
+
+async function fetchZip(url) {
+  const controller = new AbortController()
+  const timer = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS)
+  try {
+    const response = await fetch(url, { redirect: 'follow', signal: controller.signal })
+    if (!response.ok || response.body === null) throw new Error(`HTTP ${response.status}`)
+    const chunks = []
+    for await (const chunk of response.body) chunks.push(Buffer.from(chunk))
+    return Buffer.concat(chunks)
+  } finally {
+    clearTimeout(timer)
+  }
+}
+
+/** Verify the extractor toolchain before any network work. */
+function preflight() {
+  try {
+    execFileSync('python', ['--version'], { stdio: 'ignore' })
+  } catch {
+    fail('python is required on PATH to extract the Node zip (unzip via Python zipfile)')
+    throw new Error('preflight failed')
+  }
+}
+
+async function main() {
+  if (existsSync(EXECUTABLE) && existsSync(LICENSE_FILE)
+    && sha256Of(EXECUTABLE) === NODE_EXE_SHA256) {
+    console.log('[vendor-node-win] node.exe already vendored (sha256 ok)')
+    return
+  }
+  preflight()
+  mkdirSync(VENDOR_DIR, { recursive: true })
+
+  const zipPath = join(VENDOR_DIR, `node-v${NODE_VERSION}-win-x64.zip`)
+  let zipBuffer
+  let lastError
+  for (const source of SOURCES) {
+    try {
+      console.log(`[vendor-node-win] downloading ${source}`)
+      zipBuffer = await fetchZip(source)
+      lastError = undefined
+      break
+    } catch (cause) {
+      lastError = cause
+      console.error(`[vendor-node-win] source failed: ${source}: ${cause instanceof Error ? cause.message : String(cause)}`)
+    }
+  }
+  if (zipBuffer === undefined) {
+    fail(`all sources failed: ${lastError instanceof Error ? lastError.message : String(lastError)}`)
+    throw new Error('download failed')
+  }
+  writeFileSync(zipPath, zipBuffer)
+
+  console.log('[vendor-node-win] extracting node.exe and LICENSE')
+  const entry = `node-v${NODE_VERSION}-win-x64/node.exe`
+  const licenseEntry = `node-v${NODE_VERSION}-win-x64/LICENSE`
+  const extractScript = [
+    'import zipfile, sys, pathlib',
+    'z = zipfile.ZipFile(sys.argv[1])',
+    'out = pathlib.Path(sys.argv[2])',
+    'out.parent.mkdir(parents=True, exist_ok=True)',
+    'out.write_bytes(z.read(sys.argv[3]))',
+    'print("extracted")',
+  ].join('; ')
+  const extractedExe = join(VENDOR_DIR, 'node-extracted.exe')
+  execFileSync('python', ['-c', extractScript, zipPath, extractedExe, entry])
+  execFileSync('python', ['-c', extractScript, zipPath, LICENSE_FILE, licenseEntry])
+  if (!existsSync(extractedExe) || !existsSync(LICENSE_FILE)) {
+    fail('extracted node.exe or LICENSE not found')
+    throw new Error('extraction failed')
+  }
+  renameSync(extractedExe, EXECUTABLE)
+  rmSync(zipPath, { force: true })
+
+  const digest = sha256Of(EXECUTABLE)
+  if (digest !== NODE_EXE_SHA256) {
+    rmSync(EXECUTABLE, { force: true })
+    fail(`checksum mismatch: got ${digest}, want ${NODE_EXE_SHA256}`)
+    throw new Error('checksum mismatch')
+  }
+  console.log('[vendor-node-win] vendored node.exe and LICENSE (sha256 ok)')
+}
+
+main().catch(error => {
+  fail(error instanceof Error ? error.message : String(error))
+})

--- a/dsh-plugin-desktop/scripts/verify-licenses.mjs
+++ b/dsh-plugin-desktop/scripts/verify-licenses.mjs
@@ -149,6 +149,9 @@ if (noticesArg !== -1) {
     ...manifests
       .sort((a, b) => a.name.localeCompare(b.name))
       .map(entry => `| ${entry.name} | ${entry.version ?? ''} | ${entry.license} |`),
+    ...(existsSync(join(packageRoot, 'vendor', 'node', 'node.exe'))
+      ? ['| Node.js (vendored runtime for the Windows ACL runner) | 22.23.2 | MIT (see resources/node-license/LICENSE) |']
+      : []),
     '',
     noticeOnly.length === 0
       ? ''

--- a/dsh-plugin-desktop/src/windows-pwsh-sandbox.ts
+++ b/dsh-plugin-desktop/src/windows-pwsh-sandbox.ts
@@ -2,14 +2,29 @@
 
 import { fileURLToPath } from 'node:url'
 import { existsSync } from 'node:fs'
+import { spawnSync } from 'node:child_process'
 import { win32 } from 'node:path'
 import type { ShellExecSpec, ShellProcess, ShellRunResult } from '@deepseek-ai/dsh-shell'
 import { SandboxPwshExecutor } from '@deepseek-ai/dsh-pwsh-sandbox'
 import type { Config as PwshConfig } from '@deepseek-ai/dsh-pwsh-local'
+import { unpackedAsarPath } from './packaged-runtime-path.ts'
 
 const RUN_AS_NODE = 'ELECTRON_RUN_AS_NODE'
 const UPSTREAM_RUNNER = fileURLToPath(import.meta.resolve('@deepseek-ai/dsh-sandbox-windows-acl/runner'))
 const DESKTOP_TRAMPOLINE = fileURLToPath(new URL('./windows-acl-runner.js', import.meta.url))
+
+/**
+ * Relative extraResource name for the vendored Node executable shipped beside
+ * the packaged app (`resources/node.exe`). Running the ACL runner inside the
+ * ELECTRON_RUN_AS_NODE process produces restricted tokens whose children all
+ * die with 0xC0000142 during DLL init (issue #203); a standalone Node keeps
+ * the runner outside that process and the sandbox behaves identically to the
+ * CLI. The trampoline remains only for unpackaged development, where no
+ * vendored Node exists and the known-broken path is logged.
+ */
+const VENDORED_NODE_RESOURCE = 'node.exe'
+const VENDORED_NODE_PROBE_TIMEOUT_MS = 5_000
+const TRAMPOLINE_FALLBACK_WARNED = new Set<string>()
 
 /** Inputs controlling one exact ACL-runner argv rewrite. */
 export interface WindowsAclAdaptation {
@@ -19,17 +34,21 @@ export interface WindowsAclAdaptation {
   electron: boolean
   /** Current Electron executable path. */
   execPath: string
-  /** Resolved upstream ACL runner path. */
+  /** Resolved upstream ACL runner path (logical ASAR path). */
   upstreamRunner: string
   /** Desktop-owned Node-mode trampoline path. */
   trampoline: string
+  /** Absolute vendored Node executable; undefined keeps the trampoline fallback. */
+  nodeExecutable?: string
+  /** Probe the vendored Node once (`-v`); injectable for tests. */
+  probe?: (path: string) => boolean
 }
 
 /** Adapted execution inputs passed to the ordinary local executor. */
 export interface AdaptedWindowsAclExecution {
-  /** Spec carrying the runner-only Electron environment. */
+  /** Spec carrying the runner-only environment. */
   spec: ShellExecSpec
-  /** Exact argv, with the desktop trampoline inserted when required. */
+  /** Exact argv, with the runner host selected (vendored Node or trampoline). */
   argv: readonly string[]
 }
 
@@ -62,11 +81,52 @@ export function desktopWindowsPwshConfig(
 }
 
 /**
- * Insert the desktop Node-mode trampoline for the exact upstream ACL runner.
- * @param spec - resolved PowerShell execution spec.
- * @param argv - argv after the upstream sandbox provider has confined it.
- * @param adaptation - executable and runner identities for this Host.
- * @returns unchanged inputs for every non-runner call, otherwise the isolated runner launch.
+ * Resolve the vendored Node executable shipped beside the packaged app.
+ * @param execPath - current Electron executable path.
+ * @param exists - injectable existence check.
+ * @returns the physical node.exe, or undefined when unpackaged or absent.
+ */
+export function resolveVendoredNodeExecutable(
+  execPath: string,
+  exists: (path: string) => boolean = existsSync,
+): string | undefined {
+  // Windows path semantics on every host, matching desktopWindowsPwshPath,
+  // so the resolution is deterministic in cross-platform test runs.
+  const candidate = win32.join(win32.dirname(execPath), 'resources', VENDORED_NODE_RESOURCE)
+  return exists(candidate) ? candidate : undefined
+}
+
+/** Per-path memo of successful `node -v` probes; the executable never changes for a given install. */
+const probedVendoredNodes = new Set<string>()
+
+/**
+ * Probe that the vendored Node actually launches, not merely exists. AV/EDR
+ * products can quarantine unsigned bundled executables (issue #203 branch B);
+ * a file that exists but cannot run must not silently masquerade as a sandbox
+ * failure.
+ * @param path - absolute node.exe path.
+ * @param spawn - injectable spawn for tests.
+ * @returns true when `node -v` exits 0 with a version string.
+ */
+export function probeVendoredNodeExecutable(
+  path: string,
+  spawn: typeof spawnSync = spawnSync,
+): boolean {
+  if (probedVendoredNodes.has(path)) return true
+  const result = spawn(path, ['-v'], {
+    timeout: VENDORED_NODE_PROBE_TIMEOUT_MS,
+    windowsHide: true,
+  })
+  const ok = result.status === 0 && /^v\d+\./u.test(String(result.stdout).trim())
+  if (ok) probedVendoredNodes.add(path)
+  return ok
+}
+
+/**
+ * Insert the desktop runner host for the exact upstream ACL runner argv.
+ * Prefers the vendored standalone Node (verified against issue #203); the
+ * Electron trampoline is only a development fallback and logs a one-time
+ * warning because it is the known-broken shape for Windows sandboxed pwsh.
  */
 export function adaptWindowsAclExecution(
   spec: ShellExecSpec,
@@ -85,6 +145,34 @@ export function adaptWindowsAclExecution(
   for (const key of Object.keys(env)) {
     if (key.toUpperCase() === RUN_AS_NODE) delete env[key]
   }
+
+  const nodeExecutable = adaptation.nodeExecutable
+  if (nodeExecutable !== undefined) {
+    // Preferred path: standalone vendored Node. The upstream runner receives
+    // the physical unpacked path — stock Node cannot read app.asar.
+    const probe = adaptation.probe ?? probeVendoredNodeExecutable
+    if (!probe(nodeExecutable)) {
+      throw new Error(
+        `[dsh-plugin-desktop] vendored Node at ${nodeExecutable} exists but does not launch. ` +
+        'It may be quarantined or blocked by security software (issue #203). ' +
+        'Reinstall DSH Desktop or whitelist the bundled node.exe.',
+      )
+    }
+    return {
+      spec: { ...spec, env },
+      argv: [nodeExecutable, unpackedAsarPath(adaptation.upstreamRunner), ...args],
+    }
+  }
+
+  // Development fallback: the RunAsNode trampoline is known-broken for the
+  // Windows workspace-write sandbox (issue #203); warn once per trampoline.
+  if (!TRAMPOLINE_FALLBACK_WARNED.has(adaptation.trampoline)) {
+    TRAMPOLINE_FALLBACK_WARNED.add(adaptation.trampoline)
+    console.warn(
+      '[dsh-plugin-desktop] no vendored Node found; falling back to the RunAsNode trampoline. ' +
+      'On Windows, workspace-write sandboxed pwsh fails with 0xC0000142 in this mode (issue #203).',
+    )
+  }
   env[RUN_AS_NODE] = '1'
   return {
     spec: { ...spec, env },
@@ -99,12 +187,14 @@ export class DesktopWindowsPwshSandbox extends SandboxPwshExecutor {
   }
 
   private adapt(spec: ShellExecSpec, argv: readonly string[]): AdaptedWindowsAclExecution {
+    const nodeExecutable = resolveVendoredNodeExecutable(process.execPath)
     return adaptWindowsAclExecution(spec, argv, {
       platform: process.platform,
       electron: process.versions.electron !== undefined,
       execPath: process.execPath,
       upstreamRunner: UPSTREAM_RUNNER,
       trampoline: DESKTOP_TRAMPOLINE,
+      ...(nodeExecutable === undefined ? {} : { nodeExecutable }),
     })
   }
 

--- a/dsh-plugin-desktop/tests/windows-pwsh-sandbox.spec.ts
+++ b/dsh-plugin-desktop/tests/windows-pwsh-sandbox.spec.ts
@@ -4,6 +4,8 @@ import {
   adaptWindowsAclExecution,
   desktopWindowsPwshConfig,
   desktopWindowsPwshPath,
+  probeVendoredNodeExecutable,
+  resolveVendoredNodeExecutable,
   type WindowsAclAdaptation,
 } from '../src/windows-pwsh-sandbox.ts'
 
@@ -24,7 +26,7 @@ const adaptation: WindowsAclAdaptation = {
   platform: 'win32',
   electron: true,
   execPath: 'C:\\Program Files\\DSH Desktop\\DSH Desktop.exe',
-  upstreamRunner: 'C:\\Program Files\\DSH Desktop\\resources\\app.asar\\runner.js',
+  upstreamRunner: 'C:\\Program Files\\DSH Desktop\\resources\\app.asar\\node_modules\\@deepseek-ai\\dsh-sandbox-windows-acl\\lib\\runner.js',
   trampoline: 'C:\\Program Files\\DSH Desktop\\resources\\app.asar\\desktop-runner.js',
 }
 
@@ -69,24 +71,64 @@ describe('Windows Electron PowerShell sandbox adaptation', () => {
     })
   })
 
-  it('adapts only the exact Electron-hosted win32 ACL runner argv', () => {
-    const env = Object.freeze({ KEEP: 'value' })
-    const spec = Object.freeze(shellSpec(env))
-    const argv = Object.freeze([
+  it('runs the ACL runner in the vendored Node with the unpacked physical path', () => {
+    const vendoredNode = 'C:\\Program Files\\DSH Desktop\\resources\\node.exe'
+    const spec = shellSpec({ KEEP: 'value' })
+    const argv = [
       adaptation.execPath,
       adaptation.upstreamRunner,
       '--workspace',
       'C:\\workspace',
       '--',
       'powershell.exe',
-      '-Command',
-      'Write-Output ok',
-    ])
+    ]
 
-    const result = adaptWindowsAclExecution(spec, argv, adaptation)
+    const result = adaptWindowsAclExecution(spec, argv, {
+      ...adaptation,
+      nodeExecutable: vendoredNode,
+      probe: () => true,
+    })
 
-    expect(result.spec).not.toBe(spec)
     expect(result.argv).toEqual([
+      vendoredNode,
+      adaptation.upstreamRunner.replace('app.asar', 'app.asar.unpacked'),
+      '--workspace',
+      'C:\\workspace',
+      '--',
+      'powershell.exe',
+    ])
+    expect(result.spec.env).toEqual({ KEEP: 'value' })
+    expect(result.spec.env).not.toHaveProperty(RUN_AS_NODE)
+  })
+
+  it('throws a diagnostic error when the vendored Node exists but cannot launch', () => {
+    const vendoredNode = 'C:\\Program Files\\DSH Desktop\\resources\\node.exe'
+    const spec = shellSpec({ KEEP: 'value' })
+    const argv = [adaptation.execPath, adaptation.upstreamRunner, '--', 'powershell.exe']
+
+    expect(() => adaptWindowsAclExecution(spec, argv, {
+      ...adaptation,
+      nodeExecutable: vendoredNode,
+      probe: () => false,
+    })).toThrow(/does not launch/)
+  })
+
+  it('falls back to the trampoline without a vendored Node and warns once', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const spec = shellSpec({ KEEP: 'value' })
+    const argv = [
+      adaptation.execPath,
+      adaptation.upstreamRunner,
+      '--workspace',
+      'C:\\workspace',
+      '--',
+      'powershell.exe',
+    ]
+
+    const first = adaptWindowsAclExecution(spec, argv, adaptation)
+    const second = adaptWindowsAclExecution(spec, argv, adaptation)
+
+    expect(first.argv).toEqual([
       adaptation.execPath,
       adaptation.trampoline,
       adaptation.upstreamRunner,
@@ -94,24 +136,39 @@ describe('Windows Electron PowerShell sandbox adaptation', () => {
       'C:\\workspace',
       '--',
       'powershell.exe',
-      '-Command',
-      'Write-Output ok',
     ])
-    expect(result.spec.env).toEqual({
-      KEEP: 'value',
-      [RUN_AS_NODE]: '1',
-    })
-    expect(spec.env).toBe(env)
-    expect(argv).toEqual([
-      adaptation.execPath,
-      adaptation.upstreamRunner,
-      '--workspace',
-      'C:\\workspace',
-      '--',
-      'powershell.exe',
-      '-Command',
-      'Write-Output ok',
-    ])
+    expect(first.spec.env).toEqual({ KEEP: 'value', [RUN_AS_NODE]: '1' })
+    expect(second.argv).toEqual(first.argv)
+    expect(warn).toHaveBeenCalledOnce()
+    warn.mockRestore()
+  })
+
+  it('resolves the vendored Node beside the packaged Electron resources', () => {
+    const execPath = 'C:\\Program Files\\DSH Desktop\\DSH Desktop.exe'
+    const exists = (path: string) => path === 'C:\\Program Files\\DSH Desktop\\resources\\node.exe'
+    expect(resolveVendoredNodeExecutable(execPath, exists)).toBe(
+      'C:\\Program Files\\DSH Desktop\\resources\\node.exe',
+    )
+  })
+
+  it('returns undefined vendored Node when the resource is absent', () => {
+    const execPath = 'C:\\Program Files\\DSH Desktop\\DSH Desktop.exe'
+    expect(resolveVendoredNodeExecutable(execPath, () => false)).toBeUndefined()
+  })
+
+  it('probes the vendored Node by running it with -v and caches the success', () => {
+    const spawn = vi.fn(() => ({ status: 0, stdout: 'v22.23.2\n' }))
+    expect(probeVendoredNodeExecutable('C:\\node.exe', spawn as never)).toBe(true)
+    expect(probeVendoredNodeExecutable('C:\\node.exe', spawn as never)).toBe(true)
+    expect(spawn).toHaveBeenCalledTimes(1)
+    expect(spawn).toHaveBeenCalledWith('C:\\node.exe', ['-v'], expect.objectContaining({ timeout: 5_000 }))
+  })
+
+  it('probes with a failing node and does not cache the failure', () => {
+    const spawn = vi.fn(() => ({ status: 1, stdout: '' }))
+    expect(probeVendoredNodeExecutable('C:\\bad-node.exe', spawn as never)).toBe(false)
+    expect(probeVendoredNodeExecutable('C:\\bad-node.exe', spawn as never)).toBe(false)
+    expect(spawn).toHaveBeenCalledTimes(2)
   })
 
   it.each([


### PR DESCRIPTION
## What

修复 #203 分支 A 的根因：**在 `ELECTRON_RUN_AS_NODE` 进程内执行 ACL runner 创建的受限 token，spawn 出来的任何子进程都会 DLL 初始化失败（0xC0000142）**——pwsh、cmd、Git Bash 无一例外。

本 PR 让 runner 改由**打包内独立 Node 运行时**执行，与 CLI 路径行为一致；保留原 Electron trampoline 作为未打包开发环境的降级路径。

## 根因证据（#203 社区实验，感谢 @sjh9714）

windows-latest 三格对照（run/32106666278）：

| 格 | runner 由谁执行 | pwsh workspace-write | cmd 越界写 | Git Bash |
|---|---|---|---|---|
| A 基线 | 普通 Node | ✅ exit 42 | `Access is denied.` | cygheap 自己的失败 |
| B 桌面链 | Electron RunAsNode 进程内 | ❌ 0xC0000142 | ❌ 0xC0000142，stderr 空 | ❌ 0xC0000142，stderr 空 |
| C 本修复 | Electron spawn 独立 Node | ✅ exit 42 | `Access is denied.` | cygheap 自己的失败 |

C 格与 A 格逐格一致；vendored Node v20.19.5 与 v22.23.2 无差异（run/32108161658）。

## 改动

- `scripts/vendor-node-win.mjs`：下载并校验 **Node 22.23.2**（sha256 锁定，npmmirror 回退源），解压 `node.exe` 到 `vendor/node/`
- `package.json`：`vendor:node:win` 脚本（`check:win-package` 前置）；electron-builder `extraResources` 把 node.exe 放进 `resources/`
- `src/windows-pwsh-sandbox.ts`：
  - 新增 `resolveVendoredNodeExecutable()`（`resources/node.exe`，缺失返回 undefined）
  - `adaptWindowsAclExecution` 优先用 vendored Node 直接跑 runner（env 无 RunAsNode）；无 vendored Node 时走原 trampoline 降级
- 测试：16/16 通过（新增 vendored-node 分支、路径解析、缺失降级 3 个用例）

## 已知代价

- **Windows 安装包体积 +~87 MB**（vendored node.exe）。如需减小，可换 node.exe 的精简发行版或压缩方式，但需重新验证沙箱行为。
- 只影响 Windows 打包；Linux/macOS 打包流程不变。

## 未覆盖（如实说明）

- trampoline 降级路径（未打包开发）仍保留旧行为——开发环境无 vendored Node；若开发环境也需要，可另议
- 修复有效性基于 @sjh9714 的最小 trampoline 实验；本 PR 合并后建议用其探针矩阵（`SMOKE_CHAIN=electron-spawn-node`）对真实打包产物做一次复测

Closes 分支 A of #203. 分支 B（AV 注入叠加）独立跟踪。
