### PR TITLE
docs(architecture): document native shell platform seams

### DIFF
--- a/.agents/notes/implemented/architecture/2026-08-19-native-shell-generation-and-platform-adapters.i18n.yaml
+++ b/.agents/notes/implemented/architecture/2026-08-19-native-shell-generation-and-platform-adapters.i18n.yaml
@@ -1,0 +1,5 @@
+# Bilingual-pair consistency record: the git blob hash of each side as of the last
+# confirmed-consistent state. Both languages carry equal authority. Update both files
+# and re-record their hashes with git hash-object after editing either side.
+2026-08-19-native-shell-generation-and-platform-adapters.md: de96e45bdb1dcfc291d469fbaa01d253ab5580ff
+2026-08-19-native-shell-generation-and-platform-adapters.zh.md: 8b9d762669b81f031b8afd428796fb115bc4b0d8

--- a/.agents/notes/implemented/architecture/2026-08-19-native-shell-generation-and-platform-adapters.i18n.yaml
+++ b/.agents/notes/implemented/architecture/2026-08-19-native-shell-generation-and-platform-adapters.i18n.yaml
@@ -1,5 +1,5 @@
 # Bilingual-pair consistency record: the git blob hash of each side as of the last
 # confirmed-consistent state. Both languages carry equal authority. Update both files
 # and re-record their hashes with git hash-object after editing either side.
-2026-08-19-native-shell-generation-and-platform-adapters.md: de96e45bdb1dcfc291d469fbaa01d253ab5580ff
-2026-08-19-native-shell-generation-and-platform-adapters.zh.md: 8b9d762669b81f031b8afd428796fb115bc4b0d8
+2026-08-19-native-shell-generation-and-platform-adapters.md: 1848c6f43bd67c4a41fa13981a4a3fa28143a24e
+2026-08-19-native-shell-generation-and-platform-adapters.zh.md: 00bb31ef3be5f6286b9d22f691d56a7794f1db65

--- a/.agents/notes/implemented/architecture/2026-08-19-native-shell-generation-and-platform-adapters.i18n.yaml
+++ b/.agents/notes/implemented/architecture/2026-08-19-native-shell-generation-and-platform-adapters.i18n.yaml
@@ -1,5 +1,5 @@
 # Bilingual-pair consistency record: the git blob hash of each side as of the last
 # confirmed-consistent state. Both languages carry equal authority. Update both files
 # and re-record their hashes with git hash-object after editing either side.
-2026-08-19-native-shell-generation-and-platform-adapters.md: 1848c6f43bd67c4a41fa13981a4a3fa28143a24e
-2026-08-19-native-shell-generation-and-platform-adapters.zh.md: 00bb31ef3be5f6286b9d22f691d56a7794f1db65
+2026-08-19-native-shell-generation-and-platform-adapters.md: 43634f30d9e6d9550aa259ee3672c6f888b4e00f
+2026-08-19-native-shell-generation-and-platform-adapters.zh.md: 7dfd5f0bd95dd9798ee35d61e44c499cb4a352d8

--- a/.agents/notes/implemented/architecture/2026-08-19-native-shell-generation-and-platform-adapters.md
+++ b/.agents/notes/implemented/architecture/2026-08-19-native-shell-generation-and-platform-adapters.md
@@ -19,6 +19,63 @@ Keep `DesktopRuntime` as the existing Host-facing interface and deepen two priva
 
 The runtime coordinates these modules but does not expose either one as a third-party interface. The renderer carrier, public profile and pnpm interfaces, and the pinned upstream checkout remain unchanged.
 
