### PR TITLE
feat(desktop): manage downloaded update installers

### DIFF
--- a/dsh-plugin-desktop/src/electron-runtime.ts
+++ b/dsh-plugin-desktop/src/electron-runtime.ts
@@ -41,6 +41,10 @@ import {
 import {
   desktopUpdateFilename,
   downloadDesktopUpdate,
+  pendingDesktopUpdateArtifact,
+  recordDesktopUpdateArtifact,
+  resolveDesktopUpdateArtifact,
+  type DesktopUpdateArtifact,
 } from './update-download.ts'
 import type { UpdateCheckResult } from './update-checker.ts'
 import {
@@ -102,6 +106,7 @@ export class ElectronDesktopRuntime implements DesktopRuntime {
   private terminalSpec: DesktopTerminalSpec | undefined
   private diagnosticExport: Promise<void> | undefined
   private directoryPickTask: Promise<string | null> | undefined
+  private updateCleanupTask: Promise<void> | undefined
   private rendererBootReported = false
   private rendererBootMonitoring = false
   private rendererBootTimer: NodeJS.Timeout | undefined
@@ -217,7 +222,11 @@ export class ElectronDesktopRuntime implements DesktopRuntime {
         logError: message => { this.logError(message) },
       })
       this.generation = generation
-      this.mountTask = generation.mount(beforeInteractive).catch((cause: unknown) => {
+      this.mountTask = generation.mount(beforeInteractive).then(() => {
+        void this.offerUpdateArtifactCleanup().catch((cause: unknown) => {
+          this.logError(`dsh-plugin-desktop: failed to resolve update installer cleanup: ${cause instanceof Error ? cause.message : String(cause)}`)
+        })
+      }).catch((cause: unknown) => {
         if (this.generation === generation) this.generation = undefined
         throw cause
       })
@@ -592,6 +601,12 @@ export class ElectronDesktopRuntime implements DesktopRuntime {
       signal,
     })
     signal.throwIfAborted()
+    const artifact: DesktopUpdateArtifact = { platform, version, path: artifactPath }
+    try {
+      await recordDesktopUpdateArtifact(app.getPath('userData'), artifact)
+    } catch (cause) {
+      this.logError(`dsh-plugin-desktop: failed to remember update installer for cleanup: ${cause instanceof Error ? cause.message : String(cause)}`)
+    }
 
     if (platform === 'darwin') {
       const openError = await shell.openPath(artifactPath)
@@ -647,6 +662,38 @@ export class ElectronDesktopRuntime implements DesktopRuntime {
       properties: ['createDirectory', 'showOverwriteConfirmation', 'dontAddToRecent'],
     })
     return result.canceled ? undefined : result.filePath
+  }
+
+  private offerUpdateArtifactCleanup(): Promise<void> {
+    if (this.updateCleanupTask !== undefined) return this.updateCleanupTask
+    const task = this.performUpdateArtifactCleanup().finally(() => {
+      if (this.updateCleanupTask === task) this.updateCleanupTask = undefined
+    })
+    this.updateCleanupTask = task
+    return task
+  }
+
+  private async performUpdateArtifactCleanup(): Promise<void> {
+    if (this.platform !== 'darwin' && this.platform !== 'win32') return
+    const userDataPath = app.getPath('userData')
+    const artifact = await pendingDesktopUpdateArtifact(userDataPath, PRODUCT_VERSION, this.platform)
+    if (artifact === undefined) return
+    const zh = this.currentLocale === 'zh'
+    const result = await dialog.showMessageBox({
+      type: 'question',
+      title: zh ? '删除更新安装包' : 'Remove Update Installer',
+      message: zh
+        ? `DSH Desktop ${artifact.version} 已安装。`
+        : `DSH Desktop ${artifact.version} has been installed.`,
+      detail: zh
+        ? `是否删除下载的安装包以释放磁盘空间？\n\n${artifact.path}`
+        : `Delete the downloaded installer to free disk space?\n\n${artifact.path}`,
+      buttons: zh ? ['删除安装包', '保留安装包'] : ['Delete Installer', 'Keep Installer'],
+      defaultId: 1,
+      cancelId: 1,
+      noLink: true,
+    })
+    await resolveDesktopUpdateArtifact(userDataPath, artifact, result.response === 0)
   }
 
   /** Start the downloaded NSIS installer before releasing the current process. */

--- a/dsh-plugin-desktop/src/electron-runtime.ts
+++ b/dsh-plugin-desktop/src/electron-runtime.ts
@@ -38,7 +38,10 @@ import {
   desktopLocaleFromLanguageTag,
   desktopTrayLabel,
 } from './tray-locale.ts'
-import { downloadDesktopUpdate } from './update-download.ts'
+import {
+  desktopUpdateFilename,
+  downloadDesktopUpdate,
+} from './update-download.ts'
 import type { UpdateCheckResult } from './update-checker.ts'
 import {
   evaluateWindowsWorkspaceVolume,
@@ -578,10 +581,13 @@ export class ElectronDesktopRuntime implements DesktopRuntime {
     if (platform === undefined) {
       throw new Error(`dsh-plugin-desktop: updates are unavailable on ${this.platform}`)
     }
+    const destinationPath = await this.chooseUpdateDestination(version)
+    if (destinationPath === undefined) return
+    signal.throwIfAborted()
     const artifactPath = await downloadDesktopUpdate({
       platform,
       version,
-      userDataPath: app.getPath('userData'),
+      destinationPath,
       request: (url, init) => net.fetch(url, init),
       signal,
     })
@@ -621,6 +627,26 @@ export class ElectronDesktopRuntime implements DesktopRuntime {
     await this.launchWindowsUpdateInstaller(artifactPath)
     this.quitting = true
     spec.requestQuit(0)
+  }
+
+  private async chooseUpdateDestination(version: string): Promise<string | undefined> {
+    if (this.platform !== 'darwin' && this.platform !== 'win32') return undefined
+    const zh = this.currentLocale === 'zh'
+    const filename = desktopUpdateFilename(this.platform, version)
+    const extension = this.platform === 'darwin' ? 'dmg' : 'exe'
+    const result = await dialog.showSaveDialog({
+      title: zh ? '保存更新安装包' : 'Save Update Installer',
+      defaultPath: join(app.getPath('downloads'), filename),
+      buttonLabel: zh ? '保存并下载' : 'Save and Download',
+      filters: [{
+        name: this.platform === 'darwin'
+          ? zh ? '磁盘映像' : 'Disk Image'
+          : zh ? 'Windows 安装程序' : 'Windows Installer',
+        extensions: [extension],
+      }],
+      properties: ['createDirectory', 'showOverwriteConfirmation', 'dontAddToRecent'],
+    })
+    return result.canceled ? undefined : result.filePath
   }
 
   /** Start the downloaded NSIS installer before releasing the current process. */

--- a/dsh-plugin-desktop/src/update-download.ts
+++ b/dsh-plugin-desktop/src/update-download.ts
@@ -1,8 +1,8 @@
 /** Headless, confirmation-gated downloads for DSH Desktop installers. */
 
 import { randomUUID } from 'node:crypto'
-import { chmod, lstat, mkdir, open, rename, unlink } from 'node:fs/promises'
-import { isAbsolute, join, resolve } from 'node:path'
+import { lstat, open, rename, unlink } from 'node:fs/promises'
+import { basename, dirname, extname, isAbsolute, join, resolve } from 'node:path'
 import { parseSemVer } from './update-checker.ts'
 
 /** Desktop platforms with a fixed installer download endpoint. */
@@ -34,10 +34,10 @@ export type UpdateArtifactRequest = (url: string, init: RequestInit) => Promise<
 export interface DownloadDesktopUpdateOptions {
   /** Host platform selecting the fixed endpoint and installer validation. */
   readonly platform: DesktopDownloadPlatform
-  /** Stable release version used as one private directory segment. */
+  /** Stable release version used to validate the selected installer. */
   readonly version: string
-  /** Absolute Electron user-data directory that owns update artifacts. */
-  readonly userDataPath: string
+  /** Absolute installer path selected by the user. */
+  readonly destinationPath: string
   /** Request implementation, normally backed by Electron `net.fetch`. */
   readonly request: UpdateArtifactRequest
   /** Optional cancellation signal owned by the update coordinator. */
@@ -69,7 +69,6 @@ export class UpdateDownloadError extends Error {
   }
 }
 
-const PRIVATE_DIRECTORY_MODE = 0o700
 const PRIVATE_FILE_MODE = 0o600
 const DECIMAL_BYTES = /^(0|[1-9][0-9]*)$/u
 const DMG_TRAILER_BYTES = 512
@@ -79,22 +78,21 @@ const PE_OFFSET_POSITION = 0x3c
 const PE_MAGIC = Buffer.from([0x50, 0x45, 0x00, 0x00])
 
 interface DownloadPaths {
-  readonly directory: string
   readonly completed: string
   readonly temporary: string
 }
 
 /**
  * Download one installer after its caller has obtained user confirmation.
- * @param options - Fixed platform, release version, private storage, request, and cancellation inputs.
+ * @param options - Fixed platform, release version, selected destination, request, and cancellation inputs.
  * @returns Absolute path to the completely written and validated installer.
  * @throws {UpdateDownloadError} For invalid inputs, transport failures, rejected responses, cancellation, and invalid installers.
  */
 export async function downloadDesktopUpdate(options: DownloadDesktopUpdateOptions): Promise<string> {
   const platform = validatedPlatform(options.platform)
-  const version = validatedVersion(options.version)
-  const userDataPath = validatedUserDataPath(options.userDataPath)
-  const paths = await prepareDownloadPaths(userDataPath, platform, version)
+  validatedVersion(options.version)
+  const destinationPath = validatedArtifactPath(options.destinationPath, platform)
+  const paths = await prepareDownloadPaths(destinationPath)
   throwIfAborted(options.signal)
 
   let response: Response
@@ -128,6 +126,7 @@ export async function downloadDesktopUpdate(options: DownloadDesktopUpdateOption
     throwIfAborted(options.signal)
     await validateArtifact(paths.temporary, platform)
     throwIfAborted(options.signal)
+    await unlinkIfPresent(paths.completed)
     await rename(paths.temporary, paths.completed)
     return paths.completed
   } catch (cause) {
@@ -141,6 +140,15 @@ export async function downloadDesktopUpdate(options: DownloadDesktopUpdateOption
       throw new AggregateError([failure, cleanupCause], 'Failed to download and clean up the update installer.')
     }
   }
+}
+
+/** Fixed default filename shown by the native destination picker. */
+export function desktopUpdateFilename(platform: DesktopDownloadPlatform, version: string): string {
+  validatedPlatform(platform)
+  validatedVersion(version)
+  const extension = platform === 'darwin' ? 'dmg' : 'exe'
+  const platformName = platform === 'darwin' ? 'mac' : 'windows'
+  return `DSH-Desktop-${version}-${platformName}.${extension}`
 }
 
 function validatedPlatform(platform: DesktopDownloadPlatform): DesktopDownloadPlatform {
@@ -158,57 +166,36 @@ function validatedVersion(version: string): string {
   return version
 }
 
-function validatedUserDataPath(userDataPath: string): string {
-  if (userDataPath.length === 0 || /[\0\r\n]/u.test(userDataPath) || !isAbsolute(userDataPath)) {
-    throw new UpdateDownloadError('invalid-options', 'The update user-data path must be an absolute path.')
-  }
-  return resolve(userDataPath)
-}
-
 async function prepareDownloadPaths(
-  userDataPath: string,
-  platform: DesktopDownloadPlatform,
-  version: string,
+  destinationPath: string,
 ): Promise<DownloadPaths> {
-  const userDataStat = await lstat(userDataPath)
-  if (!userDataStat.isDirectory() || userDataStat.isSymbolicLink()) {
-    throw new UpdateDownloadError('invalid-options', 'The update user-data path must be a real directory.')
+  const directory = dirname(destinationPath)
+  const directoryStat = await lstat(directory)
+  if (!directoryStat.isDirectory() || directoryStat.isSymbolicLink()) {
+    throw new UpdateDownloadError('invalid-options', 'The update destination directory must be a real directory.')
   }
-
-  const updatesDirectory = join(userDataPath, 'updates')
-  const directory = join(updatesDirectory, version)
-  if (resolve(directory) !== directory) {
-    throw new UpdateDownloadError('invalid-options', 'The update destination escaped the user-data directory.')
-  }
-  await preparePrivateDirectory(updatesDirectory)
-  await preparePrivateDirectory(directory)
-
-  const extension = platform === 'darwin' ? 'dmg' : 'exe'
-  const platformName = platform === 'darwin' ? 'mac' : 'windows'
-  const filename = `DSH-Desktop-${version}-${platformName}.${extension}`
-  const completed = join(directory, filename)
-  const completedStat = await lstatOptional(completed)
+  const completedStat = await lstatOptional(destinationPath)
   if (completedStat !== undefined) {
     if (!completedStat.isFile() || completedStat.isSymbolicLink()) {
       throw new UpdateDownloadError('invalid-options', 'The completed update path is not a regular file.')
     }
-    await unlink(completed)
   }
 
   return {
-    directory,
-    completed,
-    temporary: join(directory, `.${filename}.${process.pid}.${randomUUID()}.partial`),
+    completed: destinationPath,
+    temporary: join(directory, `.${basename(destinationPath)}.${process.pid}.${randomUUID()}.partial`),
   }
 }
 
-async function preparePrivateDirectory(directory: string): Promise<void> {
-  await mkdir(directory, { recursive: true, mode: PRIVATE_DIRECTORY_MODE })
-  const stat = await lstat(directory)
-  if (!stat.isDirectory() || stat.isSymbolicLink()) {
-    throw new UpdateDownloadError('invalid-options', 'An update destination component is not a real directory.')
+function validatedArtifactPath(path: string, platform: DesktopDownloadPlatform): string {
+  if (path.length === 0 || /[\0\r\n]/u.test(path) || !isAbsolute(path)) {
+    throw new UpdateDownloadError('invalid-options', 'The update destination path must be absolute.')
   }
-  await chmod(directory, PRIVATE_DIRECTORY_MODE)
+  const expectedExtension = platform === 'darwin' ? '.dmg' : '.exe'
+  if (extname(path).toLowerCase() !== expectedExtension) {
+    throw new UpdateDownloadError('invalid-options', `The update destination must use ${expectedExtension}.`)
+  }
+  return resolve(path)
 }
 
 async function lstatOptional(filename: string): Promise<Awaited<ReturnType<typeof lstat>> | undefined> {

--- a/dsh-plugin-desktop/src/update-download.ts
+++ b/dsh-plugin-desktop/src/update-download.ts
@@ -1,9 +1,10 @@
 /** Headless, confirmation-gated downloads for DSH Desktop installers. */
 
 import { randomUUID } from 'node:crypto'
-import { lstat, open, rename, unlink } from 'node:fs/promises'
+import { chmod, lstat, mkdir, open, readFile, rename, unlink } from 'node:fs/promises'
 import { basename, dirname, extname, isAbsolute, join, resolve } from 'node:path'
-import { parseSemVer } from './update-checker.ts'
+import { writeFileAtomic } from '@deepseek-ai/dsh-atomic-write'
+import { compareSemVerVersions, parseSemVer } from './update-checker.ts'
 
 /** Desktop platforms with a fixed installer download endpoint. */
 export type DesktopDownloadPlatform = 'darwin' | 'win32'
@@ -69,6 +70,7 @@ export class UpdateDownloadError extends Error {
   }
 }
 
+const PRIVATE_DIRECTORY_MODE = 0o700
 const PRIVATE_FILE_MODE = 0o600
 const DECIMAL_BYTES = /^(0|[1-9][0-9]*)$/u
 const DMG_TRAILER_BYTES = 512
@@ -81,6 +83,17 @@ interface DownloadPaths {
   readonly completed: string
   readonly temporary: string
 }
+
+/** Downloaded installer tracked until the upgraded application resolves retention. */
+export interface DesktopUpdateArtifact {
+  readonly platform: DesktopDownloadPlatform
+  readonly version: string
+  readonly path: string
+}
+
+const UPDATE_ARTIFACT_STATE_VERSION = 1
+const UPDATE_ARTIFACT_STATE_BYTES = 4 * 1024
+const UPDATE_ARTIFACT_STATE_FILENAME = 'pending-installer.json'
 
 /**
  * Download one installer after its caller has obtained user confirmation.
@@ -151,6 +164,72 @@ export function desktopUpdateFilename(platform: DesktopDownloadPlatform, version
   return `DSH-Desktop-${version}-${platformName}.${extension}`
 }
 
+/** Remember a downloaded installer until an upgraded application resolves its retention. */
+export async function recordDesktopUpdateArtifact(
+  userDataPath: string,
+  artifact: DesktopUpdateArtifact,
+): Promise<void> {
+  const statePath = await prepareArtifactStatePath(userDataPath)
+  const value = await validatedArtifactRecord(artifact, true)
+  await writeFileAtomic(statePath, `${JSON.stringify({
+    stateVersion: UPDATE_ARTIFACT_STATE_VERSION,
+    ...value,
+  })}\n`, {
+    mode: PRIVATE_FILE_MODE,
+    dirMode: PRIVATE_DIRECTORY_MODE,
+  })
+}
+
+/** Return a retained installer only after the running version reaches its target. */
+export async function pendingDesktopUpdateArtifact(
+  userDataPath: string,
+  currentVersion: string,
+  platform: DesktopDownloadPlatform,
+): Promise<DesktopUpdateArtifact | undefined> {
+  const statePath = artifactStatePath(validatedUserDataPath(userDataPath))
+  validatedVersion(currentVersion)
+  validatedPlatform(platform)
+  let value: DesktopUpdateArtifact
+  try {
+    value = await readArtifactRecord(statePath)
+  } catch (cause) {
+    if ((cause as NodeJS.ErrnoException).code === 'ENOENT') return undefined
+    throw cause
+  }
+  if (value.platform !== platform) return undefined
+  const comparison = compareSemVerVersions(currentVersion, value.version)
+  if (comparison === null || comparison < 0) return undefined
+  try {
+    const stat = await lstat(value.path)
+    if (!stat.isFile() || stat.isSymbolicLink()) {
+      throw new UpdateDownloadError('invalid-options', 'The retained update installer is not a regular file.')
+    }
+  } catch (cause) {
+    if ((cause as NodeJS.ErrnoException).code !== 'ENOENT') throw cause
+    await unlinkIfPresent(statePath)
+    return undefined
+  }
+  return value
+}
+
+/** Apply one explicit delete/keep choice and consume its cleanup state. */
+export async function resolveDesktopUpdateArtifact(
+  userDataPath: string,
+  artifact: DesktopUpdateArtifact,
+  remove: boolean,
+): Promise<void> {
+  const statePath = artifactStatePath(validatedUserDataPath(userDataPath))
+  const current = await readArtifactRecord(statePath)
+  const expected = await validatedArtifactRecord(artifact, false)
+  if (current.platform !== expected.platform
+    || current.version !== expected.version
+    || current.path !== expected.path) {
+    throw new UpdateDownloadError('invalid-options', 'The update artifact cleanup state changed.')
+  }
+  if (remove) await unlinkIfPresent(expected.path)
+  await unlinkIfPresent(statePath)
+}
+
 function validatedPlatform(platform: DesktopDownloadPlatform): DesktopDownloadPlatform {
   if (platform !== 'darwin' && platform !== 'win32') {
     throw new UpdateDownloadError('invalid-options', `Unsupported update download platform: ${String(platform)}`)
@@ -164,6 +243,13 @@ function validatedVersion(version: string): string {
     throw new UpdateDownloadError('invalid-options', 'The update version must be stable Semantic Versioning.')
   }
   return version
+}
+
+function validatedUserDataPath(userDataPath: string): string {
+  if (userDataPath.length === 0 || /[\0\r\n]/u.test(userDataPath) || !isAbsolute(userDataPath)) {
+    throw new UpdateDownloadError('invalid-options', 'The update user-data path must be an absolute path.')
+  }
+  return resolve(userDataPath)
 }
 
 async function prepareDownloadPaths(
@@ -196,6 +282,72 @@ function validatedArtifactPath(path: string, platform: DesktopDownloadPlatform):
     throw new UpdateDownloadError('invalid-options', `The update destination must use ${expectedExtension}.`)
   }
   return resolve(path)
+}
+
+async function prepareArtifactStatePath(userDataPath: string): Promise<string> {
+  const root = validatedUserDataPath(userDataPath)
+  const rootStat = await lstat(root)
+  if (!rootStat.isDirectory() || rootStat.isSymbolicLink()) {
+    throw new UpdateDownloadError('invalid-options', 'The update user-data path must be a real directory.')
+  }
+  const directory = join(root, 'updates')
+  await preparePrivateDirectory(directory)
+  return artifactStatePath(root)
+}
+
+function artifactStatePath(userDataPath: string): string {
+  return join(userDataPath, 'updates', UPDATE_ARTIFACT_STATE_FILENAME)
+}
+
+async function validatedArtifactRecord(
+  artifact: DesktopUpdateArtifact,
+  requireFile: boolean,
+): Promise<DesktopUpdateArtifact> {
+  const platform = validatedPlatform(artifact.platform)
+  const version = validatedVersion(artifact.version)
+  const path = validatedArtifactPath(artifact.path, platform)
+  if (requireFile) {
+    const stat = await lstat(path)
+    if (!stat.isFile() || stat.isSymbolicLink()) {
+      throw new UpdateDownloadError('invalid-options', 'The retained update installer must be a regular file.')
+    }
+  }
+  return { platform, version, path }
+}
+
+async function parseArtifactRecord(text: string): Promise<DesktopUpdateArtifact> {
+  let value: unknown
+  try { value = JSON.parse(text) } catch {
+    throw new UpdateDownloadError('invalid-options', 'The update artifact cleanup state is invalid.')
+  }
+  if (value === null
+    || typeof value !== 'object'
+    || (value as { stateVersion?: unknown }).stateVersion !== UPDATE_ARTIFACT_STATE_VERSION
+    || ((value as { platform?: unknown }).platform !== 'darwin'
+      && (value as { platform?: unknown }).platform !== 'win32')
+    || typeof (value as { version?: unknown }).version !== 'string'
+    || typeof (value as { path?: unknown }).path !== 'string'
+    || Object.keys(value).some(key => !['stateVersion', 'platform', 'version', 'path'].includes(key))) {
+    throw new UpdateDownloadError('invalid-options', 'The update artifact cleanup state is invalid.')
+  }
+  return await validatedArtifactRecord(value as DesktopUpdateArtifact, false)
+}
+
+async function readArtifactRecord(statePath: string): Promise<DesktopUpdateArtifact> {
+  const stat = await lstat(statePath)
+  if (!stat.isFile() || stat.isSymbolicLink() || stat.size > UPDATE_ARTIFACT_STATE_BYTES) {
+    throw new UpdateDownloadError('invalid-options', 'The update artifact cleanup state is invalid.')
+  }
+  return await parseArtifactRecord(await readFile(statePath, 'utf8'))
+}
+
+async function preparePrivateDirectory(directory: string): Promise<void> {
+  await mkdir(directory, { recursive: true, mode: PRIVATE_DIRECTORY_MODE })
+  const stat = await lstat(directory)
+  if (!stat.isDirectory() || stat.isSymbolicLink()) {
+    throw new UpdateDownloadError('invalid-options', 'An update destination component is not a real directory.')
+  }
+  await chmod(directory, PRIVATE_DIRECTORY_MODE)
 }
 
 async function lstatOptional(filename: string): Promise<Awaited<ReturnType<typeof lstat>> | undefined> {

--- a/dsh-plugin-desktop/tests/electron-runtime.spec.ts
+++ b/dsh-plugin-desktop/tests/electron-runtime.spec.ts
@@ -4,7 +4,10 @@ import type { DesktopShellSpec } from '../src/runtime.ts'
 
 const terminal = vi.hoisted(() => ({ open: vi.fn() }))
 const diagnostics = vi.hoisted(() => ({ export: vi.fn() }))
-const updater = vi.hoisted(() => ({ download: vi.fn() }))
+const updater = vi.hoisted(() => ({
+  download: vi.fn(),
+  filename: vi.fn(),
+}))
 const childProcess = vi.hoisted(() => {
   type Listener = (...args: unknown[]) => void
   const listeners = new Map<string, Listener[]>()
@@ -41,6 +44,7 @@ vi.mock('../src/diagnostic-export.ts', () => ({
 }))
 
 vi.mock('../src/update-download.ts', () => ({
+  desktopUpdateFilename: updater.filename,
   downloadDesktopUpdate: updater.download,
 }))
 
@@ -62,6 +66,7 @@ const electron = vi.hoisted(() => {
   const dialog = {
     showErrorBox: vi.fn(),
     showOpenDialog: vi.fn(async () => ({ canceled: true, filePaths: [] as string[] })),
+    showSaveDialog: vi.fn(async () => ({ canceled: true, filePath: undefined as string | undefined })),
     showMessageBox: vi.fn(async () => ({ response: 0, checkboxChecked: false })),
   }
   const appIcon = {
@@ -145,9 +150,11 @@ const electron = vi.hoisted(() => {
     app: {
       dock: { setIcon: vi.fn() },
       getLocale: vi.fn(() => 'en-US'),
-      getPath: vi.fn((name: string) => name === 'crashDumps'
-        ? '/tmp/dsh-desktop-user-data/Crashpad'
-        : '/tmp/dsh-desktop-user-data'),
+      getPath: vi.fn((name: string) => {
+        if (name === 'crashDumps') return '/tmp/dsh-desktop-user-data/Crashpad'
+        if (name === 'downloads') return '/tmp/Downloads'
+        return '/tmp/dsh-desktop-user-data'
+      }),
       getVersion: vi.fn(() => '43.4.0'),
       isPackaged: false,
       on: vi.fn(),
@@ -233,11 +240,16 @@ describe('Electron compatibility runtime', () => {
     childProcess.reset()
     vi.clearAllMocks()
     updater.download.mockReset()
+    updater.filename.mockReset()
+    updater.filename.mockImplementation((platform: string, version: string) => (
+      `DSH-Desktop-${version}-${platform === 'darwin' ? 'mac.dmg' : 'windows.exe'}`
+    ))
     diagnostics.export.mockReset()
     electron.loadURL.mockReset()
     electron.loadURL.mockResolvedValue(undefined)
     electron.dialog.showMessageBox.mockResolvedValue({ response: 0, checkboxChecked: false })
     electron.dialog.showOpenDialog.mockResolvedValue({ canceled: true, filePaths: [] })
+    electron.dialog.showSaveDialog.mockResolvedValue({ canceled: true, filePath: undefined })
     electron.shell.openPath.mockResolvedValue('')
     electron.nativeTheme.themeSource = 'system'
     electron.resetZoomLevel()
@@ -1068,11 +1080,19 @@ describe('Electron compatibility runtime', () => {
     electron.dialog.showMessageBox.mockResolvedValueOnce({ response: 0, checkboxChecked: false })
     await expect(runtime.updates.confirmDownload('2.1.0')).resolves.toBe(true)
     const controller = new AbortController()
+    electron.dialog.showSaveDialog.mockResolvedValueOnce({
+      canceled: false,
+      filePath: '/tmp/Downloads/DSH-Desktop-2.1.0-mac.dmg',
+    })
     await runtime.updates.downloadAndOpen('2.1.0', controller.signal)
+    expect(electron.dialog.showSaveDialog).toHaveBeenCalledWith(expect.objectContaining({
+      defaultPath: join('/tmp/Downloads', 'DSH-Desktop-2.1.0-mac.dmg'),
+      filters: [{ name: 'Disk Image', extensions: ['dmg'] }],
+    }))
     expect(updater.download).toHaveBeenCalledWith({
       platform: 'darwin',
       version: '2.1.0',
-      userDataPath: '/tmp/dsh-desktop-user-data',
+      destinationPath: '/tmp/Downloads/DSH-Desktop-2.1.0-mac.dmg',
       request: expect.any(Function),
       signal: controller.signal,
     })
@@ -1102,6 +1122,10 @@ describe('Electron compatibility runtime', () => {
     const { ElectronDesktopRuntime } = await import('../src/electron-runtime.ts')
     const runtime = new ElectronDesktopRuntime(async () => {})
     runtime.schedule({ ...spec, requestQuit })
+    electron.dialog.showSaveDialog.mockResolvedValueOnce({
+      canceled: false,
+      filePath: 'C:\\Updates\\DSH-Desktop-2.1.0-windows.exe',
+    })
 
     const pending = runtime.updates.downloadAndOpen('2.1.0', new AbortController().signal)
     await vi.waitFor(() => { expect(childProcess.spawn).toHaveBeenCalledOnce() })
@@ -1130,6 +1154,10 @@ describe('Electron compatibility runtime', () => {
     const { ElectronDesktopRuntime } = await import('../src/electron-runtime.ts')
     const runtime = new ElectronDesktopRuntime(async () => {})
     runtime.schedule({ ...spec, requestQuit })
+    electron.dialog.showSaveDialog.mockResolvedValueOnce({
+      canceled: false,
+      filePath: 'C:\\Updates\\DSH-Desktop-2.1.0-windows.exe',
+    })
 
     const pending = runtime.updates.downloadAndOpen('2.1.0', new AbortController().signal)
     await vi.waitFor(() => { expect(childProcess.spawn).toHaveBeenCalledOnce() })
@@ -1146,10 +1174,25 @@ describe('Electron compatibility runtime', () => {
     electron.dialog.showMessageBox.mockResolvedValueOnce({ response: 1, checkboxChecked: false })
     const { ElectronDesktopRuntime } = await import('../src/electron-runtime.ts')
     const runtime = new ElectronDesktopRuntime(async () => {})
+    electron.dialog.showSaveDialog.mockResolvedValueOnce({
+      canceled: false,
+      filePath: 'C:\\Updates\\DSH-Desktop-2.1.0-windows.exe',
+    })
 
     await runtime.updates.downloadAndOpen('2.1.0', new AbortController().signal)
 
     expect(childProcess.spawn).not.toHaveBeenCalled()
+  })
+
+  it('does not download when the update destination picker is cancelled', async () => {
+    vi.spyOn(process, 'platform', 'get').mockReturnValue('win32')
+    const { ElectronDesktopRuntime } = await import('../src/electron-runtime.ts')
+    const runtime = new ElectronDesktopRuntime(async () => {})
+
+    await runtime.updates.downloadAndOpen('2.1.0', new AbortController().signal)
+
+    expect(electron.dialog.showSaveDialog).toHaveBeenCalledOnce()
+    expect(updater.download).not.toHaveBeenCalled()
   })
 
   it('rejects a macOS handoff when the operating system cannot open the DMG', async () => {
@@ -1158,6 +1201,10 @@ describe('Electron compatibility runtime', () => {
     electron.shell.openPath.mockResolvedValueOnce('Launch Services rejected the image')
     const { ElectronDesktopRuntime } = await import('../src/electron-runtime.ts')
     const runtime = new ElectronDesktopRuntime(async () => {})
+    electron.dialog.showSaveDialog.mockResolvedValueOnce({
+      canceled: false,
+      filePath: '/tmp/DSH-Desktop-2.1.0-mac.dmg',
+    })
 
     await expect(runtime.updates.downloadAndOpen('2.1.0', new AbortController().signal))
       .rejects.toThrow('Launch Services rejected the image')
@@ -1174,6 +1221,10 @@ describe('Electron compatibility runtime', () => {
     const { ElectronDesktopRuntime } = await import('../src/electron-runtime.ts')
     const runtime = new ElectronDesktopRuntime(async () => {})
     const controller = new AbortController()
+    electron.dialog.showSaveDialog.mockResolvedValueOnce({
+      canceled: false,
+      filePath: '/tmp/DSH-Desktop-2.1.0-mac.dmg',
+    })
 
     const pending = runtime.updates.downloadAndOpen('2.1.0', controller.signal)
     await vi.waitFor(() => { expect(electron.shell.openPath).toHaveBeenCalledOnce() })

--- a/dsh-plugin-desktop/tests/electron-runtime.spec.ts
+++ b/dsh-plugin-desktop/tests/electron-runtime.spec.ts
@@ -7,6 +7,9 @@ const diagnostics = vi.hoisted(() => ({ export: vi.fn() }))
 const updater = vi.hoisted(() => ({
   download: vi.fn(),
   filename: vi.fn(),
+  pending: vi.fn(),
+  record: vi.fn(),
+  resolve: vi.fn(),
 }))
 const childProcess = vi.hoisted(() => {
   type Listener = (...args: unknown[]) => void
@@ -46,6 +49,9 @@ vi.mock('../src/diagnostic-export.ts', () => ({
 vi.mock('../src/update-download.ts', () => ({
   desktopUpdateFilename: updater.filename,
   downloadDesktopUpdate: updater.download,
+  pendingDesktopUpdateArtifact: updater.pending,
+  recordDesktopUpdateArtifact: updater.record,
+  resolveDesktopUpdateArtifact: updater.resolve,
 }))
 
 vi.mock('node:child_process', async (importOriginal) => ({
@@ -244,6 +250,12 @@ describe('Electron compatibility runtime', () => {
     updater.filename.mockImplementation((platform: string, version: string) => (
       `DSH-Desktop-${version}-${platform === 'darwin' ? 'mac.dmg' : 'windows.exe'}`
     ))
+    updater.pending.mockReset()
+    updater.pending.mockResolvedValue(undefined)
+    updater.record.mockReset()
+    updater.record.mockResolvedValue(undefined)
+    updater.resolve.mockReset()
+    updater.resolve.mockResolvedValue(undefined)
     diagnostics.export.mockReset()
     electron.loadURL.mockReset()
     electron.loadURL.mockResolvedValue(undefined)
@@ -1097,6 +1109,11 @@ describe('Electron compatibility runtime', () => {
       signal: controller.signal,
     })
     expect(electron.shell.openPath).toHaveBeenCalledWith('/tmp/DSH-Desktop-2.1.0-mac.dmg')
+    expect(updater.record).toHaveBeenCalledWith('/tmp/dsh-desktop-user-data', {
+      platform: 'darwin',
+      version: '2.1.0',
+      path: '/tmp/DSH-Desktop-2.1.0-mac.dmg',
+    })
     expect(electron.dialog.showMessageBox).toHaveBeenLastCalledWith(expect.objectContaining({
       title: 'DSH Desktop Update Downloaded',
       buttons: ['OK'],
@@ -1144,6 +1161,11 @@ describe('Electron compatibility runtime', () => {
     await pending
 
     expect(childProcess.child.unref).toHaveBeenCalledOnce()
+    expect(updater.record).toHaveBeenCalledWith('/tmp/dsh-desktop-user-data', {
+      platform: 'win32',
+      version: '2.1.0',
+      path: 'C:\\Updates\\DSH-Desktop-2.1.0-windows.exe',
+    })
     expect(requestQuit).toHaveBeenCalledWith(0)
   })
 
@@ -1164,6 +1186,12 @@ describe('Electron compatibility runtime', () => {
     childProcess.emit('error', new Error('blocked'))
 
     await expect(pending).rejects.toThrow('blocked')
+    expect(updater.record).toHaveBeenCalledWith('/tmp/dsh-desktop-user-data', {
+      platform: 'win32',
+      version: '2.1.0',
+      path: 'C:\\Updates\\DSH-Desktop-2.1.0-windows.exe',
+    })
+    expect(updater.resolve).not.toHaveBeenCalled()
     expect(childProcess.child.unref).not.toHaveBeenCalled()
     expect(requestQuit).not.toHaveBeenCalled()
   })
@@ -1182,6 +1210,29 @@ describe('Electron compatibility runtime', () => {
     await runtime.updates.downloadAndOpen('2.1.0', new AbortController().signal)
 
     expect(childProcess.spawn).not.toHaveBeenCalled()
+    expect(updater.record).toHaveBeenCalledOnce()
+  })
+
+  it('continues the update handoff when cleanup tracking cannot be persisted', async () => {
+    vi.spyOn(process, 'platform', 'get').mockReturnValue('win32')
+    updater.download.mockResolvedValueOnce('C:\\Updates\\DSH-Desktop-2.1.0-windows.exe')
+    updater.record.mockRejectedValueOnce(new Error('read-only user data'))
+    electron.dialog.showMessageBox.mockResolvedValueOnce({ response: 1, checkboxChecked: false })
+    electron.dialog.showSaveDialog.mockResolvedValueOnce({
+      canceled: false,
+      filePath: 'C:\\Updates\\DSH-Desktop-2.1.0-windows.exe',
+    })
+    const logger = { error: vi.fn(), errorCause: vi.fn() }
+    const { ElectronDesktopRuntime } = await import('../src/electron-runtime.ts')
+    const runtime = new ElectronDesktopRuntime(async () => {}, undefined, logger)
+
+    await expect(runtime.updates.downloadAndOpen('2.1.0', new AbortController().signal))
+      .resolves.toBeUndefined()
+
+    expect(logger.error).toHaveBeenCalledWith(
+      'dsh-plugin-desktop: failed to remember update installer for cleanup: read-only user data',
+    )
+    expect(childProcess.spawn).not.toHaveBeenCalled()
   })
 
   it('does not download when the update destination picker is cancelled', async () => {
@@ -1193,6 +1244,33 @@ describe('Electron compatibility runtime', () => {
 
     expect(electron.dialog.showSaveDialog).toHaveBeenCalledOnce()
     expect(updater.download).not.toHaveBeenCalled()
+  })
+
+  it.each([
+    [0, true],
+    [1, false],
+  ])('resolves the post-install artifact choice response=%s remove=%s', async (response, remove) => {
+    vi.spyOn(process, 'platform', 'get').mockReturnValue('win32')
+    const artifact = {
+      platform: 'win32' as const,
+      version: '2.0.1',
+      path: 'C:\\Updates\\DSH-Desktop-2.0.1-windows.exe',
+    }
+    updater.pending.mockResolvedValueOnce(artifact)
+    electron.dialog.showMessageBox.mockResolvedValueOnce({ response, checkboxChecked: false })
+    const { ElectronDesktopRuntime } = await import('../src/electron-runtime.ts')
+    const runtime = new ElectronDesktopRuntime(async () => {})
+    runtime.schedule(spec)
+
+    await runtime.mountScheduled()
+    await vi.waitFor(() => { expect(updater.resolve).toHaveBeenCalledOnce() })
+
+    expect(electron.dialog.showMessageBox).toHaveBeenCalledWith(expect.objectContaining({
+      title: 'Remove Update Installer',
+      detail: expect.stringContaining(artifact.path),
+      buttons: ['Delete Installer', 'Keep Installer'],
+    }))
+    expect(updater.resolve).toHaveBeenCalledWith('/tmp/dsh-desktop-user-data', artifact, remove)
   })
 
   it('rejects a macOS handoff when the operating system cannot open the DMG', async () => {

--- a/dsh-plugin-desktop/tests/update-download.spec.ts
+++ b/dsh-plugin-desktop/tests/update-download.spec.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, readFile, readdir, rm, symlink, writeFile } from 'node:fs/promises'
+import { access, mkdir, mkdtemp, readFile, readdir, rm, symlink, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, describe, expect, it } from 'vitest'
@@ -8,6 +8,9 @@ import {
   UpdateDownloadError,
   desktopUpdateFilename,
   downloadDesktopUpdate,
+  pendingDesktopUpdateArtifact,
+  recordDesktopUpdateArtifact,
+  resolveDesktopUpdateArtifact,
   type DesktopDownloadPlatform,
   type UpdateArtifactRequest,
 } from '../src/update-download.ts'
@@ -297,5 +300,57 @@ describe('desktop update installer download', () => {
       request,
     }), 'invalid-options')
     expect(requested).toBe(false)
+  })
+})
+
+describe('desktop update artifact cleanup', () => {
+  it('rejects malformed cleanup state with a typed failure', async () => {
+    const userDataPath = await temporaryDirectory()
+    const updates = join(userDataPath, 'updates')
+    await mkdir(updates)
+    await writeFile(join(updates, 'pending-installer.json'), '{}')
+
+    await expectFailure(
+      pendingDesktopUpdateArtifact(userDataPath, '2.1.0', 'win32'),
+      'invalid-options',
+    )
+  })
+
+  it('offers a recorded artifact only after the installed version reaches the update', async () => {
+    const userDataPath = await temporaryDirectory()
+    const downloads = await temporaryDirectory()
+    const path = destinationPath(downloads, 'win32', '2.1.0')
+    await writeFile(path, windowsArtifact())
+
+    await recordDesktopUpdateArtifact(userDataPath, {
+      platform: 'win32',
+      version: '2.1.0',
+      path,
+    })
+
+    await expect(pendingDesktopUpdateArtifact(userDataPath, '2.0.1', 'win32')).resolves.toBeUndefined()
+    await expect(pendingDesktopUpdateArtifact(userDataPath, '2.1.0', 'win32')).resolves.toEqual({
+      platform: 'win32',
+      version: '2.1.0',
+      path,
+    })
+  })
+
+  it.each([false, true])('resolves one cleanup choice with remove=%s', async (remove) => {
+    const userDataPath = await temporaryDirectory()
+    const downloads = await temporaryDirectory()
+    const artifact = {
+      platform: 'darwin' as const,
+      version: '2.1.0',
+      path: destinationPath(downloads, 'darwin', '2.1.0'),
+    }
+    await writeFile(artifact.path, dmgArtifact())
+    await recordDesktopUpdateArtifact(userDataPath, artifact)
+
+    await resolveDesktopUpdateArtifact(userDataPath, artifact, remove)
+
+    await expect(pendingDesktopUpdateArtifact(userDataPath, '2.1.0', 'darwin')).resolves.toBeUndefined()
+    if (remove) await expect(access(artifact.path)).rejects.toMatchObject({ code: 'ENOENT' })
+    else await expect(access(artifact.path)).resolves.toBeUndefined()
   })
 })

--- a/dsh-plugin-desktop/tests/update-download.spec.ts
+++ b/dsh-plugin-desktop/tests/update-download.spec.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, readFile, readdir, rm, symlink } from 'node:fs/promises'
+import { mkdtemp, readFile, readdir, rm, symlink, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, describe, expect, it } from 'vitest'
@@ -6,6 +6,7 @@ import {
   DESKTOP_DOWNLOAD_URLS,
   MAX_UPDATE_DOWNLOAD_BYTES,
   UpdateDownloadError,
+  desktopUpdateFilename,
   downloadDesktopUpdate,
   type DesktopDownloadPlatform,
   type UpdateArtifactRequest,
@@ -13,10 +14,14 @@ import {
 
 const temporaryRoots: string[] = []
 
-async function temporaryUserData(): Promise<string> {
+async function temporaryDirectory(): Promise<string> {
   const root = await mkdtemp(join(tmpdir(), 'dsh-update-download-'))
   temporaryRoots.push(root)
   return root
+}
+
+function destinationPath(root: string, platform: DesktopDownloadPlatform, version: string): string {
+  return join(root, desktopUpdateFilename(platform, version))
 }
 
 function dmgArtifact(): Uint8Array {
@@ -59,8 +64,8 @@ async function expectFailure(
   throw new Error('Expected update download to fail.')
 }
 
-async function expectNoPartialFiles(userDataPath: string, version: string): Promise<void> {
-  const entries = await readdir(join(userDataPath, 'updates', version))
+async function expectNoPartialFiles(directory: string): Promise<void> {
+  const entries = await readdir(directory)
   expect(entries.filter(entry => entry.endsWith('.partial'))).toEqual([])
 }
 
@@ -70,7 +75,7 @@ afterEach(async () => {
 
 describe('desktop update installer download', () => {
   it('streams a macOS DMG from only the fixed endpoint and atomically completes it', async () => {
-    const userDataPath = await temporaryUserData()
+    const directory = await temporaryDirectory()
     const artifact = dmgArtifact()
     const calls: Array<{ url: string; init: RequestInit }> = []
     const request: UpdateArtifactRequest = async (url, init) => {
@@ -81,49 +86,47 @@ describe('desktop update installer download', () => {
     const result = await downloadDesktopUpdate({
       platform: 'darwin',
       version: '2.1.0',
-      userDataPath,
+      destinationPath: destinationPath(directory, 'darwin', '2.1.0'),
       request,
     })
 
-    expect(result).toBe(join(userDataPath, 'updates', '2.1.0', 'DSH-Desktop-2.1.0-mac.dmg'))
+    expect(result).toBe(join(directory, 'DSH-Desktop-2.1.0-mac.dmg'))
     expect(await readFile(result)).toEqual(Buffer.from(artifact))
     expect(calls).toHaveLength(1)
     expect(calls[0]?.url).toBe(DESKTOP_DOWNLOAD_URLS.darwin)
     expect(calls[0]?.init).toMatchObject({ method: 'GET', cache: 'no-store', redirect: 'follow' })
-    await expectNoPartialFiles(userDataPath, '2.1.0')
+    await expectNoPartialFiles(directory)
   })
 
   it('accepts a Windows executable only when it has both MZ and PE signatures', async () => {
-    const userDataPath = await temporaryUserData()
+    const directory = await temporaryDirectory()
     const artifact = windowsArtifact()
     const result = await downloadDesktopUpdate({
       platform: 'win32',
       version: '2.2.0',
-      userDataPath,
+      destinationPath: destinationPath(directory, 'win32', '2.2.0'),
       request: async (url) => {
         expect(url).toBe(DESKTOP_DOWNLOAD_URLS.win32)
         return chunkedResponse([artifact])
       },
     })
 
-    expect(result).toBe(join(userDataPath, 'updates', '2.2.0', 'DSH-Desktop-2.2.0-windows.exe'))
+    expect(result).toBe(join(directory, 'DSH-Desktop-2.2.0-windows.exe'))
     expect(await readFile(result)).toEqual(Buffer.from(artifact))
-    await expectNoPartialFiles(userDataPath, '2.2.0')
+    await expectNoPartialFiles(directory)
   })
 
   it('accepts canonical stable SemVer build metadata in the private artifact path', async () => {
-    const userDataPath = await temporaryUserData()
+    const directory = await temporaryDirectory()
     const result = await downloadDesktopUpdate({
       platform: 'darwin',
       version: '2.8.0+build',
-      userDataPath,
+      destinationPath: destinationPath(directory, 'darwin', '2.8.0+build'),
       request: async () => chunkedResponse([dmgArtifact()]),
     })
 
     expect(result).toBe(join(
-      userDataPath,
-      'updates',
-      '2.8.0+build',
+      directory,
       'DSH-Desktop-2.8.0+build-mac.dmg',
     ))
   })
@@ -133,15 +136,40 @@ describe('desktop update installer download', () => {
     ['win32', Object.assign(windowsArtifact(), { 0: 0 })],
     ['win32', Object.assign(windowsArtifact(), { 0x80: 0 })],
   ] as const)('rejects and removes an invalid %s artifact', async (platform, artifact) => {
-    const userDataPath = await temporaryUserData()
+    const directory = await temporaryDirectory()
     await expectFailure(downloadDesktopUpdate({
       platform,
       version: '2.3.0',
-      userDataPath,
+      destinationPath: destinationPath(directory, platform, '2.3.0'),
       request: async () => chunkedResponse([artifact]),
     }), 'invalid-artifact')
-    await expectNoPartialFiles(userDataPath, '2.3.0')
-    expect(await readdir(join(userDataPath, 'updates', '2.3.0'))).toEqual([])
+    await expectNoPartialFiles(directory)
+    expect(await readdir(directory)).toEqual([])
+  })
+
+  it('keeps an existing destination until its validated replacement is ready', async () => {
+    const directory = await temporaryDirectory()
+    const path = destinationPath(directory, 'win32', '2.3.1')
+    const existing = Buffer.from('existing installer')
+    await writeFile(path, existing)
+
+    await expectFailure(downloadDesktopUpdate({
+      platform: 'win32',
+      version: '2.3.1',
+      destinationPath: path,
+      request: async () => chunkedResponse([Buffer.alloc(128)]),
+    }), 'invalid-artifact')
+    expect(await readFile(path)).toEqual(existing)
+
+    const replacement = windowsArtifact()
+    await downloadDesktopUpdate({
+      platform: 'win32',
+      version: '2.3.1',
+      destinationPath: path,
+      request: async () => chunkedResponse([replacement]),
+    })
+    expect(await readFile(path)).toEqual(Buffer.from(replacement))
+    await expectNoPartialFiles(directory)
   })
 
   it.each([
@@ -149,32 +177,32 @@ describe('desktop update installer download', () => {
     ['a missing response body', async () => new Response(null, { status: 200 }), 'empty-body'],
     ['a zero-byte response body', async () => chunkedResponse([]), 'empty-body'],
   ] as const)('rejects %s without leaving a partial file', async (_label, request, code) => {
-    const userDataPath = await temporaryUserData()
+    const directory = await temporaryDirectory()
     await expectFailure(downloadDesktopUpdate({
       platform: 'darwin',
       version: '2.4.0',
-      userDataPath,
+      destinationPath: destinationPath(directory, 'darwin', '2.4.0'),
       request,
     }), code)
-    await expectNoPartialFiles(userDataPath, '2.4.0')
+    await expectNoPartialFiles(directory)
   })
 
   it('rejects a declared body above the fixed 1 GiB limit before writing it', async () => {
-    const userDataPath = await temporaryUserData()
+    const directory = await temporaryDirectory()
     await expectFailure(downloadDesktopUpdate({
       platform: 'darwin',
       version: '2.5.0',
-      userDataPath,
+      destinationPath: destinationPath(directory, 'darwin', '2.5.0'),
       request: async () => chunkedResponse(
         [dmgArtifact()],
         { 'content-length': String(MAX_UPDATE_DOWNLOAD_BYTES + 1) },
       ),
     }), 'response-too-large')
-    await expectNoPartialFiles(userDataPath, '2.5.0')
+    await expectNoPartialFiles(directory)
   })
 
   it('passes the caller signal and removes a partial file when aborted during streaming', async () => {
-    const userDataPath = await temporaryUserData()
+    const directory = await temporaryDirectory()
     const controller = new AbortController()
     let requestSignal: AbortSignal | null | undefined
     const request: UpdateArtifactRequest = async (_url, init) => {
@@ -190,30 +218,29 @@ describe('desktop update installer download', () => {
     await expectFailure(downloadDesktopUpdate({
       platform: 'darwin',
       version: '2.6.0',
-      userDataPath,
+      destinationPath: destinationPath(directory, 'darwin', '2.6.0'),
       request,
       signal: controller.signal,
     }), 'aborted')
     expect(requestSignal).toBe(controller.signal)
-    await expectNoPartialFiles(userDataPath, '2.6.0')
+    await expectNoPartialFiles(directory)
   })
 
   it('normalizes request aborts and transport failures without creating an artifact', async () => {
-    const userDataPath = await temporaryUserData()
+    const directory = await temporaryDirectory()
     await expectFailure(downloadDesktopUpdate({
       platform: 'darwin',
       version: '2.7.0',
-      userDataPath,
+      destinationPath: destinationPath(directory, 'darwin', '2.7.0'),
       request: async () => { throw new DOMException('cancelled', 'AbortError') },
     }), 'aborted')
     await expectFailure(downloadDesktopUpdate({
       platform: 'darwin',
       version: '2.7.1',
-      userDataPath,
+      destinationPath: destinationPath(directory, 'darwin', '2.7.1'),
       request: async () => { throw new Error('offline') },
     }), 'network')
-    await expectNoPartialFiles(userDataPath, '2.7.0')
-    await expectNoPartialFiles(userDataPath, '2.7.1')
+    await expectNoPartialFiles(directory)
   })
 
   it.each([
@@ -222,12 +249,12 @@ describe('desktop update installer download', () => {
     ['win32', 'v2.8.0'],
     ['win32', '2.8.0-rc.1'],
   ])('rejects platform %s and version %s before requesting', async (platform, version) => {
-    const userDataPath = await temporaryUserData()
+    const directory = await temporaryDirectory()
     let requested = false
     await expectFailure(downloadDesktopUpdate({
       platform: platform as DesktopDownloadPlatform,
       version,
-      userDataPath,
+      destinationPath: join(directory, 'installer.dmg'),
       request: async () => {
         requested = true
         return chunkedResponse([dmgArtifact()])
@@ -236,7 +263,7 @@ describe('desktop update installer download', () => {
     expect(requested).toBe(false)
   })
 
-  it('rejects a relative user-data path before requesting', async () => {
+  it('rejects a relative destination path before requesting', async () => {
     let requested = false
     const request = async (): Promise<Response> => {
       requested = true
@@ -246,17 +273,17 @@ describe('desktop update installer download', () => {
     await expectFailure(downloadDesktopUpdate({
       platform: 'darwin',
       version: '2.9.0',
-      userDataPath: 'relative',
+      destinationPath: 'relative.dmg',
       request,
     }), 'invalid-options')
     expect(requested).toBe(false)
   })
 
-  it('rejects a linked user-data path before requesting', async () => {
-    const userDataPath = await temporaryUserData()
-    const linked = `${userDataPath}-link`
+  it('rejects a linked destination directory before requesting', async () => {
+    const directory = await temporaryDirectory()
+    const linked = `${directory}-link`
     temporaryRoots.push(linked)
-    await symlink(userDataPath, linked, process.platform === 'win32' ? 'junction' : 'dir')
+    await symlink(directory, linked, process.platform === 'win32' ? 'junction' : 'dir')
     let requested = false
     const request = async (): Promise<Response> => {
       requested = true
@@ -266,7 +293,7 @@ describe('desktop update installer download', () => {
     await expectFailure(downloadDesktopUpdate({
       platform: 'darwin',
       version: '2.9.0',
-      userDataPath: linked,
+      destinationPath: join(linked, 'installer.dmg'),
       request,
     }), 'invalid-options')
     expect(requested).toBe(false)


### PR DESCRIPTION
## Summary

- let users choose where desktop update installers are saved
- remember downloaded installers across the upgrade
- offer to delete or keep the installer after the upgraded app starts

## Verification

- corepack yarn test tests/update-download.spec.ts tests/electron-runtime.spec.ts tests/updates.spec.ts (86 passed)
- corepack yarn typecheck
- corepack yarn test (552 passed, 11 skipped)
- corepack yarn build
- git diff --check
- manually verified the Windows save dialog, pending installer state, post-upgrade cleanup prompt, and installer deletion