### PR TITLE
fix(desktop): report failed update rechecks

### DIFF
--- a/dsh-plugin-desktop/src/updates.ts
+++ b/dsh-plugin-desktop/src/updates.ts
@@ -148,7 +148,15 @@ export function apply(ctx: Context, config: Config): void {
         }
         if (!confirmed || disposed) return
 
-        const confirmedVersion = observeResult(await startCheck())
+        const confirmedResult = await startCheck()
+        if (disposed) return
+        if (confirmedResult === null) {
+          // The user just confirmed a download, so a failed recheck must surface a
+          // retry prompt instead of silently abandoning the accepted download.
+          await adapter.showManualCheckResult(null)
+          return
+        }
+        const confirmedVersion = observeResult(confirmedResult)
         if (confirmedVersion !== version || disposed) return
 
         const controller = new AbortController()

--- a/dsh-plugin-desktop/tests/updates.spec.ts
+++ b/dsh-plugin-desktop/tests/updates.spec.ts
@@ -249,6 +249,27 @@ describe('desktop update Host plugin', () => {
     expect(harness.tray.label()).toBe('DSH Desktop 2.2.0 Available')
   })
 
+  it('surfaces a failed post-confirmation recheck and does not start the download', async () => {
+    const request = vi.fn()
+      .mockResolvedValueOnce(versionResponse('2.1.0'))
+      .mockRejectedValueOnce(new TypeError('offline'))
+    const harness = await createHarness({
+      packaged: false,
+      request,
+      confirmDownload: async () => true,
+    })
+
+    await harness.tray.invoke()
+
+    expect(request).toHaveBeenCalledTimes(2)
+    expect(harness.confirmDownload).toHaveBeenCalledWith('2.1.0')
+    expect(harness.showManualCheckResult).toHaveBeenCalledWith(null)
+    expect(harness.downloadAndOpen).not.toHaveBeenCalled()
+    expect(harness.notifications).toEqual([])
+    expect(harness.warnings).toEqual([])
+    expect(harness.tray.label()).toBe('DSH Desktop 2.1.0 Available')
+  })
+
   it.each([
     ['up-to-date', async () => versionResponse('2.0.0')],
     ['failed', async () => new Response('unavailable', { status: 503 })],


### PR DESCRIPTION
## Summary

- show a retry prompt when the post-confirmation update check fails
- keep version-rotation behavior unchanged
- add regression coverage for failed post-confirmation checks

## Problem

After a user confirms an available update, DSH Desktop rechecks the advertised version before starting the download. If this second check fails because of a network error, the update flow returns silently. No retry prompt or other feedback is shown, and the download does not start.

## Fix

Show the existing manual update failure prompt when the post-confirmation check fails. Automatic check failures and actual download or installer-opening failures remain silent as before.

## Verification

- `corepack yarn workspace dsh-plugin-desktop exec vitest run tests/updates.spec.ts` — 22 tests passed
- `corepack yarn workspace dsh-plugin-desktop typecheck` — passed
- `git diff --check` — passed

This PR is independent of #267, which addresses preserving an existing installer during a failed redownload.