### PR TITLE
fix(desktop): fix the sidebar color was not synchronized with the chat interface.

### DIFF
--- a/dsh-plugin-desktop/src/electron-runtime.ts
+++ b/dsh-plugin-desktop/src/electron-runtime.ts
@@ -331,6 +331,10 @@ export class ElectronDesktopRuntime implements DesktopRuntime {
   setThemeSource(source: DesktopThemeSource): void {
     if (this.scheduled?.mode === 'advanced' && this.window !== undefined) {
       nativeTheme.themeSource = source
+      // Windows can retain the preceding DWM Mica palette until the window is
+      // recomposed (for example after minimize/restore). Reapplying the active
+      // material invalidates the backdrop immediately after a live theme change.
+      if (this.platform === 'win32') this.window.setBackgroundMaterial('mica')
     }
   }
 

--- a/dsh-plugin-desktop/tests/electron-runtime.spec.ts
+++ b/dsh-plugin-desktop/tests/electron-runtime.spec.ts
@@ -103,6 +103,7 @@ const electron = vi.hoisted(() => {
     readonly destroy = vi.fn()
     readonly loadURL = loadURL
     readonly removeMenu = vi.fn()
+    readonly setBackgroundMaterial = vi.fn()
   }
 
   class Tray {
@@ -1020,6 +1021,31 @@ describe('Electron compatibility runtime', () => {
     expect(electron.nativeTheme.themeSource).toBe('light')
     runtime.setThemeSource('dark')
     expect(electron.nativeTheme.themeSource).toBe('light')
+  })
+
+  it('refreshes the Windows Mica backdrop after a live advanced theme change', async () => {
+    vi.spyOn(process, 'platform', 'get').mockReturnValue('win32')
+    electron.nativeTheme.themeSource = 'light'
+    const { ElectronDesktopRuntime } = await import('../src/electron-runtime.ts')
+    const runtime = new ElectronDesktopRuntime(async () => {})
+    const release = runtime.schedule({
+      ...spec,
+      mode: 'advanced',
+      readThemeSource: () => 'light',
+    })
+
+    runtime.setThemeSource('dark')
+    expect(electron.nativeTheme.themeSource).toBe('light')
+    await runtime.mountScheduled()
+
+    const window = electron.browserWindows[0]
+    runtime.setThemeSource('dark')
+
+    expect(electron.nativeTheme.themeSource).toBe('dark')
+    expect(window?.setBackgroundMaterial).toHaveBeenCalledOnce()
+    expect(window?.setBackgroundMaterial).toHaveBeenCalledWith('mica')
+
+    await release()
   })
 
   it('restores the preceding native appearance when advanced loading fails', async () => {


### PR DESCRIPTION
## Summary

- refresh the Windows Mica backdrop after live advanced-mode theme changes
- keep the native sidebar material synchronized with the renderer color scheme
- cover Windows Mica refresh behavior with an Electron runtime regression test

## Verification

- corepack yarn workspace dsh-plugin-desktop test tests/electron-runtime.spec.ts
- corepack yarn workspace dsh-plugin-desktop typecheck
- corepack yarn workspace dsh-plugin-desktop build