### PR TITLE
fix(market): reject invalid cursor sources before scans

### DIFF
--- a/dsh-community-market/src/catalog/service.ts
+++ b/dsh-community-market/src/catalog/service.ts
@@ -195,6 +195,8 @@ export interface CatalogService {
 export interface CatalogScanOptions {
   readonly force?: boolean
   readonly locale?: string
+  /** Reject a stale or foreign cursor scope before any provider I/O. */
+  readonly expectedSourceRecordId?: string
 }
 
 /** Complete, Host-normalized active-source scan. Page snapshots remain schema-bounded. */
@@ -470,6 +472,12 @@ export class DefaultCatalogService implements CatalogService {
     if (options.force !== undefined && typeof options.force !== 'boolean') {
       throw new TypeError('invalid catalog scan options')
     }
+    if (
+      options.expectedSourceRecordId !== undefined
+      && (typeof options.expectedSourceRecordId !== 'string' || options.expectedSourceRecordId.length === 0)
+    ) {
+      throw new TypeError('invalid catalog scan options')
+    }
     const scanQuery = normalizeCatalogQuery({
       limit: 100,
       ...(options.locale === undefined ? {} : { locale: options.locale }),
@@ -480,6 +488,12 @@ export class DefaultCatalogService implements CatalogService {
     const records = [...await this.store.load()].sort((left, right) => left.order - right.order)
     signal.throwIfAborted()
     const source = records.find(record => record.enabled)
+    if (
+      options.expectedSourceRecordId !== undefined
+      && source?.sourceRecordId !== options.expectedSourceRecordId
+    ) {
+      throw new Error('catalog source is not active')
+    }
     if (source === undefined) return undefined
     const sourceGeneration = sourceGenerationsAtLoadStart.get(source.sourceRecordId) ?? 0
     if ((this.sourceGenerations.get(source.sourceRecordId) ?? 0) !== sourceGeneration) {
@@ -670,7 +684,10 @@ export class DefaultCatalogService implements CatalogService {
   ): Promise<readonly MarketCatalogSourceResult[]> {
     const query = normalizeCatalogQuery(value)
     if (query.cursor !== undefined) throw new Error('catalog cursor requires an explicit source scope')
-    const index = await this.scanCatalog(signal, query.locale === undefined ? {} : { locale: query.locale })
+    const index = await this.scanCatalog(signal, {
+      ...(query.locale === undefined ? {} : { locale: query.locale }),
+      ...(scope === undefined ? {} : { expectedSourceRecordId: scope.sourceRecordId }),
+    })
     signal.throwIfAborted()
     return index === undefined ? [] : this.queryCatalog(index, query, scope)
   }

--- a/dsh-community-market/src/host/routes.ts
+++ b/dsh-community-market/src/host/routes.ts
@@ -733,6 +733,7 @@ export function registerMarketRoutes(
         const index = await service.scanCatalog(signal, {
           force,
           ...(locale === null || locale === '' ? {} : { locale }),
+          ...(scope === undefined ? {} : { expectedSourceRecordId: scope.sourceRecordId }),
         })
         signal.throwIfAborted()
         const results = index === undefined ? [] : service.queryCatalog(index, query, scope)

--- a/dsh-community-market/tests/market-runtime.spec.ts
+++ b/dsh-community-market/tests/market-runtime.spec.ts
@@ -707,13 +707,20 @@ describe('catalog Host route pagination boundary', () => {
     ['unknown', [active], '038f1f77-a5c4-7b73-a9ae-0242ac120004'],
     ['inactive', [active, inactive], inactive.sourceRecordId],
   ] as const)('rejects a cursor scoped to an %s source before fetching', async (_label, records, sourceRecordId) => {
-    const response = await requestMarketCatalog(
-      records,
-      `${marketRoutes.catalog}?sourceRecordId=${sourceRecordId}&cursor=page-2`,
-    )
+    const scanCatalog = vi.spyOn(dsh1024StoreAdapter, 'scanCatalog')
+      .mockRejectedValue(new Error('invalid cursor scope reached the catalog adapter'))
+    try {
+      const response = await requestMarketCatalog(
+        records,
+        `${marketRoutes.catalog}?sourceRecordId=${sourceRecordId}&cursor=page-2`,
+      )
 
-    expect(response.statusCode).toBe(400)
-    expect(response.body).toEqual({ error: 'invalid catalog query' })
+      expect(response.statusCode).toBe(400)
+      expect(response.body).toEqual({ error: 'invalid catalog query' })
+      expect(scanCatalog).not.toHaveBeenCalled()
+    } finally {
+      scanCatalog.mockRestore()
+    }
   })
 })
 


### PR DESCRIPTION
## Summary
- reject unknown or inactive cursor sources before catalog provider I/O
- propagate the expected active source through route and service fetch scans
- make the regression test deterministic and assert zero adapter calls

## Verification
- `corepack yarn workspace dsh-community-market exec vitest run tests/market-runtime.spec.ts -t "rejects a cursor scoped"`
- `corepack yarn workspace dsh-community-market test` (220 passed)
- `corepack yarn workspace dsh-community-market typecheck`
- `corepack yarn typecheck`