### PR TITLE
refactor(desktop): isolate native shell and platform adapters

### DIFF
--- a/dsh-plugin-desktop/src/electron-platform.ts
+++ b/dsh-plugin-desktop/src/electron-platform.ts
@@ -1,0 +1,68 @@
+import { app } from 'electron'
+import type { BrowserWindow, NativeImage } from 'electron'
+import type { DesktopPlatform } from './runtime.ts'
+import type { DesktopDownloadPlatform } from './update-download.ts'
+
+/** Native presentation and capability differences selected once at startup. */
+export interface ElectronPlatformStrategy {
+  readonly platform: DesktopPlatform
+  readonly updateDownloadPlatform: DesktopDownloadPlatform | undefined
+  readonly canPickDirectory: boolean
+  readonly canToggleShellMode: boolean
+  configureApplication(icon: NativeImage): void
+  configureWindow(window: BrowserWindow): void
+  refreshThemeMaterial(window: BrowserWindow): void
+}
+
+class WindowsPlatformStrategy implements ElectronPlatformStrategy {
+  readonly platform = 'win32'
+  readonly updateDownloadPlatform = 'win32'
+  readonly canPickDirectory = true
+  readonly canToggleShellMode = true
+
+  configureApplication(_icon: NativeImage): void {}
+
+  configureWindow(window: BrowserWindow): void {
+    window.removeMenu()
+  }
+
+  refreshThemeMaterial(window: BrowserWindow): void {
+    window.setBackgroundMaterial('mica')
+  }
+}
+
+class MacPlatformStrategy implements ElectronPlatformStrategy {
+  readonly platform = 'darwin'
+  readonly updateDownloadPlatform = 'darwin'
+  readonly canPickDirectory = false
+  readonly canToggleShellMode = true
+
+  configureApplication(icon: NativeImage): void {
+    app.dock?.setIcon(icon)
+  }
+
+  configureWindow(_window: BrowserWindow): void {}
+
+  refreshThemeMaterial(_window: BrowserWindow): void {}
+}
+
+class LinuxPlatformStrategy implements ElectronPlatformStrategy {
+  readonly platform = 'linux'
+  readonly updateDownloadPlatform = undefined
+  readonly canPickDirectory = false
+  readonly canToggleShellMode = false
+
+  configureApplication(_icon: NativeImage): void {}
+
+  configureWindow(_window: BrowserWindow): void {}
+
+  refreshThemeMaterial(_window: BrowserWindow): void {}
+}
+
+/** Select the only platform adapter used by one Electron runtime generation. */
+export function electronPlatformStrategy(platform: NodeJS.Platform = process.platform): ElectronPlatformStrategy {
+  if (platform === 'win32') return new WindowsPlatformStrategy()
+  if (platform === 'darwin') return new MacPlatformStrategy()
+  if (platform === 'linux') return new LinuxPlatformStrategy()
+  throw new Error(`dsh-plugin-desktop: unsupported Electron platform ${platform}`)
+}

--- a/dsh-plugin-desktop/src/electron-runtime.ts
+++ b/dsh-plugin-desktop/src/electron-runtime.ts
@@ -2,15 +2,11 @@
 
 import {
   app,
-  BrowserWindow,
   dialog,
-  Menu,
-  nativeImage,
   nativeTheme,
   net,
   Notification,
   shell,
-  Tray,
 } from 'electron'
 import { spawn } from 'node:child_process'
 import { readFileSync } from 'node:fs'
@@ -19,6 +15,7 @@ import { fileURLToPath } from 'node:url'
 import { desktopTerminalStateDirectory, openDesktopTerminal } from './desktop-terminal.ts'
 import { desktopInstallRecoveryStatePath } from './install-recovery.ts'
 import { packagedDependencyPath } from './packaged-runtime-path.ts'
