### PR TITLE
ci: skip product gates for documentation changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,6 +85,7 @@ jobs:
 
   # Windows-only logic and unsigned NSIS/portable builds on a real Windows runner:
   # updates, window options, pwsh sandbox, volume diagnostics, and packaging.
+  # The shared gate runs once; both artifacts reuse its build output.
   desktop-windows:
     needs: changes
     if: needs.changes.outputs.product == 'true'
@@ -107,8 +108,14 @@ jobs:
           key: yarn-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('yarn.lock', '.yarnrc.yml') }}
       - run: yarn install --immutable
       - run: yarn check
-      - run: yarn dist:win
-      - run: yarn dist:win-portable
+      - name: Build Windows installer
+        env:
+          DSH_PACKAGE_CHECK_ALREADY_RAN: '1'
+        run: yarn workspace dsh-plugin-desktop dist:win
+      - name: Build Windows portable archive
+        env:
+          DSH_PACKAGE_CHECK_ALREADY_RAN: '1'
+        run: yarn workspace dsh-plugin-desktop dist:win-portable
 
   # macOS-only universal packaging smoke on a real macOS runner: the signed
   # release is built manually on a credentialed machine, so an unsigned DMG
@@ -136,8 +143,11 @@ jobs:
           path: ${{ steps.yarn-cache.outputs.dir }}
           key: yarn-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('yarn.lock', '.yarnrc.yml') }}
       - run: yarn install --immutable
-      - run: yarn workspace dsh-community-market check
-      - run: yarn dist:mac-smoke
+      - run: yarn check
+      - name: Build macOS smoke artifact
+        env:
+          DSH_PACKAGE_CHECK_ALREADY_RAN: '1'
+        run: yarn workspace dsh-plugin-desktop dist:mac-smoke
 
   # Upstream toolchain smoke: the portable-shell scripts must resolve the
   # pinned submodule's own Yarn/pnpm release on Windows.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,31 +18,76 @@ env:
   DSH_TELEMETRY_DISABLED: '1'
 
 jobs:
-  # Full product gate: build, typecheck, unit tests, and every headless smoke.
-  check:
+  # Keep required checks conclusive for documentation-only changes. Workflow
+  # path filters can leave required checks pending, so classify inside the run.
+  changes:
     runs-on: ubuntu-latest
+    outputs:
+      product: ${{ steps.scope.outputs.product }}
     steps:
       - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 22.23.2
+      - name: Classify changed paths
+        id: scope
+        shell: bash
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.before }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+        run: |
+          set -euo pipefail
+          if [[ "$EVENT_NAME" == "workflow_dispatch" || -z "$BASE_SHA" || "$BASE_SHA" =~ ^0+$ ]]; then
+            product=true
+          else
+            git diff --check "$BASE_SHA" "$HEAD_SHA"
+            product="$(git diff --name-only -z "$BASE_SHA" "$HEAD_SHA" | node scripts/classify-ci-changes.mjs)"
+          fi
+          echo "product=$product" >> "$GITHUB_OUTPUT"
+
+  # Full product gate: build, typecheck, unit tests, and every headless smoke.
+  # A documentation-only change already passed diff validation in `changes`.
+  check:
+    needs: changes
+    runs-on: ubuntu-latest
+    steps:
+      - name: Documentation-only gate
+        if: needs.changes.outputs.product == 'false'
+        run: echo "Documentation-only change; product build and tests are not required."
+      - uses: actions/checkout@v6
+        if: needs.changes.outputs.product == 'true'
         with:
           persist-credentials: false
           submodules: recursive
       - uses: actions/setup-node@v6
+        if: needs.changes.outputs.product == 'true'
         with:
           node-version: 22.23.2
-      - run: corepack enable
+      - if: needs.changes.outputs.product == 'true'
+        run: corepack enable
       - name: Resolve Yarn cache folder
+        if: needs.changes.outputs.product == 'true'
         id: yarn-cache
         run: echo "dir=$(yarn config get cacheFolder)" >> "$GITHUB_OUTPUT"
       - uses: actions/cache@v6
+        if: needs.changes.outputs.product == 'true'
         with:
           path: ${{ steps.yarn-cache.outputs.dir }}
           key: yarn-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('yarn.lock', '.yarnrc.yml') }}