+### Architecture shift
+
+The refactor moves the native lifecycle and platform policy behind two focused interfaces:
+
+```mermaid
+flowchart LR
+  subgraph Before[Before]
+    RuntimeBefore[ElectronRuntime]
+    RuntimeBefore --> WindowBefore[BrowserWindow]
+    RuntimeBefore --> TrayBefore[Tray]
+    RuntimeBefore --> ListenersBefore[Electron listeners]
+    RuntimeBefore --> PlatformBranches[process.platform branches]
+  end
+
+  subgraph After[After]
+    RuntimeAfter[ElectronRuntime]
+    Generation[ElectronShellGeneration]
+    Strategy[ElectronPlatformStrategy seam]
+    RuntimeAfter --> Generation
+    RuntimeAfter --> Strategy
+    Generation --> WindowAfter[BrowserWindow]
+    Generation --> TrayAfter[Tray]
+    Generation --> ListenersAfter[Listeners and navigation policy]
+    Strategy --> Windows[Windows adapter]
+    Strategy --> macOS[macOS adapter]
+    Strategy --> Linux[Linux adapter]
+  end
+```
+
+The `ElectronRuntime` interface remains the orchestration point. The generation module earns locality by owning resources together, while the strategy seam earns leverage by giving the shared lifecycle one place to consume platform capabilities.
+
+### Generation lifecycle
+
+```mermaid
+sequenceDiagram
+  participant Runtime as ElectronRuntime
+  participant Generation as ElectronShellGeneration
+  participant Window as BrowserWindow
+  participant Tray as Tray
+
+  Runtime->>Generation: mount()
+  Generation->>Window: construct and register listeners
+  Generation->>Window: loadURL(loopback origin)
+  alt load succeeds
+    Generation->>Tray: create tray and menu
+    Generation-->>Runtime: mounted generation
+  else load fails
+    Generation->>Generation: release() partial resources
+    Generation-->>Runtime: throw startup error
+  end
+  Runtime->>Generation: release() on restart or quit
+  Generation->>Tray: remove listeners and destroy
+  Generation->>Window: remove listeners and destroy
+```
+
+The same `release()` path handles both partial startup and ordinary shutdown, so a restart cannot leave a listener, tray, or window from the previous generation alive.
+
 ### One owner for native shell resources
 
 `ElectronShellGeneration.mount()` creates the application icon, configures the application through the selected platform adapter, creates the window, registers every window/application/webContents listener, loads the loopback URL, and creates the tray only after loading succeeds. It also owns same-origin navigation enforcement, external-link delegation, renderer failure reporting, tray menu refresh, and bounded zoom shortcuts.

--- a/.agents/notes/implemented/architecture/2026-08-19-native-shell-generation-and-platform-adapters.md
+++ b/.agents/notes/implemented/architecture/2026-08-19-native-shell-generation-and-platform-adapters.md
@@ -21,34 +21,109 @@ The runtime coordinates these modules but does not expose either one as a third-
 
 ### Architecture shift
 
-The refactor moves the native lifecycle and platform policy behind two focused interfaces:
+The first change moves native resource ownership out of the runtime facade and behind one deep generation module:
 
 ```mermaid
 flowchart LR
-  subgraph Before[Before]
-    RuntimeBefore[ElectronRuntime]
-    RuntimeBefore --> WindowBefore[BrowserWindow]
-    RuntimeBefore --> TrayBefore[Tray]
-    RuntimeBefore --> ListenersBefore[Electron listeners]
-    RuntimeBefore --> PlatformBranches[process.platform branches]
+  subgraph BeforeShell["Before / shallow ownership"]
+    direction LR
+    RuntimeBefore[ElectronDesktopRuntime]
+    UpdatesBefore[Updates]
+    PickerBefore[Directory picker]
+    DiagnosticsBefore[Diagnostics]
+    ListenersBefore[Listeners and cleanup]
+    WindowBefore[BrowserWindow]
+    TrayBefore[Tray]
+
+    RuntimeBefore --> UpdatesBefore
+    RuntimeBefore --> PickerBefore
+    RuntimeBefore --> DiagnosticsBefore
+    RuntimeBefore --> ListenersBefore
+    RuntimeBefore --> WindowBefore
+    RuntimeBefore --> TrayBefore
+    ListenersBefore -. leak risk .-> WindowBefore
+    ListenersBefore -. leak risk .-> TrayBefore
   end
 
-  subgraph After[After]
-    RuntimeAfter[ElectronRuntime]
+  subgraph AfterShell["After / facade over a deep module"]
+    direction LR
+    RuntimeAfter[DesktopRuntime facade]
     Generation[ElectronShellGeneration]
-    Strategy[ElectronPlatformStrategy seam]
+    OrchestrationAfter[Updates and diagnostics orchestration]
+    WindowAfter[BrowserWindow]
+    TrayAfter[Tray]
+    ListenersAfter[Listeners and navigation policy]
+    DisposerAfter[One idempotent release path]
+
     RuntimeAfter --> Generation
-    RuntimeAfter --> Strategy
-    Generation --> WindowAfter[BrowserWindow]
-    Generation --> TrayAfter[Tray]
-    Generation --> ListenersAfter[Listeners and navigation policy]
-    Strategy --> Windows[Windows adapter]
-    Strategy --> macOS[macOS adapter]
-    Strategy --> Linux[Linux adapter]
+    RuntimeAfter --> OrchestrationAfter
+    Generation --> WindowAfter
+    Generation --> TrayAfter
+    Generation --> ListenersAfter
+    Generation --> DisposerAfter
   end
+
+  classDef focus fill:#0f172a,color:#ffffff,stroke:#0f172a,stroke-width:2px;
+  classDef risk fill:#ffffff,color:#111827,stroke:#ef4444,stroke-width:2px;
+  class Generation focus;
+  class ListenersBefore risk;
 ```
 