+import { ElectronShellGeneration } from './electron-shell-generation.ts'
 import type {
   DesktopNotification,
   DesktopLocale,
@@ -33,9 +30,8 @@ import type {
   DesktopUpdateAdapter,
 } from './runtime.ts'
 import type { RendererBootReport } from './renderer-boot-contract.ts'
-import { formatDesktopExitCode, type DesktopLogger } from './desktop-logger.ts'
+import type { DesktopLogger } from './desktop-logger.ts'
 import { exportDesktopDiagnostics } from './diagnostic-export.ts'
-import { prepareTrayIcon } from './tray-icons.ts'
 import {
   desktopDiagnosticsPrivacyCopy,
   desktopLocaleFromLanguageTag,
@@ -48,7 +44,6 @@ import {
   formatWindowsVolumeConcern,
   type WindowsVolumeQuery,
 } from './windows-volume-diagnostics.ts'
-import { desktopWindowOptions } from './window-options.ts'
 
 /** Return the presentation mode opposite the active generation. */
 export function nextDesktopShellMode(mode: DesktopShellSpec['mode']): DesktopShellSpec['mode'] {
@@ -81,26 +76,12 @@ export function desktopPreloadPath(moduleUrl: string = import.meta.url): string 
 }
 
 const PRODUCT_VERSION = desktopProductVersion()
-const MIN_ZOOM_LEVEL = -4
-const MAX_ZOOM_LEVEL = 4
 
 /** Main-process deadline for one Renderer generation to settle its client Loader. */
 export const RENDERER_BOOT_TIMEOUT_MS = 30_000
 
 /** Failure class used by startup recovery to distinguish a hung Renderer. */
 export type RendererBootFailureReason = 'renderer-failed' | 'renderer-timeout'
-
-function clampedZoomLevel(level: number): number {
-  return Math.min(MAX_ZOOM_LEVEL, Math.max(MIN_ZOOM_LEVEL, level))
-}
-
-function isZoomShortcut(input: Electron.Input): 'in' | 'out' | 'reset' | undefined {
-  if (input.type !== 'keyDown' || input.alt || (!input.control && !input.meta)) return undefined
-  if (input.key === '+' || input.key === '=') return 'in'
-  if (input.key === '-' || input.key === '_') return 'out'
-  if (input.key === '0') return 'reset'
-  return undefined
-}
 
 /** Native adapter used by the DSH Desktop launcher and owned by its Cordis shell plugin. */
 export class ElectronDesktopRuntime implements DesktopRuntime {
@@ -117,12 +98,10 @@ export class ElectronDesktopRuntime implements DesktopRuntime {
     notify: notification => { this.showNotification(notification) },
   }
 
-  private window: BrowserWindow | undefined
+  private generation: ElectronShellGeneration | undefined
   private currentLocale: DesktopLocale = 'en'
-  private tray: Tray | undefined
   private scheduled: DesktopShellSpec | undefined
   private mountTask: Promise<void> | undefined
-  private release: (() => Promise<void>) | undefined
   private quitting = false
   private readonly trayItems = new Map<symbol, DesktopTrayItem>()
   private terminalSpec: DesktopTerminalSpec | undefined
@@ -201,9 +180,9 @@ export class ElectronDesktopRuntime implements DesktopRuntime {
         await this.mountTask
       } finally {
         try {
-          await this.release?.()
+          await this.generation?.release()
         } finally {
-          this.release = undefined
+          this.generation = undefined
           this.mountTask = undefined
           if (this.scheduled === spec) {
             if (spec.mode === 'advanced') nativeTheme.themeSource = previousThemeSource
@@ -220,17 +199,30 @@ export class ElectronDesktopRuntime implements DesktopRuntime {
     if (spec === undefined) {
       return Promise.reject(new Error('dsh-plugin-desktop: the Cordis shell plugin did not register a window'))
     }
-    this.mountTask ??= this.mount(spec, beforeInteractive).then((release) => { this.release = release })
+    if (this.mountTask === undefined) {
+      this.setLocalePreference(spec.readLocalePreference())
+      const generation = new ElectronShellGeneration({
+        platform: this.platform,
+        spec,
+        preloadPath: desktopPreloadPath(),
+        isQuitting: () => this.quitting,
+        buildTrayTemplate: () => this.buildTrayTemplate(spec),
+        stopRendererBootMonitoring: () => { this.stopRendererBootMonitoring() },
+        failRendererBoot: error => { this.failRendererBoot('renderer-failed', error) },
+        logError: message => { this.logError(message) },
+      })
+      this.generation = generation
+      this.mountTask = generation.mount(beforeInteractive).catch((cause: unknown) => {
+        if (this.generation === generation) this.generation = undefined
+        throw cause
+      })
+    }
     return this.mountTask
   }
 
   /** @inheritdoc */
   show(): void {
-    const window = this.window
-    if (window === undefined || window.isDestroyed()) return
-    if (window.isMinimized()) window.restore()
-    window.show()
-    window.focus()
+    this.generation?.show()
   }
 
   /** @inheritdoc */
@@ -253,10 +245,9 @@ export class ElectronDesktopRuntime implements DesktopRuntime {
       title: this.currentLocale === 'zh' ? '选择工作区目录' : 'Select Workspace Directory',
       properties: ['openDirectory', 'dontAddToRecent'],
     }
-    const window = this.window
-    const result = window === undefined || window.isDestroyed()
+    const result = this.generation === undefined
       ? await dialog.showOpenDialog(options)
-      : await dialog.showOpenDialog(window, options)
+      : await this.generation.showOpenDialog(options)
     return result.canceled ? null : result.filePaths[0] ?? null
   }
 
@@ -434,12 +425,12 @@ export class ElectronDesktopRuntime implements DesktopRuntime {
 
   /** @inheritdoc */
   setThemeSource(source: DesktopThemeSource): void {
-    if (this.scheduled?.mode === 'advanced' && this.window !== undefined) {
+    if (this.scheduled?.mode === 'advanced' && this.generation !== undefined) {
       nativeTheme.themeSource = source
       // Windows can retain the preceding DWM Mica palette until the window is
       // recomposed (for example after minimize/restore). Reapplying the active
       // material invalidates the backdrop immediately after a live theme change.
-      if (this.platform === 'win32') this.window.setBackgroundMaterial('mica')
+      this.generation.refreshThemeMaterial()
     }
   }
 
@@ -679,11 +670,7 @@ export class ElectronDesktopRuntime implements DesktopRuntime {
     }
   }
 
-  private rebuildTrayMenu(): void {
-    const tray = this.tray
-    const spec = this.scheduled
-    if (tray === undefined || spec === undefined) return
-
+  private buildTrayTemplate(spec: DesktopShellSpec): Electron.MenuItemConstructorOptions[] {
     const show = (): void => { this.show() }
     const tools = this.contributedTrayItems('tools')
     const profiles = this.contributedTrayItems('profiles')
@@ -708,132 +695,12 @@ export class ElectronDesktopRuntime implements DesktopRuntime {
       { type: 'separator' },
       { label: desktopTrayLabel(this.locale, 'quit'), click: () => { spec.requestQuit(0) } },
     )
-    tray.setContextMenu(Menu.buildFromTemplate(template))
+    return template
   }
 
-  private async mount(
-    spec: DesktopShellSpec,
-    beforeInteractive: (() => void) | undefined,
-  ): Promise<() => Promise<void>> {
-    this.setLocalePreference(spec.readLocalePreference())
-    const icon = nativeImage.createFromPath(spec.iconPath)
-    if (icon.isEmpty()) {
-      throw new Error(`dsh-plugin-desktop: failed to load application icon ${spec.iconPath}`)
-    }
-    if (this.platform === 'darwin') app.dock?.setIcon(icon)
-    const origin = new URL(spec.url).origin
-    if (spec.mode === 'advanced') nativeTheme.themeSource = spec.readThemeSource()
-    const window = new BrowserWindow(desktopWindowOptions(spec, icon, this.platform, desktopPreloadPath()))
-    window.accessibleTitle = spec.windowTitle
-    if (this.platform === 'win32') window.removeMenu()
-    this.window = window
-
-    const show = (): void => { this.show() }
-    const close = (event: Electron.Event): void => {
-      if (this.quitting) return
-      event.preventDefault()
-      window.hide()
-    }
-    const preserveBlankTitle = (event: Electron.Event): void => { event.preventDefault() }
-    const handleZoomShortcut = (event: Electron.Event, input: Electron.Input): void => {
-      const action = isZoomShortcut(input)
-      if (action === undefined) return
-      event.preventDefault()
-      if (action === 'reset') {
-        window.webContents.setZoomLevel(0)
-        return
-      }
-      const step = action === 'in' ? 1 : -1
-      window.webContents.setZoomLevel(clampedZoomLevel(window.webContents.getZoomLevel() + step))
-    }
-    const navigate = (event: Electron.Event<{ url: string }>): void => {
-      let targetOrigin: string | undefined
-      try {
-        targetOrigin = new URL(event.url).origin
-      } catch {
-        targetOrigin = undefined
-      }
-      if (targetOrigin !== origin) event.preventDefault()
-    }
-
-    app.on('activate', show)
-    window.on('close', close)
-    window.on('page-title-updated', preserveBlankTitle)
-    window.webContents.on('before-input-event', handleZoomShortcut)
-    window.webContents.on('will-frame-navigate', navigate)
-    window.webContents.on('will-redirect', navigate)
-    window.webContents.on('render-process-gone', (_event, details) => {
-      const detail = `renderer process gone (reason: ${details.reason}, exitCode: ${formatDesktopExitCode(details.exitCode)})`
-      this.logError(`dsh-plugin-desktop: ${detail}`)
-      this.failRendererBoot('renderer-failed', detail)
-    })
-    window.webContents.on('did-fail-load', (_event, errorCode, errorDescription, _validatedUrl, isMainFrame) => {
-      this.logError(`dsh-plugin-desktop: renderer failed to load (${errorCode}: ${errorDescription})`)
-      if (isMainFrame === true && errorCode !== -3) {
-        this.failRendererBoot(
-          'renderer-failed',
-          `renderer main frame failed to load (${String(errorCode)}: ${errorDescription})`,
-        )
-      }
-    })
-    window.webContents.setWindowOpenHandler(({ url }) => {
-      try {
-        const target = new URL(url)
-        if (target.protocol === 'https:' || target.protocol === 'http:' || target.protocol === 'mailto:') {
-          void shell.openExternal(target.href).catch((cause: unknown) => {
-            this.logError(`dsh-plugin-desktop: failed to open external link: ${cause instanceof Error ? cause.message : String(cause)}`)
-          })
-        }
-      } catch {
-        // A malformed target is rejected with the same deny result.
-      }
-      return { action: 'deny' }
-    })
-
-    window.once('ready-to-show', show)
-    let tray: Tray | undefined
-    try {
-      await window.loadURL(spec.url)
-      tray = new Tray(prepareTrayIcon(spec.trayIcons, this.platform))
-      this.tray = tray
-      tray.setToolTip(spec.productName)
-      this.rebuildTrayMenu()
-      tray.on('click', show)
-      beforeInteractive?.()
-    } catch (cause) {
-      this.stopRendererBootMonitoring()
-      app.off('activate', show)
-      window.off('page-title-updated', preserveBlankTitle)
-      window.webContents.off('before-input-event', handleZoomShortcut)
-      tray?.off('click', show)
-      tray?.destroy()
-      window.destroy()
-      this.tray = undefined
-      this.window = undefined
-      throw cause
-    }
-
-    if (tray === undefined) {
-      throw new Error('dsh-plugin-desktop: native tray did not mount')
-    }
-    const mountedTray = tray
-
-    let released = false
-    return async () => {
-      if (released) return
-      released = true
-      this.stopRendererBootMonitoring()
-      app.off('activate', show)
-      window.off('close', close)
-      window.off('page-title-updated', preserveBlankTitle)
-      window.webContents.off('before-input-event', handleZoomShortcut)
-      window.webContents.off('will-frame-navigate', navigate)
-      window.webContents.off('will-redirect', navigate)
-      mountedTray.off('click', show)
-      mountedTray.destroy()
-      if (!window.isDestroyed()) window.destroy()
-      if (this.tray === mountedTray) this.tray = undefined
-      if (this.window === window) this.window = undefined
-    }
+  private rebuildTrayMenu(): void {
+    const spec = this.scheduled
+    if (spec === undefined) return
+    this.generation?.refreshTrayMenu()
   }
 }

--- a/dsh-plugin-desktop/src/electron-runtime.ts
+++ b/dsh-plugin-desktop/src/electron-runtime.ts
@@ -16,6 +16,7 @@ import { desktopTerminalStateDirectory, openDesktopTerminal } from './desktop-te
 import { desktopInstallRecoveryStatePath } from './install-recovery.ts'
 import { packagedDependencyPath } from './packaged-runtime-path.ts'
 import { ElectronShellGeneration } from './electron-shell-generation.ts'
+import { electronPlatformStrategy, type ElectronPlatformStrategy } from './electron-platform.ts'
 import type {
   DesktopNotification,
   DesktopLocale,
@@ -86,17 +87,8 @@ export type RendererBootFailureReason = 'renderer-failed' | 'renderer-timeout'
 /** Native adapter used by the DSH Desktop launcher and owned by its Cordis shell plugin. */
 export class ElectronDesktopRuntime implements DesktopRuntime {
   readonly platform: DesktopPlatform
-  readonly updates: DesktopUpdateAdapter = {
-    get isPackaged() { return app.isPackaged },
-    get canDownload() { return app.isPackaged && (process.platform === 'darwin' || process.platform === 'win32') },
-    get currentVersion() { return PRODUCT_VERSION },
-    get statePath() { return join(app.getPath('userData'), 'updates', 'state.json') },
-    request: (url, init) => net.fetch(url, init),
-    confirmDownload: version => this.confirmUpdateDownload(version),
-    showManualCheckResult: result => this.showManualUpdateCheckResult(result),
-    downloadAndOpen: (version, signal) => this.downloadAndOpenUpdate(version, signal),
-    notify: notification => { this.showNotification(notification) },
-  }
+  private readonly platformStrategy: ElectronPlatformStrategy
+  readonly updates: DesktopUpdateAdapter
 
   private generation: ElectronShellGeneration | undefined
   private currentLocale: DesktopLocale = 'en'
@@ -118,10 +110,20 @@ export class ElectronDesktopRuntime implements DesktopRuntime {
     private readonly logger: DesktopLogger | undefined = undefined,
     private readonly workspaceVolumeQuery: WindowsVolumeQuery | undefined = undefined,
   ) {
-    if (process.platform !== 'darwin' && process.platform !== 'win32' && process.platform !== 'linux') {
-      throw new Error(`dsh-plugin-desktop: unsupported Electron platform ${process.platform}`)
+    this.platformStrategy = electronPlatformStrategy()
+    this.platform = this.platformStrategy.platform
+    const platformStrategy = this.platformStrategy
+    this.updates = {
+      get isPackaged() { return app.isPackaged },
+      get canDownload() { return app.isPackaged && platformStrategy.updateDownloadPlatform !== undefined },
+      get currentVersion() { return PRODUCT_VERSION },
+      get statePath() { return join(app.getPath('userData'), 'updates', 'state.json') },
+      request: (url, init) => net.fetch(url, init),
+      confirmDownload: version => this.confirmUpdateDownload(version),
+      showManualCheckResult: result => this.showManualUpdateCheckResult(result),
+      downloadAndOpen: (version, signal) => this.downloadAndOpenUpdate(version, signal),
+      notify: notification => { this.showNotification(notification) },
     }
-    this.platform = process.platform
   }
 
   /** Log an Electron-scope error to the sink, falling back to stderr without a logger. */
@@ -202,7 +204,7 @@ export class ElectronDesktopRuntime implements DesktopRuntime {
     if (this.mountTask === undefined) {
       this.setLocalePreference(spec.readLocalePreference())
       const generation = new ElectronShellGeneration({
-        platform: this.platform,
+        platform: this.platformStrategy,
         spec,
         preloadPath: desktopPreloadPath(),
         isQuitting: () => this.quitting,
@@ -227,7 +229,7 @@ export class ElectronDesktopRuntime implements DesktopRuntime {
 
   /** @inheritdoc */
   async pickDirectory(): Promise<string | null> {
-    if (this.platform !== 'win32') {
+    if (!this.platformStrategy.canPickDirectory) {
       throw new Error(`dsh-plugin-desktop: native workspace picker is unavailable on ${this.platform}`)
     }
     if (this.directoryPickTask !== undefined) return await this.directoryPickTask
@@ -572,11 +574,12 @@ export class ElectronDesktopRuntime implements DesktopRuntime {
 
   /** Download a confirmed installer and hand it to the native installation flow. */
   private async downloadAndOpenUpdate(version: string, signal: AbortSignal): Promise<void> {
-    if (this.platform !== 'darwin' && this.platform !== 'win32') {
+    const platform = this.platformStrategy.updateDownloadPlatform
+    if (platform === undefined) {
       throw new Error(`dsh-plugin-desktop: updates are unavailable on ${this.platform}`)
     }
     const artifactPath = await downloadDesktopUpdate({
-      platform: this.platform,
+      platform,
       version,
       userDataPath: app.getPath('userData'),
       request: (url, init) => net.fetch(url, init),
@@ -584,7 +587,7 @@ export class ElectronDesktopRuntime implements DesktopRuntime {
     })
     signal.throwIfAborted()
 
-    if (this.platform === 'darwin') {
+    if (platform === 'darwin') {
       const openError = await shell.openPath(artifactPath)
       if (openError !== '') throw new Error(`dsh-plugin-desktop: failed to open update disk image: ${openError}`)
       signal.throwIfAborted()
@@ -685,7 +688,7 @@ export class ElectronDesktopRuntime implements DesktopRuntime {
       { type: 'separator' },
       {
         label: modeToggleLabel(spec.mode, this.locale),
-        enabled: this.platform !== 'linux',
+        enabled: this.platformStrategy.canToggleShellMode,
         click: () => {
           void spec.requestModeChange(nextDesktopShellMode(spec.mode)).catch((cause: unknown) => {
             this.logError(`dsh-plugin-desktop: failed to change shell mode: ${cause instanceof Error ? cause.message : String(cause)}`)

--- a/dsh-plugin-desktop/src/electron-shell-generation.ts
+++ b/dsh-plugin-desktop/src/electron-shell-generation.ts
@@ -1,0 +1,210 @@
+import {
+  app,
+  BrowserWindow,
+  dialog,
+  Menu,
+  nativeImage,
+  nativeTheme,
+  shell,
+  Tray,
+} from 'electron'
+import { formatDesktopExitCode } from './desktop-logger.ts'
+import type { DesktopPlatform, DesktopShellSpec } from './runtime.ts'
+import { prepareTrayIcon } from './tray-icons.ts'
+import { desktopWindowOptions } from './window-options.ts'
+
+const MIN_ZOOM_LEVEL = -4
+const MAX_ZOOM_LEVEL = 4
+
+function clampedZoomLevel(level: number): number {
+  return Math.min(MAX_ZOOM_LEVEL, Math.max(MIN_ZOOM_LEVEL, level))
+}
+
+function isZoomShortcut(input: Electron.Input): 'in' | 'out' | 'reset' | undefined {
+  if (input.type !== 'keyDown' || input.alt || (!input.control && !input.meta)) return undefined
+  if (input.key === '+' || input.key === '=') return 'in'
+  if (input.key === '-' || input.key === '_') return 'out'
+  if (input.key === '0') return 'reset'
+  return undefined
+}
+
+export interface ElectronShellGenerationOptions {
+  readonly platform: DesktopPlatform
+  readonly spec: DesktopShellSpec
+  readonly preloadPath: string
+  readonly isQuitting: () => boolean
+  readonly buildTrayTemplate: () => Electron.MenuItemConstructorOptions[]
+  readonly stopRendererBootMonitoring: () => void
+  readonly failRendererBoot: (error: string) => void
+  readonly logError: (message: string) => void
+}
+
+/** Own one BrowserWindow and Tray generation, including every native listener. */
+export class ElectronShellGeneration {
+  private window: BrowserWindow | undefined
+  private tray: Tray | undefined
+  private mounted = false
+  private released = false
+  private cleanupListeners: (() => void) | undefined
+
+  constructor(private readonly options: ElectronShellGenerationOptions) {}
+
+  async mount(beforeInteractive?: () => void): Promise<void> {
+    if (this.mounted || this.window !== undefined) {
+      throw new Error('dsh-plugin-desktop: native shell generation is already mounted')
+    }
+
+    const { platform, spec } = this.options
+    const icon = nativeImage.createFromPath(spec.iconPath)
+    if (icon.isEmpty()) {
+      throw new Error(`dsh-plugin-desktop: failed to load application icon ${spec.iconPath}`)
+    }
+    if (platform === 'darwin') app.dock?.setIcon(icon)
+    const origin = new URL(spec.url).origin
+    if (spec.mode === 'advanced') nativeTheme.themeSource = spec.readThemeSource()
+    const window = new BrowserWindow(desktopWindowOptions(spec, icon, platform, this.options.preloadPath))
+    window.accessibleTitle = spec.windowTitle
+    if (platform === 'win32') window.removeMenu()
+    this.window = window
+
+    const show = (): void => { this.show() }
+    const close = (event: Electron.Event): void => {
+      if (this.options.isQuitting()) return
+      event.preventDefault()
+      window.hide()
+    }
+    const preserveBlankTitle = (event: Electron.Event): void => { event.preventDefault() }
+    const handleZoomShortcut = (event: Electron.Event, input: Electron.Input): void => {
+      const action = isZoomShortcut(input)
+      if (action === undefined) return
+      event.preventDefault()
+      if (action === 'reset') {
+        window.webContents.setZoomLevel(0)
+        return
+      }
+      const step = action === 'in' ? 1 : -1
+      window.webContents.setZoomLevel(clampedZoomLevel(window.webContents.getZoomLevel() + step))
+    }
+    const navigate = (event: Electron.Event<{ url: string }>): void => {
+      let targetOrigin: string | undefined
+      try {
+        targetOrigin = new URL(event.url).origin
+      } catch {
+        targetOrigin = undefined
+      }
+      if (targetOrigin !== origin) event.preventDefault()
+    }
+    const rendererGone = (_event: Electron.Event, details: Electron.RenderProcessGoneDetails): void => {
+      const detail = `renderer process gone (reason: ${details.reason}, exitCode: ${formatDesktopExitCode(details.exitCode)})`
+      this.options.logError(`dsh-plugin-desktop: ${detail}`)
+      this.options.failRendererBoot(detail)
+    }
+    const loadFailed = (
+      _event: Electron.Event,
+      errorCode: number,
+      errorDescription: string,
+      _validatedUrl: string,
+      isMainFrame: boolean,
+    ): void => {
+      this.options.logError(`dsh-plugin-desktop: renderer failed to load (${errorCode}: ${errorDescription})`)
+      if (isMainFrame === true && errorCode !== -3) {
+        this.options.failRendererBoot(
+          `renderer main frame failed to load (${String(errorCode)}: ${errorDescription})`,
+        )
+      }
+    }
+
+    app.on('activate', show)
+    window.on('close', close)
+    window.on('page-title-updated', preserveBlankTitle)
+    window.webContents.on('before-input-event', handleZoomShortcut)
+    window.webContents.on('will-frame-navigate', navigate)
+    window.webContents.on('will-redirect', navigate)
+    window.webContents.on('render-process-gone', rendererGone)
+    window.webContents.on('did-fail-load', loadFailed)
+    window.webContents.setWindowOpenHandler(({ url }) => {
+      try {
+        const target = new URL(url)
+        if (target.protocol === 'https:' || target.protocol === 'http:' || target.protocol === 'mailto:') {
+          void shell.openExternal(target.href).catch((cause: unknown) => {
+            this.options.logError(`dsh-plugin-desktop: failed to open external link: ${cause instanceof Error ? cause.message : String(cause)}`)
+          })
+        }
+      } catch {
+        // A malformed target is rejected with the same deny result.
+      }
+      return { action: 'deny' }
+    })
+    window.once('ready-to-show', show)
+    let tray: Tray | undefined
+    this.cleanupListeners = () => {
+      app.off('activate', show)
+      window.off('close', close)
+      window.off('page-title-updated', preserveBlankTitle)
+      window.off('ready-to-show', show)
+      window.webContents.off('before-input-event', handleZoomShortcut)
+      window.webContents.off('will-frame-navigate', navigate)
+      window.webContents.off('will-redirect', navigate)
+      window.webContents.off('render-process-gone', rendererGone)
+      window.webContents.off('did-fail-load', loadFailed)
+      tray?.off('click', show)
+    }
+
+    try {
+      await window.loadURL(spec.url)
+      tray = new Tray(prepareTrayIcon(spec.trayIcons, platform))
+      this.tray = tray
+      tray.setToolTip(spec.productName)
+      this.refreshTrayMenu()
+      tray.on('click', show)
+      beforeInteractive?.()
+      this.mounted = true
+    } catch (cause) {
+      await this.release()
+      throw cause
+    }
+  }
+
+  show(): void {
+    const window = this.window
+    if (window === undefined || window.isDestroyed()) return
+    if (window.isMinimized()) window.restore()
+    window.show()
+    window.focus()
+  }
+
+  async showOpenDialog(options: Electron.OpenDialogOptions): Promise<Electron.OpenDialogReturnValue> {
+    const window = this.window
+    return window === undefined || window.isDestroyed()
+      ? await dialog.showOpenDialog(options)
+      : await dialog.showOpenDialog(window, options)
+  }
+
+  refreshTrayMenu(): void {
+    if (this.tray === undefined) return
+    this.tray.setContextMenu(Menu.buildFromTemplate(this.options.buildTrayTemplate()))
+  }
+
+  refreshThemeMaterial(): void {
+    if (this.options.platform === 'win32' && this.window !== undefined && !this.window.isDestroyed()) {
+      this.window.setBackgroundMaterial('mica')
+    }
+  }
+
+  async release(): Promise<void> {
+    if (this.released) return
+    this.released = true
+    this.options.stopRendererBootMonitoring()
+
+    const window = this.window
+    const tray = this.tray
+    this.window = undefined
+    this.tray = undefined
+    if (window === undefined) return
+
+    this.cleanupListeners?.()
+    this.cleanupListeners = undefined
+    tray?.destroy()
+    if (!window.isDestroyed()) window.destroy()
+  }
+}

--- a/dsh-plugin-desktop/src/electron-shell-generation.ts
+++ b/dsh-plugin-desktop/src/electron-shell-generation.ts
@@ -9,7 +9,8 @@ import {
   Tray,
 } from 'electron'
 import { formatDesktopExitCode } from './desktop-logger.ts'
-import type { DesktopPlatform, DesktopShellSpec } from './runtime.ts'
+import type { ElectronPlatformStrategy } from './electron-platform.ts'
+import type { DesktopShellSpec } from './runtime.ts'
 import { prepareTrayIcon } from './tray-icons.ts'
 import { desktopWindowOptions } from './window-options.ts'
 
@@ -29,7 +30,7 @@ function isZoomShortcut(input: Electron.Input): 'in' | 'out' | 'reset' | undefin
 }
 
 export interface ElectronShellGenerationOptions {
-  readonly platform: DesktopPlatform
+  readonly platform: ElectronPlatformStrategy
   readonly spec: DesktopShellSpec
   readonly preloadPath: string
   readonly isQuitting: () => boolean
@@ -59,12 +60,12 @@ export class ElectronShellGeneration {
     if (icon.isEmpty()) {
       throw new Error(`dsh-plugin-desktop: failed to load application icon ${spec.iconPath}`)
     }
-    if (platform === 'darwin') app.dock?.setIcon(icon)
+    platform.configureApplication(icon)
     const origin = new URL(spec.url).origin
     if (spec.mode === 'advanced') nativeTheme.themeSource = spec.readThemeSource()
-    const window = new BrowserWindow(desktopWindowOptions(spec, icon, platform, this.options.preloadPath))
+    const window = new BrowserWindow(desktopWindowOptions(spec, icon, platform.platform, this.options.preloadPath))
     window.accessibleTitle = spec.windowTitle
-    if (platform === 'win32') window.removeMenu()
+    platform.configureWindow(window)
     this.window = window
 
     const show = (): void => { this.show() }
@@ -152,7 +153,7 @@ export class ElectronShellGeneration {
 
     try {
       await window.loadURL(spec.url)
-      tray = new Tray(prepareTrayIcon(spec.trayIcons, platform))
+      tray = new Tray(prepareTrayIcon(spec.trayIcons, platform.platform))
       this.tray = tray
       tray.setToolTip(spec.productName)
       this.refreshTrayMenu()
@@ -186,9 +187,7 @@ export class ElectronShellGeneration {
   }
 
   refreshThemeMaterial(): void {
-    if (this.options.platform === 'win32' && this.window !== undefined && !this.window.isDestroyed()) {
-      this.window.setBackgroundMaterial('mica')
-    }
+    if (this.window !== undefined && !this.window.isDestroyed()) this.options.platform.refreshThemeMaterial(this.window)
   }
 
   async release(): Promise<void> {

--- a/dsh-plugin-desktop/tests/electron-runtime.spec.ts
+++ b/dsh-plugin-desktop/tests/electron-runtime.spec.ts
@@ -580,6 +580,20 @@ describe('Electron compatibility runtime', () => {
 
     await release()
     expect(electron.webContents.off).toHaveBeenCalledWith('before-input-event', zoomListener)
+    expect(electron.webContents.off).toHaveBeenCalledWith(
+      'render-process-gone',
+      electron.webContents.on.mock.calls.find(([event]) => event === 'render-process-gone')?.[1],
+    )
+    expect(electron.webContents.off).toHaveBeenCalledWith(
+      'did-fail-load',
+      electron.webContents.on.mock.calls.find(([event]) => event === 'did-fail-load')?.[1],
+    )
+    expect(electron.trays[0]?.destroy).toHaveBeenCalledOnce()
+    expect(electron.browserWindows[0]?.destroy).toHaveBeenCalledOnce()
+
+    await release()
+    expect(electron.trays[0]?.destroy).toHaveBeenCalledOnce()
+    expect(electron.browserWindows[0]?.destroy).toHaveBeenCalledOnce()
   })
 
   it('does not mount a registration disposed before Host boot settles', async () => {

--- a/dsh-plugin-desktop/tests/electron-runtime.spec.ts
+++ b/dsh-plugin-desktop/tests/electron-runtime.spec.ts
@@ -331,6 +331,27 @@ describe('Electron compatibility runtime', () => {
     expect(electron.trays[0]?.off).toHaveBeenCalledWith('click', expect.any(Function))
   })
 
+  it('selects the restricted Linux platform adapter once for native capabilities', async () => {
+    vi.spyOn(process, 'platform', 'get').mockReturnValue('linux')
+    electron.app.isPackaged = true
+    const { ElectronDesktopRuntime } = await import('../src/electron-runtime.ts')
+    const runtime = new ElectronDesktopRuntime(async () => {})
+    const release = runtime.schedule(spec)
+
+    await runtime.mountScheduled()
+
+    expect(runtime.platform).toBe('linux')
+    expect(runtime.updates.canDownload).toBe(false)
+    await expect(runtime.pickDirectory()).rejects.toThrow('native workspace picker is unavailable on linux')
+    expect(electron.app.dock.setIcon).not.toHaveBeenCalled()
+    expect(electron.browserWindows[0]?.removeMenu).not.toHaveBeenCalled()
+    expect(electron.menuTemplates[0]).toEqual(expect.arrayContaining([
+      expect.objectContaining({ label: 'Switch to Advanced Mode', enabled: false }),
+    ]))
+
+    await release()
+  })
+
   it('opens one parented Windows folder chooser and returns its selected path', async () => {
     vi.spyOn(process, 'platform', 'get').mockReturnValue('win32')
     electron.dialog.showOpenDialog.mockResolvedValue({ canceled: false, filePaths: ['C:\\Work'] })


### PR DESCRIPTION
### Summary

- isolate each BrowserWindow and Tray generation behind one lifecycle module
- release native listeners and resources through one idempotent path
- select Windows, macOS, and Linux presentation capabilities through platform adapters
- keep the public DesktopRuntime interface unchanged

### Verification

- corepack yarn workspace dsh-plugin-desktop test: 541 passed, 11 skipped
- corepack yarn workspace dsh-plugin-desktop check:win-package: 155 passed; build, typecheck, and runtime closure passed
- post-rebase electron runtime suite: 38 passed

### Commit structure

- refactor(desktop): isolate native shell lifecycle
- refactor(desktop): select native platform adapters