### PR TITLE
fix(desktop): single-flight startup diagnostics export

### DIFF
--- a/dsh-plugin-desktop/src/startup-recovery-window.ts
+++ b/dsh-plugin-desktop/src/startup-recovery-window.ts
@@ -506,8 +506,7 @@ export class DesktopStartupRecoveryWindow {
       this.finish('quit')
     })
     await this.render()
-    this.diagnosticTask = this.saveDiagnostics()
-    void this.diagnosticTask.catch(() => {})
+    void this.startDiagnosticExport().catch(() => {})
     return await result
   }
 
@@ -575,8 +574,7 @@ export class DesktopStartupRecoveryWindow {
           })
         }
       } else if (action.action === 'export-diagnostics') {
-        this.diagnosticTask = this.saveDiagnostics()
-        await this.diagnosticTask.catch(() => {})
+        await this.startDiagnosticExport().catch(() => {})
       } else if (action.action === 'show-diagnostics' && this.diagnosticPath !== undefined) {
         shell.showItemInFolder(this.diagnosticPath)
       } else if (action.action === 'open-profile-patch') {
@@ -619,14 +617,26 @@ export class DesktopStartupRecoveryWindow {
   }
 
   private async ensureDiagnostics(): Promise<boolean> {
-    if (this.diagnostics.status === 'saved') return true
-    this.diagnosticTask ??= this.saveDiagnostics()
     try {
-      await this.diagnosticTask
+      await this.startDiagnosticExport()
       return true
     } catch {
       return false
     }
+  }
+
+  private startDiagnosticExport(): Promise<string> {
+    if (this.diagnostics.status === 'saved' && this.diagnosticPath !== undefined) {
+      return Promise.resolve(this.diagnosticPath)
+    }
+    if (this.diagnosticTask !== undefined) return this.diagnosticTask
+
+    const task = this.saveDiagnostics()
+    this.diagnosticTask = task
+    void task.catch(() => {
+      if (this.diagnosticTask === task) this.diagnosticTask = undefined
+    })
+    return task
   }
 
   private async saveDiagnostics(): Promise<string> {

--- a/dsh-plugin-desktop/tests/startup-recovery-window.spec.ts
+++ b/dsh-plugin-desktop/tests/startup-recovery-window.spec.ts
@@ -6,6 +6,7 @@ import {
   desktopStartupRecoveryWindowBounds,
   parseDesktopStartupRecoveryAction,
   renderDesktopStartupRecoveryHtml,
+  DesktopStartupRecoveryWindow,
   type DesktopStartupRecoveryScreenApi,
   type DesktopStartupRecoveryViewModel,
 } from '../src/startup-recovery-window.ts'
@@ -161,6 +162,76 @@ describe('Desktop startup recovery document', () => {
     expect(html).toContain('example-plugin')
     expect(html).toContain('安装前配置已恢复。请重新启动 Desktop。')
     expect(html).toContain('class="button primary" href="dsh-recovery://restart"')
+  })
+})
+
+describe('Desktop startup recovery diagnostics export', () => {
+  function recoveryWindow(exportDiagnostics: () => Promise<string>): DesktopStartupRecoveryWindow {
+    return new DesktopStartupRecoveryWindow({
+      locale: 'zh',
+      failureStage: 'profile-composition',
+      failureDetail: 'diagnostic export test',
+      exportDiagnostics,
+    })
+  }
+
+  function handleAction(window: DesktopStartupRecoveryWindow): (action: { readonly action: string }) => Promise<void> {
+    return (window as unknown as {
+      handleAction: (action: { readonly action: string }) => Promise<void>
+    }).handleAction.bind(window)
+  }
+
+  function deferred<T>(): {
+    readonly promise: Promise<T>
+    readonly resolve: (value: T) => void
+    readonly reject: (cause: unknown) => void
+  } {
+    let resolve!: (value: T) => void
+    let reject!: (cause: unknown) => void
+    const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+      resolve = resolvePromise
+      reject = rejectPromise
+    })
+    return { promise, resolve, reject }
+  }
+
+  it('shares an in-flight export and reuses the saved result', async () => {
+    const task = deferred<string>()
+    const exportDiagnostics = vi.fn(() => task.promise)
+    const window = recoveryWindow(exportDiagnostics)
+    const runAction = handleAction(window)
+
+    const first = runAction({ action: 'export-diagnostics' })
+    await vi.waitFor(() => expect(exportDiagnostics).toHaveBeenCalledOnce())
+    const second = runAction({ action: 'export-diagnostics' })
+
+    await Promise.resolve()
+    expect(exportDiagnostics).toHaveBeenCalledOnce()
+    task.resolve('C:\\Temp\\diagnostics.zip')
+    await Promise.all([first, second])
+
+    await runAction({ action: 'export-diagnostics' })
+    expect(exportDiagnostics).toHaveBeenCalledOnce()
+  })
+
+  it('clears a failed export task so the next attempt can retry', async () => {
+    const firstTask = deferred<string>()
+    const secondTask = deferred<string>()
+    const exportDiagnostics = vi.fn()
+      .mockImplementationOnce(() => firstTask.promise)
+      .mockImplementationOnce(() => secondTask.promise)
+    const window = recoveryWindow(exportDiagnostics)
+    const runAction = handleAction(window)
+
+    const first = runAction({ action: 'export-diagnostics' })
+    await vi.waitFor(() => expect(exportDiagnostics).toHaveBeenCalledOnce())
+    firstTask.reject(new Error('archive unavailable'))
+    await first
+
+    const retry = runAction({ action: 'export-diagnostics' })
+    await vi.waitFor(() => expect(exportDiagnostics).toHaveBeenCalledTimes(2))
+    secondTask.resolve('C:\\Temp\\diagnostics-retry.zip')
+    await retry
   })
 })
 


### PR DESCRIPTION
## Summary
- share one in-flight startup diagnostics export across automatic and manual triggers
- reuse saved diagnostics and allow retry after failure
- add regression coverage for concurrency, reuse, and retry

## Verification
- corepack yarn workspace dsh-plugin-desktop vitest run tests/startup-recovery-window.spec.ts
- corepack yarn workspace dsh-plugin-desktop typecheck
- desktop test suite: 539 passed, 11 skipped