-The `ElectronRuntime` interface remains the orchestration point. The generation module earns locality by owning resources together, while the strategy seam earns leverage by giving the shared lifecycle one place to consume platform capabilities.
+The `ElectronRuntime` interface remains the orchestration point. `ElectronShellGeneration` earns locality because window, tray, listeners, navigation policy, and release now change and fail together behind one interface.
+
+### Platform strategy shift
+
+The second change consolidates the platform decisions that already vary together, while leaving unrelated one-off construction checks local:
+
+```mermaid
+flowchart LR
+  subgraph BeforePlatform["Before / runtime decisions scattered"]
+    direction LR
+    PickerDecision[Directory picker]
+    ModeDecision[Shell mode]
+    UpdateDecision[Update download]
+    PresentationDecision[Menu, Dock, and material]
+    WindowsBranch[Windows branch]
+    MacBranch[macOS branch]
+    LinuxBranch[Linux branch]
+
+    PickerDecision -->|if win32| WindowsBranch
+    ModeDecision -->|if win32 or darwin| WindowsBranch
+    ModeDecision -->|if darwin| MacBranch
+    UpdateDecision -->|if win32| WindowsBranch
+    UpdateDecision -->|if darwin| MacBranch
+    PresentationDecision --> WindowsBranch
+    PresentationDecision --> MacBranch
+    ModeDecision -. unsupported .-> LinuxBranch
+    UpdateDecision -. unsupported .-> LinuxBranch
+  end
+
+  subgraph AfterPlatform["After / one selected adapter"]
+    direction LR
+    RuntimePlatform[ElectronRuntime]
+    Strategy[ElectronPlatformStrategy seam]
+    WindowsAdapter[Windows adapter]
+    MacAdapter[macOS adapter]
+    LinuxAdapter[Linux adapter]
+    WindowsFacts[Picker, update, menu, and Mica]
+    MacFacts[Update, Dock icon, and shell mode]
+    LinuxFacts[Explicit unsupported capabilities]
+    LocalChecks[Window options and terminal keep local construction checks]
+
+    RuntimePlatform --> Strategy
+    Strategy --> WindowsAdapter --> WindowsFacts
+    Strategy --> MacAdapter --> MacFacts
+    Strategy --> LinuxAdapter --> LinuxFacts
+    RuntimePlatform -. platform value .-> LocalChecks
+  end
+
+  classDef focus fill:#0f172a,color:#ffffff,stroke:#0f172a,stroke-width:2px;
+  classDef risk fill:#ffffff,color:#111827,stroke:#ef4444,stroke-width:2px;
+  class Strategy focus;
+  class WindowsBranch,MacBranch,LinuxBranch risk;
+```
+
+With three concrete adapters, the strategy is a real seam. It gives capability checks and native presentation one selection point without forcing terminal or window-construction details into a fake universal interface.
 
 ### Generation lifecycle
 