-      - run: yarn install --immutable
-      - run: yarn check
+      - if: needs.changes.outputs.product == 'true'
+        run: yarn install --immutable
+      - if: needs.changes.outputs.product == 'true'
+        run: yarn check
 
   # Windows-only logic and unsigned NSIS/portable builds on a real Windows runner:
   # updates, window options, pwsh sandbox, volume diagnostics, and packaging.
   desktop-windows:
+    needs: changes
+    if: needs.changes.outputs.product == 'true'
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v6
@@ -70,6 +115,8 @@ jobs:
   # here catches Intel and Apple Silicon packaging regressions before a manual
   # release. No signing secrets ever reach this job.
   desktop-macos:
+    needs: changes
+    if: needs.changes.outputs.product == 'true'
     runs-on: macos-latest
     timeout-minutes: 60
     steps:
@@ -95,6 +142,8 @@ jobs:
   # Upstream toolchain smoke: the portable-shell scripts must resolve the
   # pinned submodule's own Yarn/pnpm release on Windows.
   upstream-command-windows:
+    needs: changes
+    if: needs.changes.outputs.product == 'true'
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v6

--- a/dsh-plugin-desktop/scripts/package-mac.ts
+++ b/dsh-plugin-desktop/scripts/package-mac.ts
@@ -108,12 +108,16 @@ export function packageMacSmoke(options: MacSmokePackageOptions = defaultOptions
 
   const cleanEnvironment = withoutMacReleaseSecrets(options.env)
   options.log('Building an unsigned macOS DMG smoke; signing and notarization are release-only steps.')
-  options.run(
-    'corepack',
-    ['yarn', 'workspace', 'dsh-plugin-desktop', 'check:mac-package'],
-    options.workspaceRoot,
-    cleanEnvironment,
-  )
+  if (options.env.DSH_PACKAGE_CHECK_ALREADY_RAN !== '1') {
+    options.run(
+      'corepack',
+      ['yarn', 'workspace', 'dsh-plugin-desktop', 'check:mac-package'],
+      options.workspaceRoot,
+      cleanEnvironment,
+    )
+  } else {
+    options.log('Skipping the macOS package preflight; the CI shared gate already passed.')
+  }
   options.resetOutput()
   options.prepareRuntime()
   options.run(

--- a/dsh-plugin-desktop/scripts/package-win.ts
+++ b/dsh-plugin-desktop/scripts/package-win.ts
@@ -128,17 +128,21 @@ export function packageWindowsArtifact(
 
   const cleanEnvironment = withoutWindowsSigningSecrets(options.env)
   options.log(`Building an unsigned Windows x64 ${artifact}; Authenticode is a separate release step.`)
-  options.run(
-    options.commandShell,
-    [
-      '/d',
-      '/s',
-      '/c',
-      'corepack yarn workspace dsh-plugin-desktop check:win-package',
-    ],
-    options.workspaceRoot,
-    cleanEnvironment,
-  )
+  if (options.env.DSH_PACKAGE_CHECK_ALREADY_RAN !== '1') {
+    options.run(
+      options.commandShell,
+      [
+        '/d',
+        '/s',
+        '/c',
+        'corepack yarn workspace dsh-plugin-desktop check:win-package',
+      ],
+      options.workspaceRoot,
+      cleanEnvironment,
+    )
+  } else {
+    options.log('Skipping the Windows package preflight; the CI shared gate already passed.')
+  }
   options.run(
     options.nodeExecutable,
     [

--- a/dsh-plugin-desktop/tests/package-mac.spec.ts
+++ b/dsh-plugin-desktop/tests/package-mac.spec.ts
@@ -94,6 +94,37 @@ describe('macOS DMG smoke packaging', () => {
     ])
   })
 
+  it('reuses a completed CI package gate when explicitly requested', () => {
+    const calls: CommandCall[] = []
+    const logs: string[] = []
+    const value = {
+      ...options(calls, logs),
+      env: {
+        ...options(calls).env,
+        DSH_PACKAGE_CHECK_ALREADY_RAN: '1',
+      },
+    }
+
+    packageMacSmoke(value)
+
+    expect(calls).toHaveLength(2)
+    expect(calls[0]?.args).toEqual([
+      '/repo/node_modules/electron-builder/cli.js',
+      '--mac',
+      'dmg',
+      '--universal',
+      '--publish',
+      'never',
+      '--config.mac.notarize=false',
+      '--config.npmRebuild=false',
+      '--config.directories.output=/repo/dsh-plugin-desktop/dist/mac-smoke',
+    ])
+    expect(logs).toEqual([
+      'Building an unsigned macOS DMG smoke; signing and notarization are release-only steps.',
+      'Skipping the macOS package preflight; the CI shared gate already passed.',
+    ])
+  })
+
   it.each([
     ['win32', 'arm64', '22.23.2', 'native macOS host'],
     ['darwin', 'ia32', '22.23.2', 'requires x64 or arm64 Node'],

--- a/dsh-plugin-desktop/tests/package-win.spec.ts
+++ b/dsh-plugin-desktop/tests/package-win.spec.ts
@@ -115,6 +115,36 @@ describe('Windows x64 installer packaging', () => {
     ])
   })
 
+  it('reuses a completed CI package gate when explicitly requested', () => {
+    const calls: CommandCall[] = []
+    const logs: string[] = []
+    const value = {
+      ...options(calls, logs),
+      env: {
+        ...options(calls).env,
+        DSH_PACKAGE_CHECK_ALREADY_RAN: '1',
+      },
+    }
+
+    packageWindowsInstaller(value)
+
+    expect(calls).toHaveLength(2)
+    expect(calls[0]?.args).toEqual([
+      'C:\\repo\\node_modules\\electron-builder\\cli.js',
+      '--win',
+      'nsis',
+      '--x64',
+      '--publish',
+      'never',
+      '--config.win.signExecutable=false',
+      '--config.npmRebuild=false',
+    ])
+    expect(logs).toEqual([
+      'Building an unsigned Windows x64 installer; Authenticode is a separate release step.',
+      'Skipping the Windows package preflight; the CI shared gate already passed.',
+    ])
+  })
+
   it.each([
     ['darwin', 'x64', '22.23.2', 'native Windows host'],
     ['win32', 'arm64', '22.23.2', 'requires x64 Node'],

--- a/dsh-plugin-desktop/tests/package.spec.ts
+++ b/dsh-plugin-desktop/tests/package.spec.ts
@@ -398,7 +398,7 @@ describe('published package surface', () => {
     expect(manifest.devDependencies?.['@electron/asar']).toBe('3.4.1')
   })
 
-  it('runs the full gate on Windows and packages through root scripts on native runners', () => {
+  it('runs the full gate once before reusing native packaging outputs on Windows', () => {
     const windowsJob = ciWorkflow.slice(
       ciWorkflow.indexOf('  desktop-windows:'),
       ciWorkflow.indexOf('  desktop-macos:'),
@@ -409,12 +409,14 @@ describe('published package surface', () => {
     )
 
     expect(windowsJob).toContain('- run: yarn check')
-    expect(windowsJob).toContain('- run: yarn dist:win')
-    expect(windowsJob).toContain('- run: yarn dist:win-portable')
-    expect(windowsJob).not.toContain('yarn workspace dsh-plugin-desktop dist:win')
-    expect(macosJob).toContain('- run: yarn workspace dsh-community-market check')
-    expect(macosJob).toContain('- run: yarn dist:mac-smoke')
-    expect(macosJob).not.toContain('yarn workspace dsh-plugin-desktop dist:mac-smoke')
+    expect(windowsJob).toContain('run: yarn workspace dsh-plugin-desktop dist:win')
+    expect(windowsJob).toContain('run: yarn workspace dsh-plugin-desktop dist:win-portable')
+    expect(windowsJob).toContain('DSH_PACKAGE_CHECK_ALREADY_RAN: \'1\'')
+    expect(macosJob).not.toContain('- run: yarn workspace dsh-community-market check')
+    expect(macosJob).toContain('- run: yarn check')
+    expect(macosJob).toContain('run: yarn workspace dsh-plugin-desktop dist:mac-smoke')
+    expect(macosJob).toContain('DSH_PACKAGE_CHECK_ALREADY_RAN: \'1\'')
+    expect(macosJob).not.toContain('- run: yarn dist:mac-smoke')
   })
 
   it('skips product packaging only for documentation-only changes', () => {

--- a/dsh-plugin-desktop/tests/package.spec.ts
+++ b/dsh-plugin-desktop/tests/package.spec.ts
@@ -1,7 +1,9 @@
 import { createHash } from 'node:crypto'
+import { execFileSync } from 'node:child_process'
 import { readFileSync, readdirSync } from 'node:fs'
 import { createRequire } from 'node:module'
 import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
 import sharp from 'sharp'
 import { describe, expect, it } from 'vitest'
 
@@ -413,6 +415,31 @@ describe('published package surface', () => {
     expect(macosJob).toContain('- run: yarn workspace dsh-community-market check')
     expect(macosJob).toContain('- run: yarn dist:mac-smoke')
     expect(macosJob).not.toContain('yarn workspace dsh-plugin-desktop dist:mac-smoke')
+  })
+
+  it('skips product packaging only for documentation-only changes', () => {
+    const classifier = fileURLToPath(new URL('../../scripts/classify-ci-changes.mjs', import.meta.url))
+    const classify = (paths: string[]): string => execFileSync(
+      process.execPath,
+      [classifier],
+      { input: Buffer.from(`${paths.join('\0')}\0`), encoding: 'utf8' },
+    ).trim()
+
+    expect(classify([
+      'docs/architecture.md',
+      '.agents/notes/implemented/architecture/decision.md',
+      '.agents/notes/implemented/architecture/decision.i18n.yaml',
+      'dsh-community-market/docs/schema.json',
+      '.github/ISSUE_TEMPLATE/feature_request.yml',
+    ])).toBe('false')
+    expect(classify(['README.md', 'dsh-plugin-desktop/src/index.ts'])).toBe('true')
+    expect(classify(['.github/workflows/ci.yml'])).toBe('true')
+    expect(classify(['THIRD_PARTY_NOTICES.md'])).toBe('true')
+    expect(classify([])).toBe('true')
+
+    expect(ciWorkflow).toContain('product="$(git diff --name-only -z')
+    expect(ciWorkflow).toContain("if: needs.changes.outputs.product == 'true'")
+    expect(ciWorkflow).toContain('Documentation-only change; product build and tests are not required.')
   })
 
   it('keeps one fixed brand-blue tray source for generated native assets', () => {

--- a/scripts/classify-ci-changes.mjs
+++ b/scripts/classify-ci-changes.mjs
@@ -1,0 +1,20 @@
+import { readFileSync } from 'node:fs'
+
+const changedPaths = readFileSync(0)
+  .toString('utf8')
+  .split('\0')
+  .filter(Boolean)
+
+const productCriticalDocument = /(?:^|\/)(?:LICENSE(?:\.[^/]*)?|THIRD_PARTY_NOTICES\.md)$/u
+const documentationPath = /^(?:docs\/|\.agents\/notes\/|\.github\/(?:ISSUE_TEMPLATE\/|PULL_REQUEST_TEMPLATE))/u
+const nestedDocumentationPath = /\/docs\//u
+const documentationFile = /(?:\.mdx?|\.i18n\.ya?ml)$/u
+
+const productChanged = changedPaths.length === 0 || changedPaths.some((path) => {
+  if (productCriticalDocument.test(path)) return true
+  return !documentationPath.test(path)
+    && !nestedDocumentationPath.test(path)
+    && !documentationFile.test(path)
+})
+
+process.stdout.write(productChanged ? 'true\n' : 'false\n')


### PR DESCRIPTION
## Summary\n- classify documentation-only changes inside the workflow so required checks remain conclusive\n- keep the lightweight check gate while skipping Windows/macOS packaging and upstream smoke jobs for docs-only changes\n- keep source, workflow, dependency, license, and package changes on the full product gate\n- cover path classification and workflow wiring in the package tests\n\n## Verification\n- corepack yarn workspace dsh-plugin-desktop vitest run tests/package.spec.ts\n- corepack yarn workspace dsh-plugin-desktop tsc -p tsconfig.tests.json --noEmit\n- GitHub Actions YAML parsed with the workspace YAML parser\n- git diff --check\n\nThe previous documentation PR #296 was merged separately before this CI change.