### PR TITLE
fix: treat empty Cordis patch files as no-op

### DIFF
--- a/dsh-plugin-desktop/tests/profile.spec.ts
+++ b/dsh-plugin-desktop/tests/profile.spec.ts
@@ -3,7 +3,13 @@ import { tmpdir } from 'node:os'
 import { dirname, join } from 'node:path'
 import { fileURLToPath, pathToFileURL } from 'node:url'
 import { afterEach, describe, expect, it } from 'vitest'
-import { composeEntries, initProfile, PROFILE_TEMPLATES } from '@deepseek-ai/dsh-app-boot'
+import {
+  composeEntries,
+  initProfile,
+  loadOptionalPatches,
+  PROFILE_PATCH_FILENAME,
+  PROFILE_TEMPLATES,
+} from '@deepseek-ai/dsh-app-boot'
 import {
   DESKTOP_PACKAGE_NAME,
   desktopShellModeFromSettings,
@@ -61,6 +67,14 @@ afterEach(() => {
 describe('desktop profile composition', {
   timeout: process.platform === 'win32' ? 10_000 : 5_000,
 }, () => {
+  it.each(['', '\n# no user patches\n'])('treats an empty home patch file as no patch layer (%j)', content => {
+    const home = temporaryHome()
+    const patchFile = join(home, PROFILE_PATCH_FILENAME)
+    writeFileSync(patchFile, content)
+
+    expect(loadOptionalPatches('dsh-plugin-desktop', patchFile)).toEqual([])
+  })
+
   it('reads packaged Cordis skills from the physical unpacked preset root', () => {
     const home = temporaryHome()
     const resources = join(home, 'resources')

--- a/package.json
+++ b/package.json
@@ -22,6 +22,8 @@
     "@deepseek-ai/dsh-client-ui-directory-picker-browse@npm:^0.1.0-rc.7": "patch:@deepseek-ai/dsh-client-ui-directory-picker-browse@npm%3A0.1.0-rc.7#./patches/dsh-client-ui-directory-picker-browse@0.1.0-rc.7.patch",
     "@deepseek-ai/dsh-client-ui-workspace@npm:0.1.0-rc.7": "patch:@deepseek-ai/dsh-client-ui-workspace@npm%3A0.1.0-rc.7#./patches/dsh-client-ui-workspace@0.1.0-rc.7.patch",
     "@deepseek-ai/dsh-client-ui-workspace@npm:^0.1.0-rc.7": "patch:@deepseek-ai/dsh-client-ui-workspace@npm%3A0.1.0-rc.7#./patches/dsh-client-ui-workspace@0.1.0-rc.7.patch",
+    "@deepseek-ai/dsh-app-boot@npm:0.1.0-rc.7": "patch:@deepseek-ai/dsh-app-boot@npm%3A0.1.0-rc.7#./patches/dsh-app-boot@0.1.0-rc.7.patch",
+    "@deepseek-ai/dsh-app-boot@npm:^0.1.0-rc.7": "patch:@deepseek-ai/dsh-app-boot@npm%3A0.1.0-rc.7#./patches/dsh-app-boot@0.1.0-rc.7.patch",
     "koffi@npm:^3.1.0": "3.1.5"
   },
   "dependenciesMeta": {

--- a/patches/dsh-app-boot@0.1.0-rc.7.patch
+++ b/patches/dsh-app-boot@0.1.0-rc.7.patch
@@ -1,0 +1,12 @@
+diff --git a/lib/index.js b/lib/index.js
+index 3a53e819b0affbe6fee86ce2328634f3f8d1bdd0..9b5583a84274e09e9c4b6e5a217d8954fdb4df5d 100644
+--- a/lib/index.js
++++ b/lib/index.js
+@@ -837,6 +837,7 @@ function parsePatchList(binName, file, content, label) {
+ 	} catch (error) {
+ 		throw new Error(`${binName}: failed to parse ${label} ${file}: ${String(error)}`);
+ 	}
++	if (parsed === null || parsed === void 0) return [];
+ 	if (!Array.isArray(parsed)) throw new Error(`${binName}: ${label} ${file} must be a top-level YAML array of loader patch entries`);
+ 	parsed.forEach((entry, index) => {
+ 		if (typeof entry !== "object" || entry === null || Array.isArray(entry)) throw new Error(`${binName}: ${label} entry ${index + 1} in ${file} must be a mapping (a loader patch entry)`);

--- a/yarn.lock
+++ b/yarn.lock
@@ -819,7 +819,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@deepseek-ai/dsh-app-boot@npm:0.1.0-rc.7, @deepseek-ai/dsh-app-boot@npm:^0.1.0-rc.7":
+"@deepseek-ai/dsh-app-boot@npm:0.1.0-rc.7":
   version: 0.1.0-rc.7
   resolution: "@deepseek-ai/dsh-app-boot@npm:0.1.0-rc.7"
   dependencies:
@@ -838,6 +838,28 @@ __metadata:
     "@deepseek-ai/cordis-plugin-hmr":
       optional: true
   checksum: 10c0/461b35996d9602e0e5ccabb07e5183afb17b574cbce0ad9ab62c026be7b540d9874e3238f98624ac596da9e2ade9da510e3af4e524e5f8f92dbfb5cb8859e358
+  languageName: node
+  linkType: hard
+
+"@deepseek-ai/dsh-app-boot@patch:@deepseek-ai/dsh-app-boot@npm%3A0.1.0-rc.7#./patches/dsh-app-boot@0.1.0-rc.7.patch::locator=deepseek-harness-desktop%40workspace%3A.":
+  version: 0.1.0-rc.7
+  resolution: "@deepseek-ai/dsh-app-boot@patch:@deepseek-ai/dsh-app-boot@npm%3A0.1.0-rc.7#./patches/dsh-app-boot@0.1.0-rc.7.patch::version=0.1.0-rc.7&hash=b8561c&locator=deepseek-harness-desktop%40workspace%3A."
+  dependencies:
+    js-yaml: "npm:^4.2.0"
+  peerDependencies:
+    "@deepseek-ai/cordis": ^4.0.1
+    "@deepseek-ai/cordis-plugin-group": ^1.0.1
+    "@deepseek-ai/cordis-plugin-hmr": ^1.0.16
+    "@deepseek-ai/cordis-plugin-include": ^1.0.6
+    "@deepseek-ai/cordis-plugin-loader": ^1.0.2
+    "@deepseek-ai/dsh-home-paths": ^0.1.0-rc.7
+    "@deepseek-ai/dsh-invariants": ^0.1.0-rc.7
+    "@deepseek-ai/dsh-launch-environment": ^0.1.0-rc.7
+    "@deepseek-ai/dsh-system-prompt": ^0.1.0-rc.7
+  peerDependenciesMeta:
+    "@deepseek-ai/cordis-plugin-hmr":
+      optional: true
+  checksum: 10c0/2a12822b9bd87edb7f66943c82c57e133a7567d8ba1b435f5c99ee930e32960cfdd2081a680376f66c8b0da37b1cb310f0f0df70cda80f9cd6dfaefeb54a5297
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

- treat empty or comment-only `cordis.patch.yml` files as an empty patch layer
- keep malformed non-array patch files failing loudly
- add desktop regression coverage for empty and comment-only files

Fixes #289

## Validation

- `yarn workspace dsh-plugin-desktop test tests/profile.spec.ts`
- `yarn workspace dsh-plugin-desktop typecheck`
- `yarn install --immutable`

The desktop test suite also passed 57 files; one pre-existing `market-pnpm-integration.spec.ts` test timed out.