--- a/.agents/notes/implemented/architecture/2026-08-19-native-shell-generation-and-platform-adapters.md
+++ b/.agents/notes/implemented/architecture/2026-08-19-native-shell-generation-and-platform-adapters.md
@@ -1,0 +1,62 @@
+# Agent Note: Native shell generation and platform adapters
+
+Status: implemented
+
+English | [中文](2026-08-19-native-shell-generation-and-platform-adapters.zh.md)
+
+## Problem
+
+The Electron runtime used to coordinate the Host while also constructing the `BrowserWindow` and `Tray`, registering their listeners, enforcing navigation rules, handling zoom shortcuts, and branching on the operating system. A profile or mode restart replaces all native resources together, but their ownership and cleanup were spread across the larger runtime implementation. Adding platform behavior required more conditionals in that same lifecycle.
+
+This reduced locality: a maintainer had to inspect construction, event registration, failure cleanup, ordinary shutdown, and platform checks together to verify one generation. It also made the public `DesktopRuntime` interface a poor test surface for native resources that are intentionally private to Electron.
+
+## Decision
+
+Keep `DesktopRuntime` as the existing Host-facing interface and deepen two private Electron modules behind it:
+
+- `ElectronShellGeneration` owns one complete native shell generation.
+- `ElectronPlatformStrategy` is the seam where startup selects one Windows, macOS, or Linux adapter.
+
+The runtime coordinates these modules but does not expose either one as a third-party interface. The renderer carrier, public profile and pnpm interfaces, and the pinned upstream checkout remain unchanged.
+
+### One owner for native shell resources
+
+`ElectronShellGeneration.mount()` creates the application icon, configures the application through the selected platform adapter, creates the window, registers every window/application/webContents listener, loads the loopback URL, and creates the tray only after loading succeeds. It also owns same-origin navigation enforcement, external-link delegation, renderer failure reporting, tray menu refresh, and bounded zoom shortcuts.
+
+`release()` is the only disposal path for resources owned by the generation. It is idempotent, stops renderer boot monitoring, removes the registered listeners, destroys the tray, and destroys the window. A failed `mount()` uses that same path, so partial startup and ordinary shutdown have the same cleanup semantics. The runtime may replace its generation reference, but callers must not cache `BrowserWindow`, `Tray`, or their listeners across a profile or mode restart.
+
+This module is deep because a small `mount` / `show` / `refresh` / `release` interface hides the ordering and failure behavior of the complete native shell. Deleting it would move that complexity back into the runtime rather than remove it, and its interface is therefore the test surface for generation ownership.
+
+### One platform adapter per runtime
+
+`electronPlatformStrategy()` selects exactly one adapter at runtime construction. Each adapter provides a platform identity, declares directory-picking, shell-mode, and update-download capabilities, and owns native presentation operations:
+
+- Windows removes the application menu and restores Mica after theme changes.
+- macOS configures the Dock icon.
+- Linux declares unsupported advanced-shell and update-download capabilities without pretending to provide them.
+
+The shell generation consumes this interface without branching on `process.platform`. The runtime uses the same selected adapter for capability checks and update behavior, so platform policy and native implementation remain at one seam. With three concrete adapters, this is a real seam rather than a hypothetical abstraction.
+
+New platform-specific behavior belongs in the relevant adapter when it satisfies this interface. Shared generation ordering, resource ownership, navigation policy, and failure handling remain in `ElectronShellGeneration`. Product features and public Host interfaces do not depend directly on an adapter.
+
+## Verification
+
+The implementation and its focused tests were committed together. Electron runtime tests cover repeated release, listener cleanup after failed startup, Windows directory selection, Windows menu removal, Windows Mica refresh, macOS Dock configuration, Linux capability rejection, and unsupported platform rejection.
+
+Before merge, the desktop package completed 541 tests with 11 skips, the Windows package gate completed 155 tests, and the Electron runtime focus completed 38 tests. Build, type checking, and packaged-runtime closure also passed locally. Pull request #291 then passed the repository `check`, `desktop-windows`, `desktop-macos`, and `upstream-command-windows` jobs.
+
+Graphical native appearance and operating-system integration still require verification on real target machines; headless tests verify the selected calls and lifecycle, not their visual result.
+
+## Alternatives considered
+
+**Keep all behavior in `ElectronRuntime`.** This avoids two files but restores mixed Host coordination, native resource ownership, and platform branching. The interface would stay small only because the implementation remains concentrated in one oversized module, without the locality needed to reason about restart cleanup.
+
+**Create separate Windows, macOS, and Linux runtime classes.** Most startup, navigation, failure, and disposal behavior is identical. Duplicating it would weaken locality and allow platform implementations to drift. Small adapters at one seam isolate only what actually varies.
+
+**Expose window and tray handles through `DesktopRuntime`.** That would enlarge a Host-facing interface with Electron implementation details and encourage resources to outlive their generation. Keeping them private preserves the existing public contract and cleanup invariant.
+
+## Consequences
+
+Native resource ownership is now local to one generation module, and platform variation is local to three adapters. Callers gain leverage from small interfaces while restart cleanup and platform policy can be tested without widening the public desktop contract.
+
+Future changes must preserve the split: shared lifecycle behavior belongs to `ElectronShellGeneration`, platform-specific capability or native presentation behavior belongs to an adapter, and orchestration belongs to `ElectronRuntime`. This structure does not make Electron platform behavior portable by itself; every new adapter operation still needs Windows and macOS verification proportional to its impact.

--- a/.agents/notes/implemented/architecture/2026-08-19-native-shell-generation-and-platform-adapters.zh.md
+++ b/.agents/notes/implemented/architecture/2026-08-19-native-shell-generation-and-platform-adapters.zh.md
@@ -19,6 +19,63 @@ Status: implemented
 
 Runtime 负责协调这两个 module，但不会把任何一个暴露为第三方 interface。Renderer carrier、公开的 profile 与 pnpm interface，以及 pinned 上游 checkout 均保持不变。
 
