### PR TITLE
feat(desktop): toggle DevTools with F12

### DIFF
--- a/dsh-plugin-desktop/src/electron-shell-generation.ts
+++ b/dsh-plugin-desktop/src/electron-shell-generation.ts
@@ -29,6 +29,10 @@ function isZoomShortcut(input: Electron.Input): 'in' | 'out' | 'reset' | undefin
   return undefined
 }
 
+function isDevToolsShortcut(input: Electron.Input): boolean {
+  return input.type === 'keyDown' && input.key === 'F12'
+}
+
 export interface ElectronShellGenerationOptions {
   readonly platform: ElectronPlatformStrategy
   readonly spec: DesktopShellSpec
@@ -75,7 +79,12 @@ export class ElectronShellGeneration {
       window.hide()
     }
     const preserveBlankTitle = (event: Electron.Event): void => { event.preventDefault() }
-    const handleZoomShortcut = (event: Electron.Event, input: Electron.Input): void => {
+    const handleShortcut = (event: Electron.Event, input: Electron.Input): void => {
+      if (isDevToolsShortcut(input)) {
+        event.preventDefault()
+        window.webContents.toggleDevTools()
+        return
+      }
       const action = isZoomShortcut(input)
       if (action === undefined) return
       event.preventDefault()
@@ -134,7 +143,7 @@ export class ElectronShellGeneration {
     app.on('activate', show)
     window.on('close', close)
     window.on('page-title-updated', preserveBlankTitle)
-    window.webContents.on('before-input-event', handleZoomShortcut)
+    window.webContents.on('before-input-event', handleShortcut)
     window.webContents.on('will-frame-navigate', navigate)
     window.webContents.on('will-redirect', redirect)
     window.webContents.on('render-process-gone', rendererGone)
@@ -159,7 +168,7 @@ export class ElectronShellGeneration {
       window.off('close', close)
       window.off('page-title-updated', preserveBlankTitle)
       window.off('ready-to-show', show)
-      window.webContents.off('before-input-event', handleZoomShortcut)
+      window.webContents.off('before-input-event', handleShortcut)
       window.webContents.off('will-frame-navigate', navigate)
       window.webContents.off('will-redirect', redirect)
       window.webContents.off('render-process-gone', rendererGone)

--- a/dsh-plugin-desktop/tests/electron-runtime.spec.ts
+++ b/dsh-plugin-desktop/tests/electron-runtime.spec.ts
@@ -93,6 +93,7 @@ const electron = vi.hoisted(() => {
     off: vi.fn(),
     setZoomLevel: vi.fn((level: number) => { zoomLevel = level }),
     setWindowOpenHandler: vi.fn(),
+    toggleDevTools: vi.fn(),
   }
   const nativeTheme = { themeSource: 'system' }
 
@@ -640,6 +641,36 @@ describe('Electron desktop runtime', () => {
     await release()
     expect(electron.trays[0]?.destroy).toHaveBeenCalledOnce()
     expect(electron.browserWindows[0]?.destroy).toHaveBeenCalledOnce()
+  })
+
+  it('toggles DevTools with F12 while keeping zoom shortcuts intact', async () => {
+    vi.spyOn(process, 'platform', 'get').mockReturnValue('win32')
+    const { ElectronDesktopRuntime } = await import('../src/electron-runtime.ts')
+    const runtime = new ElectronDesktopRuntime(async () => {})
+    const release = runtime.schedule(spec)
+
+    await runtime.mountScheduled()
+
+    const shortcutListener = electron.webContents.on.mock.calls
+      .find(([event]) => event === 'before-input-event')?.[1]
+    expect(shortcutListener).toEqual(expect.any(Function))
+
+    const f12 = { preventDefault: vi.fn() }
+    shortcutListener(f12, { type: 'keyDown', key: 'F12' })
+    expect(f12.preventDefault).toHaveBeenCalledOnce()
+    expect(electron.webContents.toggleDevTools).toHaveBeenCalledOnce()
+
+    const f12Release = { preventDefault: vi.fn() }
+    shortcutListener(f12Release, { type: 'keyUp', key: 'F12' })
+    expect(f12Release.preventDefault).not.toHaveBeenCalled()
+    expect(electron.webContents.toggleDevTools).toHaveBeenCalledOnce()
+
+    const zoomIn = { preventDefault: vi.fn() }
+    shortcutListener(zoomIn, { type: 'keyDown', control: true, key: '=' })
+    expect(zoomIn.preventDefault).toHaveBeenCalledOnce()
+    expect(electron.webContents.setZoomLevel).toHaveBeenLastCalledWith(1)
+
+    await release()
   })
 
   it('does not block a sandboxed iframe from navigating to an external origin', async () => {


### PR DESCRIPTION
## Summary

F12 现在可以在桌面壳中打开/关闭 DevTools 控制台（Addresses #175）。

## Change

- `dsh-plugin-desktop/src/electron-shell-generation.ts`：在已有的 `before-input-event` 快捷键处理中新增 `isDevToolsShortcut`，按下 F12 时调用 `webContents.toggleDevTools()`；原缩放快捷键（Ctrl/Cmd +/-/0）行为不变。
- `dsh-plugin-desktop/tests/electron-runtime.spec.ts`：新增回归测试，覆盖 F12 按下触发、keyUp 不重复触发、缩放快捷键不受影响。

## Verification

- `yarn workspace dsh-plugin-desktop typecheck` 通过
- `yarn workspace dsh-plugin-desktop test`：58 files passed，572 passed / 3 skipped
<img width="1280" height="840" alt="image" src="https://github.com/user-attachments/assets/4a8682d2-770f-4b1e-ad2d-1b102833aa2c" />


## Note

仅放行用户主动按键，不改变窗口安全配置（contextIsolation / sandbox / webSecurity 均保持现状）；DevTools 打开的是本机 GUI 自身页面。
