### PR TITLE
fix(desktop): point pnpm lifecycle builds at a packaged node-gyp

### DIFF
--- a/dsh-plugin-desktop/package.json
+++ b/dsh-plugin-desktop/package.json
@@ -228,6 +228,7 @@
     "dsh-community-market": "0.1.0-dev.0",
     "koffi": "3.1.5",
     "node-addon-require-builtin": "^0.1.4",
+    "node-gyp": "12.4.0",
     "pnpm": "11.7.0",
     "react": "18.3.1",
     "yaml": "^2.9.0"

--- a/dsh-plugin-desktop/src/pnpm.ts
+++ b/dsh-plugin-desktop/src/pnpm.ts
@@ -1,6 +1,7 @@
 /** Desktop-owned package-manager capability for the active DSH profile. */
 
-import { delimiter, isAbsolute } from 'node:path'
+import { createRequire } from 'node:module'
+import { delimiter, dirname, isAbsolute, join } from 'node:path'
 import { pathToFileURL } from 'node:url'
 import type { Readable } from 'node:stream'
 import { Context, Service } from '@deepseek-ai/cordis'
@@ -117,6 +118,29 @@ function validateBootstrap(bootstrap: DesktopPnpmBootstrap): void {
   }
 }
 
+/**
+ * Resolve a node-gyp entry pnpm lifecycle scripts can use.
+ *
+ * Packaged pnpm ships its own node-gyp at `dist/node_modules/node-gyp`, but
+ * Electron Builder prunes nested `node_modules` inside the packaged pnpm
+ * release, so that path does not exist in the shipped app (see
+ * `node_modules/pnpm/dist`). Point pnpm at the node-gyp we declare as a
+ * direct dependency instead; `npm_config_node_gyp` is the npm/pnpm knob
+ * that overrides the lifecycle tool without touching the package tree.
+ *
+ * @returns the absolute node-gyp.js path, or undefined when unavailable
+ * (lifecycle scripts then fail loudly with pnpm's own diagnostic).
+ */
+function resolveNodeGyp(): string | undefined {
+  try {
+    const requireFromPlugin = createRequire(import.meta.url)
+    const packageJson = requireFromPlugin.resolve('node-gyp/package.json')
+    return join(dirname(packageJson), 'bin', 'node-gyp.js')
+  } catch {
+    return undefined
+  }
+}
+
 /** Host service providing one managed pnpm operation at a time. */
 export class DesktopPnpm extends Service {
   private active: ActiveOperation | undefined
@@ -206,6 +230,7 @@ export class DesktopPnpm extends Service {
     }
     command.signal?.throwIfAborted()
     const path = inheritedPath()
+    const nodeGyp = resolveNodeGyp()
     const spec: SubprocessSpawnSpec = {
       argv: command.argv,
       cwd: command.cwd,
@@ -227,6 +252,7 @@ export class DesktopPnpm extends Service {
         npm_config_runtime: 'electron',
         npm_config_target: this.bootstrap.electronVersion,
         npm_config_disturl: ELECTRON_HEADERS_URL,
+        ...(nodeGyp === undefined ? {} : { npm_config_node_gyp: nodeGyp }),
       },
     }
     const child = this.ctx.subprocess.spawn(spec)


### PR DESCRIPTION
## Summary

Packaged DSH Desktop cannot build native plugin dependencies (node-pty, ssh2, cpu-features, cloudflared) because the bundled pnpm loses its nested `dist/node_modules` during Electron Builder packaging. The pnpm node-gyp shim (`node_modules/pnpm/dist/node-gyp-bin/node-gyp`) hardcodes `../node_modules/node-gyp/bin/node-gyp.js`, which no longer exists after packaging, so every native postinstall fails with:

```
ERR_MODULE_NOT_FOUND .../pnpm/dist/node_modules/node-gyp/bin/node-gyp.js
```

Evidence (macOS arm64, DSH Desktop v2.0.0): the official pnpm 11.7.0 tarball contains `dist/node_modules/node-gyp` (19MB unpacked), but the shipped app only has `dist/{node-gyp-bin,pnpm.mjs,pnpmrc,templates,worker.js}` (12MB) — `dist/node_modules/` is pruned.

## Fix

1. **Declare `node-gyp` 12.4.0** (the exact version pnpm 11.7.0 bundles) as a direct dependency of `dsh-plugin-desktop`. As a production dependency it lands in `app.asar.unpacked/node_modules/` (covered by `asarUnpack: ["node_modules/**"]`).
2. **Set `npm_config_node_gyp`** in the pnpm spawn env (`src/pnpm.ts`). `resolveNodeGyp()` locates the entry via `createRequire(import.meta.url)` (i.e. `lib/pnpm.js` → `app.asar.unpacked/node_modules/node-gyp`), and npm/pnpm's standard override makes lifecycle scripts use it instead of the pruned pnpm-internal copy.

The change is backward compatible: when node-gyp is unavailable the env is skipped and pnpm falls back to its own (fail-loud) behavior.

## Testing

- Reproduced on macOS arm64 with DSH Desktop v2.0.0 installing `@linxin666/dsh-web-ui-all@0.2.0` (cpu-features `.node` binding missing after install).
- Confirmed root cause: pnpm 11.7.0 tarball has `dist/node_modules/node-gyp`, packaged app does not.
- Verified `resolveNodeGyp()` output path shape against the packaged layout (`lib/pnpm.js` → `app.asar.unpacked/node_modules/node-gyp/bin/node-gyp.js`).
- TypeScript syntax verified via esbuild transform (full typecheck requires CI dependency install).