+### 架构变化
+
+这次重构把原生生命周期与平台策略放到两个聚焦的 interface 后面：
+
+```mermaid
+flowchart LR
+  subgraph Before[变更前]
+    RuntimeBefore[ElectronRuntime]
+    RuntimeBefore --> WindowBefore[BrowserWindow]
+    RuntimeBefore --> TrayBefore[Tray]
+    RuntimeBefore --> ListenersBefore[Electron listener]
+    RuntimeBefore --> PlatformBranches[process.platform 分支]
+  end
+
+  subgraph After[变更后]
+    RuntimeAfter[ElectronRuntime]
+    Generation[ElectronShellGeneration]
+    Strategy[ElectronPlatformStrategy seam]
+    RuntimeAfter --> Generation
+    RuntimeAfter --> Strategy
+    Generation --> WindowAfter[BrowserWindow]
+    Generation --> TrayAfter[Tray]
+    Generation --> ListenersAfter[Listener 与导航策略]
+    Strategy --> Windows[Windows adapter]
+    Strategy --> macOS[macOS adapter]
+    Strategy --> Linux[Linux adapter]
+  end
+```
+
+`ElectronRuntime` interface 仍然是协调入口。Generation module 通过把资源放在一起拥有 locality；strategy seam 则通过让共享生命周期在一个位置消费平台能力获得 leverage。
+
+### Generation 生命周期
+
+```mermaid
+sequenceDiagram
+  participant Runtime as ElectronRuntime
+  participant Generation as ElectronShellGeneration
+  participant Window as BrowserWindow
+  participant Tray as Tray
+
+  Runtime->>Generation: mount()
+  Generation->>Window: 构造并注册 listener
+  Generation->>Window: loadURL(loopback origin)
+  alt 加载成功
+    Generation->>Tray: 创建托盘与菜单
+    Generation-->>Runtime: mounted generation
+  else 加载失败
+    Generation->>Generation: release() 清理部分资源
+    Generation-->>Runtime: 抛出启动错误
+  end
+  Runtime->>Generation: 重启或退出时 release()
+  Generation->>Tray: 移除 listener 并销毁
+  Generation->>Window: 移除 listener 并销毁
+```
+
+相同的 `release()` 路径同时处理部分启动和正常关闭，因此重启不会遗留上一代 generation 的 listener、托盘或窗口。
+
 ### 原生 Shell 资源只有一个 owner
 
 `ElectronShellGeneration.mount()` 创建应用图标，通过选中的平台 adapter 配置应用，创建窗口，注册全部 window/application/webContents listener，加载 loopback URL，并仅在加载成功后创建托盘。它也负责同源导航限制、外链委托、renderer 失败报告、托盘菜单刷新和有界缩放快捷键。

