### PR TITLE
fix(desktop): preserve completed installer on failed redownload

### DIFF
--- a/dsh-plugin-desktop/src/update-download.ts
+++ b/dsh-plugin-desktop/src/update-download.ts
@@ -128,6 +128,8 @@ export async function downloadDesktopUpdate(options: DownloadDesktopUpdateOption
     throwIfAborted(options.signal)
     await validateArtifact(paths.temporary, platform)
     throwIfAborted(options.signal)
+    // Only replace a previously completed installer after full validation, so any
+    // failed or cancelled redownload keeps the working artifact in place.
     await rename(paths.temporary, paths.completed)
     return paths.completed
   } catch (cause) {
@@ -188,11 +190,8 @@ async function prepareDownloadPaths(
   const filename = `DSH-Desktop-${version}-${platformName}.${extension}`
   const completed = join(directory, filename)
   const completedStat = await lstatOptional(completed)
-  if (completedStat !== undefined) {
-    if (!completedStat.isFile() || completedStat.isSymbolicLink()) {
-      throw new UpdateDownloadError('invalid-options', 'The completed update path is not a regular file.')
-    }
-    await unlink(completed)
+  if (completedStat !== undefined && (!completedStat.isFile() || completedStat.isSymbolicLink())) {
+    throw new UpdateDownloadError('invalid-options', 'The completed update path is not a regular file.')
   }
 
   return {

--- a/dsh-plugin-desktop/tests/update-download.spec.ts
+++ b/dsh-plugin-desktop/tests/update-download.spec.ts
@@ -271,4 +271,73 @@ describe('desktop update installer download', () => {
     }), 'invalid-options')
     expect(requested).toBe(false)
   })
+
+  it('preserves a completed installer when a same-version redownload fails', async () => {
+    const userDataPath = await temporaryUserData()
+    const artifact = dmgArtifact()
+    const completed = await downloadDesktopUpdate({
+      platform: 'darwin',
+      version: '2.10.0',
+      userDataPath,
+      request: async (url) => {
+        expect(url).toBe(DESKTOP_DOWNLOAD_URLS.darwin)
+        return chunkedResponse([artifact])
+      },
+    })
+
+    await expectFailure(downloadDesktopUpdate({
+      platform: 'darwin',
+      version: '2.10.0',
+      userDataPath,
+      request: async () => { throw new Error('offline') },
+    }), 'network')
+
+    expect(await readFile(completed)).toEqual(Buffer.from(artifact))
+    await expectNoPartialFiles(userDataPath, '2.10.0')
+  })
+
+  it('preserves a completed installer when a same-version redownload is rejected as invalid', async () => {
+    const userDataPath = await temporaryUserData()
+    const artifact = dmgArtifact()
+    const completed = await downloadDesktopUpdate({
+      platform: 'darwin',
+      version: '2.11.0',
+      userDataPath,
+      request: async () => chunkedResponse([artifact]),
+    })
+
+    await expectFailure(downloadDesktopUpdate({
+      platform: 'darwin',
+      version: '2.11.0',
+      userDataPath,
+      request: async () => chunkedResponse([new Uint8Array(1024)]),
+    }), 'invalid-artifact')
+
+    expect(await readFile(completed)).toEqual(Buffer.from(artifact))
+    await expectNoPartialFiles(userDataPath, '2.11.0')
+  })
+
+  it('replaces a completed installer only after the redownload validates', async () => {
+    const userDataPath = await temporaryUserData()
+    const firstArtifact = dmgArtifact()
+    const secondArtifact = Buffer.from(dmgArtifact())
+    secondArtifact.fill(0x6b, 0, secondArtifact.byteLength - 512)
+    const completed = await downloadDesktopUpdate({
+      platform: 'darwin',
+      version: '2.12.0',
+      userDataPath,
+      request: async () => chunkedResponse([firstArtifact]),
+    })
+
+    const result = await downloadDesktopUpdate({
+      platform: 'darwin',
+      version: '2.12.0',
+      userDataPath,
+      request: async () => chunkedResponse([secondArtifact]),
+    })
+
+    expect(result).toBe(completed)
+    expect(await readFile(completed)).toEqual(Buffer.from(secondArtifact))
+    await expectNoPartialFiles(userDataPath, '2.12.0')
+  })
 })


### PR DESCRIPTION
## Summary

- preserve an existing installer when a same-version redownload fails
- replace the installer only after the new artifact passes validation
- add regression tests for failed and successful redownloads

## Problem

When downloading the same version again, the existing completed installer was removed before the new download finished. If the redownload failed or produced an invalid artifact, the previously usable installer was lost.

## Fix

Keep the existing installer during the download and replace it only after the new temporary artifact has been fully written and validated.

## Verification

- `corepack yarn workspace dsh-plugin-desktop exec vitest run tests/update-download.spec.ts` — 21 tests passed
- `corepack yarn workspace dsh-plugin-desktop typecheck` — passed
- `git diff --check` — passed

This PR is independent of #121, which handles truncated download validation.