--- a/.agents/notes/implemented/architecture/2026-08-19-native-shell-generation-and-platform-adapters.zh.md
+++ b/.agents/notes/implemented/architecture/2026-08-19-native-shell-generation-and-platform-adapters.zh.md
@@ -1,0 +1,62 @@
+# Agent Note: 原生 Shell generation 与平台 adapter
+
+Status: implemented
+
+[English](2026-08-19-native-shell-generation-and-platform-adapters.md) | 中文
+
+## Problem
+
+此前 Electron runtime 在协调 Host 的同时，还负责构造 `BrowserWindow` 与 `Tray`、注册相关 listener、执行导航规则、处理缩放快捷键，并按操作系统执行分支。Profile 或模式重启会整体替换全部原生资源，但它们的所有权与清理逻辑散落在更大的 runtime implementation 中。增加平台行为也需要继续在同一生命周期内添加条件判断。
+
+这降低了 locality：维护者必须同时检查构造、事件注册、失败清理、正常关闭和平台判断，才能验证一个 generation。公开 `DesktopRuntime` interface 也不适合作为这些 Electron 私有原生资源的测试 surface。
+
+## Decision
+
+保留 `DesktopRuntime` 现有的 Host-facing interface，并深化其后的两个 Electron 私有 module：
+
+- `ElectronShellGeneration` 完整拥有一个原生 Shell generation。
+- `ElectronPlatformStrategy` 是启动时选择 Windows、macOS 或 Linux adapter 的 seam。
+
+Runtime 负责协调这两个 module，但不会把任何一个暴露为第三方 interface。Renderer carrier、公开的 profile 与 pnpm interface，以及 pinned 上游 checkout 均保持不变。
+
+### 原生 Shell 资源只有一个 owner
+
+`ElectronShellGeneration.mount()` 创建应用图标，通过选中的平台 adapter 配置应用，创建窗口，注册全部 window/application/webContents listener，加载 loopback URL，并仅在加载成功后创建托盘。它也负责同源导航限制、外链委托、renderer 失败报告、托盘菜单刷新和有界缩放快捷键。
+
+`release()` 是 generation 所拥有资源的唯一释放路径。它是幂等的，会停止 renderer 启动监控、移除已注册 listener、销毁托盘并销毁窗口。失败的 `mount()` 也使用同一路径，因此部分启动与正常关闭具有相同的清理语义。Runtime 可以替换 generation reference，但调用方不得跨 profile 或模式重启缓存 `BrowserWindow`、`Tray` 或其 listener。
+
+这个 module 是 deep 的，因为较小的 `mount` / `show` / `refresh` / `release` interface 隐藏了完整原生 Shell 的顺序和失败行为。删除它只会把复杂度移回 runtime，而不会让复杂度消失，因此其 interface 就是 generation 所有权的测试 surface。
+
+### 每个 runtime 只选择一个平台 adapter
+
+`electronPlatformStrategy()` 在 runtime 构造时只选择一个 adapter。每个 adapter 提供平台身份，声明目录选择、Shell 模式和更新下载能力，并拥有原生呈现操作：
+
+- Windows 移除应用菜单，并在主题变化后恢复 Mica。
+- macOS 配置 Dock 图标。
+- Linux 明确声明不支持高级 Shell 与更新下载能力，而不会伪装成支持。
+
+Shell generation 使用这个 interface，不再对 `process.platform` 分支。Runtime 使用同一个已选 adapter 做能力检查与更新行为，使平台策略与原生 implementation 保持在同一个 seam。这里有三个具体 adapter，因此它是真实 seam，而不是假设性抽象。
+
+新的平台专属行为在满足该 interface 时应进入对应 adapter。共享的 generation 顺序、资源所有权、导航策略和失败处理继续留在 `ElectronShellGeneration`。产品功能与公开 Host interface 不直接依赖 adapter。
+
+## Verification
+
+Implementation 与对应定点测试已放在相同提交中。Electron runtime 测试覆盖重复释放、启动失败后的 listener 清理、Windows 目录选择、Windows 菜单移除、Windows Mica 刷新、macOS Dock 配置、Linux 能力拒绝和未知平台拒绝。
+
+合并前，Desktop package 完成 541 项测试并跳过 11 项，Windows package gate 完成 155 项测试，Electron runtime 定点测试完成 38 项。Build、typecheck 和 packaged-runtime closure 也在本地通过。随后 PR #291 通过仓库的 `check`、`desktop-windows`、`desktop-macos` 和 `upstream-command-windows` jobs。
+
+图形化原生外观与操作系统集成仍需要在真实目标机器上验证；headless 测试验证的是所选调用和生命周期，而不是其视觉结果。
+
+## Alternatives considered
+
+**继续把所有行为保留在 `ElectronRuntime`。** 这样会少两个文件，但会恢复 Host 协调、原生资源所有权和平台分支的混合。Interface 看似仍小，实际只是让 implementation 集中在一个过大的 module 中，缺少推理重启清理所需的 locality。
+
+**分别创建 Windows、macOS 与 Linux runtime class。** 大多数启动、导航、失败和释放行为完全相同。复制这些逻辑会削弱 locality，并允许各平台 implementation 漂移。在一个 seam 使用小型 adapter 只隔离真正变化的部分。
+
+**通过 `DesktopRuntime` 暴露窗口与托盘 handle。** 这会用 Electron implementation 细节扩大 Host-facing interface，并诱使资源存活超过其 generation。保持私有可以保留现有公开 contract 与清理 invariant。
+
+## Consequences
+
+原生资源所有权现在集中在一个 generation module，平台变化集中在三个 adapter。调用方从小型 interface 获得 leverage，同时无需扩大公开 desktop contract 就能测试重启清理与平台策略。
+
+未来修改必须保持这种拆分：共享生命周期行为属于 `ElectronShellGeneration`，平台专属能力或原生呈现行为属于 adapter，协调属于 `ElectronRuntime`。该结构本身不会让 Electron 平台行为自动可移植；每个新的 adapter 操作仍需按照影响范围完成 Windows 与 macOS 验证。

--- a/.agents/notes/implemented/architecture/2026-08-19-native-shell-generation-and-platform-adapters.zh.md
+++ b/.agents/notes/implemented/architecture/2026-08-19-native-shell-generation-and-platform-adapters.zh.md
@@ -21,34 +21,109 @@ Runtime 负责协调这两个 module，但不会把任何一个暴露为第三�
 
 ### 架构变化
 
-这次重构把原生生命周期与平台策略放到两个聚焦的 interface 后面：
+第一项变更把原生资源所有权从 runtime facade 移到一个 deep generation module 后面：
 
 ```mermaid
 flowchart LR
-  subgraph Before[变更前]
-    RuntimeBefore[ElectronRuntime]
-    RuntimeBefore --> WindowBefore[BrowserWindow]
-    RuntimeBefore --> TrayBefore[Tray]
-    RuntimeBefore --> ListenersBefore[Electron listener]
-    RuntimeBefore --> PlatformBranches[process.platform 分支]
+  subgraph BeforeShell["变更前 / shallow ownership"]
+    direction LR
+    RuntimeBefore[ElectronDesktopRuntime]
+    UpdatesBefore[更新]
+    PickerBefore[目录选择]
+    DiagnosticsBefore[诊断]
+    ListenersBefore[Listener 与清理]
+    WindowBefore[BrowserWindow]
+    TrayBefore[Tray]
+
+    RuntimeBefore --> UpdatesBefore
+    RuntimeBefore --> PickerBefore
+    RuntimeBefore --> DiagnosticsBefore
+    RuntimeBefore --> ListenersBefore
+    RuntimeBefore --> WindowBefore
+    RuntimeBefore --> TrayBefore
+    ListenersBefore -. 泄漏风险 .-> WindowBefore
+    ListenersBefore -. 泄漏风险 .-> TrayBefore
   end
 
-  subgraph After[变更后]
-    RuntimeAfter[ElectronRuntime]
+  subgraph AfterShell["变更后 / deep module 上的 facade"]
+    direction LR
+    RuntimeAfter[DesktopRuntime facade]
     Generation[ElectronShellGeneration]
-    Strategy[ElectronPlatformStrategy seam]
+    OrchestrationAfter[更新与诊断协调]
+    WindowAfter[BrowserWindow]
+    TrayAfter[Tray]
+    ListenersAfter[Listener 与导航策略]
+    DisposerAfter[唯一幂等 release 路径]
+
     RuntimeAfter --> Generation
-    RuntimeAfter --> Strategy
-    Generation --> WindowAfter[BrowserWindow]
-    Generation --> TrayAfter[Tray]
-    Generation --> ListenersAfter[Listener 与导航策略]
-    Strategy --> Windows[Windows adapter]
-    Strategy --> macOS[macOS adapter]
-    Strategy --> Linux[Linux adapter]
+    RuntimeAfter --> OrchestrationAfter
+    Generation --> WindowAfter
+    Generation --> TrayAfter
+    Generation --> ListenersAfter
+    Generation --> DisposerAfter
   end
+
+  classDef focus fill:#0f172a,color:#ffffff,stroke:#0f172a,stroke-width:2px;
+  classDef risk fill:#ffffff,color:#111827,stroke:#ef4444,stroke-width:2px;
+  class Generation focus;
+  class ListenersBefore risk;
 ```
 
-`ElectronRuntime` interface 仍然是协调入口。Generation module 通过把资源放在一起拥有 locality；strategy seam 则通过让共享生命周期在一个位置消费平台能力获得 leverage。
+`ElectronRuntime` interface 仍然是协调入口。`ElectronShellGeneration` 获得 locality，是因为窗口、托盘、listener、导航策略与释放现在会在同一个 interface 后共同变化、共同失败。
+
+### 平台 Strategy 变化
+
+第二项变更收敛已经共同变化的平台决策，同时让无关的一次性构造检查继续留在局部：
+
+```mermaid
+flowchart LR
+  subgraph BeforePlatform["变更前 / runtime 决策散落"]
+    direction LR
+    PickerDecision[目录选择]
+    ModeDecision[Shell 模式]
+    UpdateDecision[更新下载]
+    PresentationDecision[菜单、Dock 与原生材质]
+    WindowsBranch[Windows 分支]
+    MacBranch[macOS 分支]
+    LinuxBranch[Linux 分支]
+
+    PickerDecision -->|if win32| WindowsBranch
+    ModeDecision -->|if win32 或 darwin| WindowsBranch
+    ModeDecision -->|if darwin| MacBranch
+    UpdateDecision -->|if win32| WindowsBranch
+    UpdateDecision -->|if darwin| MacBranch
+    PresentationDecision --> WindowsBranch
+    PresentationDecision --> MacBranch
+    ModeDecision -. 不支持 .-> LinuxBranch
+    UpdateDecision -. 不支持 .-> LinuxBranch
+  end
+
+  subgraph AfterPlatform["变更后 / 选择一个 adapter"]
+    direction LR
+    RuntimePlatform[ElectronRuntime]
+    Strategy[ElectronPlatformStrategy seam]
+    WindowsAdapter[Windows adapter]
+    MacAdapter[macOS adapter]
+    LinuxAdapter[Linux adapter]
+    WindowsFacts[目录、更新、菜单与 Mica]
+    MacFacts[更新、Dock 图标与 Shell 模式]
+    LinuxFacts[明确不支持的能力]
+    LocalChecks[Window options 与 terminal 保留局部构造检查]
+
+    RuntimePlatform --> Strategy
+    Strategy --> WindowsAdapter --> WindowsFacts
+    Strategy --> MacAdapter --> MacFacts
+    Strategy --> LinuxAdapter --> LinuxFacts
+    RuntimePlatform -. platform 值 .-> LocalChecks
+  end
+
+  classDef focus fill:#0f172a,color:#ffffff,stroke:#0f172a,stroke-width:2px;
+  classDef risk fill:#ffffff,color:#111827,stroke:#ef4444,stroke-width:2px;
+  class Strategy focus;
+  class WindowsBranch,MacBranch,LinuxBranch risk;
+```
+
+这里有三个具体 adapter，因此 strategy 是真实 seam。它为能力检查和原生呈现提供一个选择点，同时不会为了统一而把 terminal 或 window 构造细节硬塞进虚假的通用 interface。
 
 ### Generation 生命周期
 

--- a/docs/architecture.en.md
+++ b/docs/architecture.en.md
@@ -39,6 +39,12 @@ Every profile or mode switch disposes the current generation before starting the
 
 Compatibility mode validates its environment and returns without installing a Desktop layout, root, sidebar, or conversation override. Advanced mode installs the Desktop-owned layout, frame, and native materials while respecting upstream and third-party slot composition.
 
+### Native shell generation and platform adapters
+
+`ElectronRuntime` coordinates the Host and native desktop environment without directly owning window and tray details. Each start creates one `ElectronShellGeneration` module that completely owns its `BrowserWindow`, `Tray`, related Electron listeners, navigation restrictions, external-link handling, and zoom shortcuts. A generation must be disposed through its idempotent `release()` interface; callers must not cache or destroy those resources separately across generations.
+
+Platform differences live at the `ElectronPlatformStrategy` seam selected once during startup. The Windows, macOS, and Linux adapters declare directory-picking, shell-mode, and update-download capabilities and own their platform-specific menu, Dock icon, and native-material operations. New platform branches belong in the corresponding adapter; the generation and runtime retain only the lifecycle shared across platforms.
+
 ## Profile and service boundaries
 
 The profile name and absolute directory come from `desktopProfiles.current`; they must not be inferred from argv, settings, or a URL. `list()` is read-only discovery. `select()` records a pending target and completes the switch through restart.
@@ -60,3 +66,4 @@ The outer workspace uses Yarn. The pinned `deepseek-harness/` submodule keeps it
 - [Pinned upstream and isolated Yarn workspace](../.agents/notes/implemented/process/2026-08-15-pinned-upstream-and-isolated-yarn-workspace.md)
 - [Profile and pnpm services decision](../.agents/notes/implemented/architecture/2026-08-15-desktop-profile-and-pnpm-services.md)
 - [Advanced shell decision](../.agents/notes/implemented/architecture/2026-08-15-desktop-advanced-shell.md)
+- [Native shell generation and platform adapters](../.agents/notes/implemented/architecture/2026-08-19-native-shell-generation-and-platform-adapters.md)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -39,6 +39,12 @@ flowchart LR
 
 兼容模式的 Client face 校验环境后直接返回，不注册 Desktop layout、root、sidebar 或 conversation override。高级模式才安装 Desktop-owned layout、frame 和原生材质，同时尊重上游和第三方 slot 组合。
 
+### 原生 Shell generation 与平台 adapter
+
+`ElectronRuntime` 负责协调 Host 与原生桌面环境，但不直接拥有窗口和托盘的细节。每次启动由一个 `ElectronShellGeneration` module 完整拥有 `BrowserWindow`、`Tray`、相关 Electron listener、导航限制、外链处理和缩放快捷键。释放 generation 必须通过其幂等 `release()` interface 完成，调用方不能跨 generation 缓存或单独销毁这些资源。
+
+平台差异集中在启动时选择一次的 `ElectronPlatformStrategy` seam。Windows、macOS 与 Linux adapter 声明目录选择、Shell 模式切换和更新下载能力，并负责各自的菜单、Dock 图标与原生材质操作。新的平台分支应进入对应 adapter；generation 与 runtime 中只保留各平台共享的生命周期流程。
+
 ## Profile 与服务边界
 
 profile 的名字和绝对目录由 `desktopProfiles.current` 提供，不能从 argv、settings 或 URL 猜测。`list()` 是只读发现；`select()` 记录 pending target，并通过重启完成切换。
@@ -60,3 +66,4 @@ Launcher 私有的 `desktopRuntime`、`desktopPnpmBootstrap`、Electron executab
 - [Pinned upstream and isolated Yarn workspace](../.agents/notes/implemented/process/2026-08-15-pinned-upstream-and-isolated-yarn-workspace.md)
 - [Profile and pnpm services decision](../.agents/notes/implemented/architecture/2026-08-15-desktop-profile-and-pnpm-services.md)
 - [Advanced shell decision](../.agents/notes/implemented/architecture/2026-08-15-desktop-advanced-shell.md)
+- [Native shell generation and platform adapters](../.agents/notes/implemented/architecture/2026-08-19-native-shell-generation-and-platform-adapters.md)


### PR DESCRIPTION
## Summary\n- document ElectronShellGeneration ownership and idempotent release semantics\n- document ElectronPlatformStrategy platform adapter seam and capability policy\n- add bilingual implemented architecture note and update the architecture index\n\n## Verification\n- git diff --check\n- bilingual i18n blob hashes verified\n- documentation-only change; desktop tests are covered by merged PR #291