### PR TITLE
feat(desktop): record startup lifecycle evidence

### DIFF
--- a/dsh-plugin-desktop/src/diagnostic-export-worker.ts
+++ b/dsh-plugin-desktop/src/diagnostic-export-worker.ts
@@ -14,9 +14,14 @@ import {
   type Stats,
   unlinkSync,
 } from 'node:fs'
-import { join } from 'node:path'
+import { dirname, join } from 'node:path'
 import { isMainThread, parentPort, workerData } from 'node:worker_threads'
 import AdmZip from 'adm-zip'
+import {
+  DESKTOP_LIFECYCLE_EVIDENCE_ENTRY,
+  DESKTOP_LIFECYCLE_SUMMARY_ENTRY,
+  summarizeDesktopLifecycleEvidence,
+} from './lifecycle-events.ts'
 import { isDesktopLogFileName } from './log-files.ts'
 
 const DIAGNOSTIC_ARCHIVE = /^diagnostics-\d+(?:-[0-9a-f-]+)?\.zip$/u
@@ -30,6 +35,7 @@ interface DiagnosticExportWorkerData {
   readonly maxEvidenceBytes: number
   readonly crashDumpsDir?: string
   readonly runStatePath?: string
+  readonly lifecycleEvidencePath?: string
 }
 
 export type DiagnosticExportWorkerResult =
@@ -64,10 +70,22 @@ function regularLogEntry(logsDir: string, name: string): LogEntry | undefined {
 function regularEvidenceEntry(path: string, name: string): LogEntry | undefined {
   try {
     const stats = lstatSync(path)
-    return !stats.isSymbolicLink() && stats.isFile() ? { name, path, stats } : undefined
+    if (stats.isSymbolicLink() || !stats.isFile() || hasLinkedParent(path)) return undefined
+    return { name, path, stats }
   } catch (cause) {
     if (skippableFileError(cause)) return undefined
     throw cause
+  }
+}
+
+function hasLinkedParent(path: string): boolean {
+  let current = dirname(path)
+  while (true) {
+    const stats = lstatSync(current)
+    if (stats.isSymbolicLink()) return true
+    const parent = dirname(current)
+    if (parent === current) return false
+    current = parent
   }
 }
 
@@ -162,6 +180,9 @@ async function createDiagnosticsArchive(data: DiagnosticExportWorkerData): Promi
   const runStateCandidate = data.runStatePath === undefined
     ? undefined
     : regularEvidenceEntry(data.runStatePath, 'crash-evidence/active-run.json')
+  const lifecycleCandidate = data.lifecycleEvidencePath === undefined
+    ? undefined
+    : regularEvidenceEntry(data.lifecycleEvidencePath, DESKTOP_LIFECYCLE_EVIDENCE_ENTRY)
   const zip = new AdmZip()
   let includedBytes = 0
   let omittedFiles = 0
@@ -169,6 +190,30 @@ async function createDiagnosticsArchive(data: DiagnosticExportWorkerData): Promi
   let omittedCrashDumps = 0
   let includedActiveRunMarker = false
   let omittedActiveRunMarker = false
+  let includedLifecycleEvidence = false
+  let omittedLifecycleEvidence = false
+  let includedLifecycleSummary = false
+  let omittedLifecycleSummary = false
+  if (lifecycleCandidate !== undefined) {
+    const content = readStableLog(lifecycleCandidate, data.maxEvidenceBytes - includedBytes)
+    if (content === undefined) {
+      omittedLifecycleEvidence = true
+    } else {
+      zip.addFile(lifecycleCandidate.name, content)
+      includedBytes += content.byteLength
+      includedLifecycleEvidence = true
+      const summary = summarizeDesktopLifecycleEvidence(content)
+      if (summary !== undefined) {
+        if (summary.byteLength <= data.maxEvidenceBytes - includedBytes) {
+          zip.addFile(DESKTOP_LIFECYCLE_SUMMARY_ENTRY, summary)
+          includedBytes += summary.byteLength
+          includedLifecycleSummary = true
+        } else {
+          omittedLifecycleSummary = true
+        }
+      }
+    }
+  }
   for (const entry of [...(runStateCandidate === undefined ? [] : [runStateCandidate]), ...crashCandidates, ...candidates]) {
     const content = readStableLog(entry, data.maxEvidenceBytes - includedBytes)
     if (content === undefined) {
@@ -197,8 +242,12 @@ async function createDiagnosticsArchive(data: DiagnosticExportWorkerData): Promi
     `omitted-crash-dumps: ${String(omittedCrashDumps)}`,
     `included-active-run-marker: ${String(includedActiveRunMarker)}`,
     `omitted-active-run-marker: ${String(omittedActiveRunMarker)}`,
+    `included-lifecycle-evidence: ${String(includedLifecycleEvidence)}`,
+    `omitted-lifecycle-evidence: ${String(omittedLifecycleEvidence)}`,
+    `included-lifecycle-summary: ${String(includedLifecycleSummary)}`,
+    `omitted-lifecycle-summary: ${String(omittedLifecycleSummary)}`,
     `evidence-byte-limit: ${String(data.maxEvidenceBytes)}`,
-    'privacy: logs may contain local paths, workspace IDs, and session IDs; crash dumps may contain process memory',
+    'privacy: logs may contain local paths, workspace IDs, and session IDs; crash dumps may contain process memory; lifecycle evidence contains startup timings and bounded plugin IDs',
   ].join('\n')
   zip.addFile('system-info.txt', Buffer.from(`${info}\n`, 'utf8'))
 

--- a/dsh-plugin-desktop/src/diagnostic-export-worker.ts
+++ b/dsh-plugin-desktop/src/diagnostic-export-worker.ts
@@ -14,7 +14,7 @@ import {
   type Stats,
   unlinkSync,
 } from 'node:fs'
-import { dirname, join } from 'node:path'
+import { dirname, isAbsolute, join, relative, resolve, sep } from 'node:path'
 import { isMainThread, parentPort, workerData } from 'node:worker_threads'
 import AdmZip from 'adm-zip'
 import {
@@ -67,10 +67,10 @@ function regularLogEntry(logsDir: string, name: string): LogEntry | undefined {
   }
 }
 
-function regularEvidenceEntry(path: string, name: string): LogEntry | undefined {
+function regularEvidenceEntry(path: string, name: string, ownerDir: string): LogEntry | undefined {
   try {
     const stats = lstatSync(path)
-    if (stats.isSymbolicLink() || !stats.isFile() || hasLinkedParent(path)) return undefined
+    if (stats.isSymbolicLink() || !stats.isFile() || hasLinkedParent(path, ownerDir)) return undefined
     return { name, path, stats }
   } catch (cause) {
     if (skippableFileError(cause)) return undefined
@@ -78,13 +78,17 @@ function regularEvidenceEntry(path: string, name: string): LogEntry | undefined 
   }
 }
 
-function hasLinkedParent(path: string): boolean {
-  let current = dirname(path)
+function hasLinkedParent(path: string, ownerDir: string): boolean {
+  const owner = resolve(ownerDir)
+  let current = dirname(resolve(path))
+  const relativeParent = relative(owner, current)
+  if (relativeParent === '..' || relativeParent.startsWith(`..${sep}`) || isAbsolute(relativeParent)) return true
   while (true) {
     const stats = lstatSync(current)
     if (stats.isSymbolicLink()) return true
+    if (relative(owner, current) === '') return false
     const parent = dirname(current)
-    if (parent === current) return false
+    if (parent === current) return true
     current = parent
   }
 }
@@ -179,10 +183,10 @@ async function createDiagnosticsArchive(data: DiagnosticExportWorkerData): Promi
     .sort((a, b) => b.stats.mtimeMs - a.stats.mtimeMs || b.name.localeCompare(a.name, 'en'))
   const runStateCandidate = data.runStatePath === undefined
     ? undefined
-    : regularEvidenceEntry(data.runStatePath, 'crash-evidence/active-run.json')
+    : regularEvidenceEntry(data.runStatePath, 'crash-evidence/active-run.json', data.userDataDir)
   const lifecycleCandidate = data.lifecycleEvidencePath === undefined
     ? undefined
-    : regularEvidenceEntry(data.lifecycleEvidencePath, DESKTOP_LIFECYCLE_EVIDENCE_ENTRY)
+    : regularEvidenceEntry(data.lifecycleEvidencePath, DESKTOP_LIFECYCLE_EVIDENCE_ENTRY, data.userDataDir)
   const zip = new AdmZip()
   let includedBytes = 0
   let omittedFiles = 0

--- a/dsh-plugin-desktop/src/diagnostic-export.ts
+++ b/dsh-plugin-desktop/src/diagnostic-export.ts
@@ -4,6 +4,7 @@ import { mkdirSync } from 'node:fs'
 import { join } from 'node:path'
 import { Worker } from 'node:worker_threads'
 import type { DiagnosticExportWorkerResult } from './diagnostic-export-worker.ts'
+import { desktopLifecycleEvidencePath } from './lifecycle-events.ts'
 
 /** Bound both worker memory and the amount of potentially sensitive log history exported. */
 export const MAX_DIAGNOSTIC_EVIDENCE_BYTES = 50 * 1024 * 1024
@@ -20,6 +21,8 @@ export interface DiagnosticExportOptions {
   readonly crashDumpsDir?: string
   /** Active-run marker used to identify a launch that did not shut down cleanly. */
   readonly runStatePath?: string
+  /** Current-run lifecycle JSONL written by the Electron launcher. */
+  readonly lifecycleEvidencePath?: string
 }
 
 export interface DesktopDiagnosticExportOptions {
@@ -96,6 +99,7 @@ export function exportDiagnosticsZip(
       maxEvidenceBytes,
       ...(options.crashDumpsDir === undefined ? {} : { crashDumpsDir: options.crashDumpsDir }),
       ...(options.runStatePath === undefined ? {} : { runStatePath: options.runStatePath }),
+      ...(options.lifecycleEvidencePath === undefined ? {} : { lifecycleEvidencePath: options.lifecycleEvidencePath }),
     },
     resourceLimits: { maxOldGenerationSizeMb: 256 },
   })
@@ -113,6 +117,7 @@ export function exportDesktopDiagnostics(
     appVersion: options.appVersion,
     crashDumpsDir: options.crashDumpsDir ?? join(userDataDir, 'Crashpad'),
     runStatePath: join(userDataDir, 'crash-evidence', 'active-run.json'),
+    lifecycleEvidencePath: desktopLifecycleEvidencePath(userDataDir),
     ...(options.maxEvidenceBytes === undefined ? {} : { maxEvidenceBytes: options.maxEvidenceBytes }),
   })
 }

--- a/dsh-plugin-desktop/src/lifecycle-events.ts
+++ b/dsh-plugin-desktop/src/lifecycle-events.ts
@@ -1,0 +1,631 @@
+import { randomUUID } from 'node:crypto'
+import {
+  chmodSync,
+  closeSync,
+  constants,
+  existsSync,
+  fstatSync,
+  lstatSync,
+  mkdirSync,
+  openSync,
+  readFileSync,
+  unlinkSync,
+  writeFileSync,
+  writeSync,
+} from 'node:fs'
+import { dirname, join } from 'node:path'
+import { performance } from 'node:perf_hooks'
+import type { DesktopLogger } from './desktop-logger.ts'
+import type { RendererBootReport } from './renderer-boot-contract.ts'
+import type { DesktopStartupFailureStage } from './startup-recovery-window.ts'
+
+export const DESKTOP_LIFECYCLE_SCHEMA_VERSION = 1
+export const DESKTOP_LIFECYCLE_EVIDENCE_ENTRY = 'lifecycle-events/startup.jsonl'
+export const DESKTOP_LIFECYCLE_SUMMARY_ENTRY = 'lifecycle-events/summary.json'
+export const MAX_DESKTOP_LIFECYCLE_EVIDENCE_BYTES = 256 * 1024
+export const MAX_DESKTOP_LIFECYCLE_EVENT_BYTES = 8 * 1024
+
+const EVIDENCE_DIRECTORY_NAME = 'lifecycle-events'
+const EVIDENCE_FILENAME = 'startup.jsonl'
+const PRIVATE_DIRECTORY_MODE = 0o700
+const PRIVATE_FILE_MODE = 0o600
+const MAX_DETAIL_STRING_LENGTH = 128
+const MAX_PLUGIN_IDS = 16
+const ID_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$/u
+const PLUGIN_ID_PATTERN = /^(?:@[a-z0-9][a-z0-9._-]{0,63}\/)?[a-z0-9][a-z0-9._-]{0,127}$/u
+
+const STARTUP_STAGES = new Set<DesktopStartupFailureStage>([
+  'electron-ready',
+  'shell-environment',
+  'runtime-bootstrap',
+  'profile-selection',
+  'install-recovery',
+  'profile-composition',
+  'host-boot',
+  'renderer-startup',
+  'health-commit',
+])
+
+const EVENT_NAMES = new Set<DesktopLifecycleEventName>([
+  'startup.run.started',
+  'startup.run.completed',
+  'startup.run.failed',
+  'startup.stage.started',
+  'startup.stage.completed',
+  'startup.stage.failed',
+  'renderer.boot.started',
+  'renderer.boot.completed',
+  'renderer.boot.failed',
+  'renderer.boot.timeout',
+])
+
+const RENDERER_STATUSES = new Set(['healthy', 'failed', 'timeout'])
+const FAILURE_REASONS = new Set(['startup-failed', 'renderer-failed', 'renderer-timeout'])
+
+export type DesktopLifecycleFailureReason = 'startup-failed' | 'renderer-failed' | 'renderer-timeout'
+export type DesktopLifecycleRendererFailureReason = 'renderer-failed' | 'renderer-timeout'
+export type DesktopLifecycleRendererStatus = 'healthy' | 'failed' | 'timeout'
+export type DesktopLifecycleEventName =
+  | 'startup.run.started'
+  | 'startup.run.completed'
+  | 'startup.run.failed'
+  | 'startup.stage.started'
+  | 'startup.stage.completed'
+  | 'startup.stage.failed'
+  | 'renderer.boot.started'
+  | 'renderer.boot.completed'
+  | 'renderer.boot.failed'
+  | 'renderer.boot.timeout'
+
+type DesktopLifecycleDetailValue = string | number | readonly string[]
+type DesktopLifecycleDetails = Readonly<Record<string, DesktopLifecycleDetailValue>>
+
+export interface DesktopLifecycleEvent {
+  readonly schemaVersion: typeof DESKTOP_LIFECYCLE_SCHEMA_VERSION
+  readonly timestamp: string
+  readonly monotonicMs: number
+  readonly durationMs?: number
+  readonly runId: string
+  readonly operationId: string
+  readonly eventName: DesktopLifecycleEventName
+  readonly stageId?: DesktopStartupFailureStage
+  readonly details: DesktopLifecycleDetails
+}
+
+export interface DesktopLifecycleSummaryStage {
+  readonly stageId: DesktopStartupFailureStage
+  readonly status: 'started' | 'completed' | 'failed'
+  readonly durationMs?: number
+}
+
+export interface DesktopLifecycleSummary {
+  readonly schemaVersion: typeof DESKTOP_LIFECYCLE_SCHEMA_VERSION
+  readonly eventCount: number
+  readonly parseErrorCount: number
+  readonly runId?: string
+  readonly operationId?: string
+  readonly finalOutcome?: 'completed' | 'failed'
+  readonly finalStage?: DesktopStartupFailureStage
+  readonly rendererStatus?: DesktopLifecycleRendererStatus
+  readonly totalDurationMs?: number
+  readonly stages: readonly DesktopLifecycleSummaryStage[]
+}
+
+export interface DesktopLifecycleRecorderOptions {
+  readonly userDataDir: string
+  readonly appVersion: string
+  readonly platform: NodeJS.Platform
+  readonly arch: string
+  readonly logger: DesktopLogger
+  readonly now?: () => Date
+  readonly monotonicNow?: () => number
+  readonly randomId?: () => string
+}
+
+export function desktopLifecycleEvidencePath(userDataDir: string): string {
+  return join(userDataDir, EVIDENCE_DIRECTORY_NAME, EVIDENCE_FILENAME)
+}
+
+export function createDesktopLifecycleRecorder(options: DesktopLifecycleRecorderOptions): DesktopLifecycleRecorder {
+  return new DesktopLifecycleRecorder(options)
+}
+
+export function parseDesktopLifecycleEvent(value: unknown): DesktopLifecycleEvent {
+  if (value === null || typeof value !== 'object' || Array.isArray(value)) throw new Error('event must be an object')
+  const event = value as Record<string, unknown>
+  if (event.schemaVersion !== DESKTOP_LIFECYCLE_SCHEMA_VERSION) throw new Error('event schemaVersion is invalid')
+  if (typeof event.timestamp !== 'string' || event.timestamp.length === 0 || /[\0\r\n]/u.test(event.timestamp)) {
+    throw new Error('event timestamp is invalid')
+  }
+  if (Number.isNaN(Date.parse(event.timestamp))) throw new Error('event timestamp is invalid')
+  if (typeof event.monotonicMs !== 'number' || !validDuration(event.monotonicMs)) {
+    throw new Error('event monotonicMs is invalid')
+  }
+  const monotonicMs = event.monotonicMs
+  let durationMs: number | undefined
+  if (event.durationMs !== undefined) {
+    if (typeof event.durationMs !== 'number' || !validDuration(event.durationMs)) {
+      throw new Error('event durationMs is invalid')
+    }
+    durationMs = event.durationMs
+  }
+  if (typeof event.runId !== 'string' || !ID_PATTERN.test(event.runId)) throw new Error('event runId is invalid')
+  const runId = event.runId
+  if (typeof event.operationId !== 'string' || !ID_PATTERN.test(event.operationId)) {
+    throw new Error('event operationId is invalid')
+  }
+  const operationId = event.operationId
+  if (typeof event.eventName !== 'string' || !EVENT_NAMES.has(event.eventName as DesktopLifecycleEventName)) {
+    throw new Error('event name is invalid')
+  }
+  const eventName = event.eventName as DesktopLifecycleEventName
+  const stageId = parseEventStage(eventName, event.stageId)
+  const details = parseDetails(eventName, event.details)
+  return {
+    schemaVersion: DESKTOP_LIFECYCLE_SCHEMA_VERSION,
+    timestamp: event.timestamp,
+    monotonicMs,
+    ...(durationMs === undefined ? {} : { durationMs }),
+    runId,
+    operationId,
+    eventName,
+    ...(stageId === undefined ? {} : { stageId }),
+    details,
+  }
+}
+
+export function summarizeDesktopLifecycleEvidence(content: Buffer): Buffer | undefined {
+  let eventCount = 0
+  let parseErrorCount = 0
+  let runId: string | undefined
+  let operationId: string | undefined
+  let finalOutcome: 'completed' | 'failed' | undefined
+  let finalStage: DesktopStartupFailureStage | undefined
+  let rendererStatus: DesktopLifecycleRendererStatus | undefined
+  let totalDurationMs: number | undefined
+  const stages: DesktopLifecycleSummaryStage[] = []
+
+  for (const line of content.toString('utf8').split(/\n/u)) {
+    if (line.length === 0) continue
+    let event: DesktopLifecycleEvent
+    try {
+      event = parseDesktopLifecycleEvent(JSON.parse(line) as unknown)
+    } catch {
+      parseErrorCount += 1
+      continue
+    }
+    if (runId === undefined) {
+      runId = event.runId
+      operationId = event.operationId
+    } else if (event.runId !== runId || event.operationId !== operationId) {
+      parseErrorCount += 1
+      continue
+    }
+    eventCount += 1
+    if (event.eventName.startsWith('startup.stage.') && event.stageId !== undefined) {
+      const status = event.eventName.endsWith('.completed')
+        ? 'completed'
+        : event.eventName.endsWith('.failed') ? 'failed' : 'started'
+      const openStage = [...stages].reverse().find(stage => stage.stageId === event.stageId && stage.status === 'started')
+      if (openStage !== undefined && status !== 'started') {
+        const index = stages.lastIndexOf(openStage)
+        stages[index] = {
+          stageId: event.stageId,
+          status,
+          ...(event.durationMs === undefined ? {} : { durationMs: event.durationMs }),
+        }
+      } else {
+        stages.push({
+          stageId: event.stageId,
+          status,
+          ...(event.durationMs === undefined ? {} : { durationMs: event.durationMs }),
+        })
+      }
+    }
+    if (event.eventName === 'renderer.boot.completed') rendererStatus = 'healthy'
+    else if (event.eventName === 'renderer.boot.failed') rendererStatus = 'failed'
+    else if (event.eventName === 'renderer.boot.timeout') rendererStatus = 'timeout'
+    if (event.eventName === 'startup.run.completed' || event.eventName === 'startup.run.failed') {
+      finalOutcome = event.eventName === 'startup.run.completed' ? 'completed' : 'failed'
+      finalStage = event.details.finalStage as DesktopStartupFailureStage | undefined
+      if (event.durationMs !== undefined) totalDurationMs = event.durationMs
+    }
+  }
+
+  if (eventCount === 0 && parseErrorCount === 0) return undefined
+  return Buffer.from(`${JSON.stringify({
+    schemaVersion: DESKTOP_LIFECYCLE_SCHEMA_VERSION,
+    eventCount,
+    parseErrorCount,
+    ...(runId === undefined ? {} : { runId }),
+    ...(operationId === undefined ? {} : { operationId }),
+    ...(finalOutcome === undefined ? {} : { finalOutcome }),
+    ...(finalStage === undefined ? {} : { finalStage }),
+    ...(rendererStatus === undefined ? {} : { rendererStatus }),
+    ...(totalDurationMs === undefined ? {} : { totalDurationMs }),
+    stages,
+  } satisfies DesktopLifecycleSummary, undefined, 2)}\n`, 'utf8')
+}
+
+export class DesktopLifecycleRecorder {
+  private readonly evidencePath: string
+  private readonly runId: string
+  private readonly operationId: string
+  private readonly now: () => Date
+  private readonly monotonicNow: () => number
+  private readonly startTime: number
+  private currentStage: DesktopStartupFailureStage | undefined
+  private currentStageStartedAt: number | undefined
+  private rendererStartedAt: number | undefined
+  private rendererSettled = false
+  private startupSettled = false
+  private evidenceUnavailable = false
+  private readonly options: DesktopLifecycleRecorderOptions
+
+  constructor(options: DesktopLifecycleRecorderOptions) {
+    this.options = options
+    this.evidencePath = desktopLifecycleEvidencePath(options.userDataDir)
+    this.now = options.now ?? (() => new Date())
+    this.monotonicNow = options.monotonicNow ?? (() => performance.now())
+    this.runId = validateId(options.randomId?.() ?? randomUUID(), 'runId')
+    this.operationId = validateId(options.randomId?.() ?? randomUUID(), 'operationId')
+    this.startTime = this.monotonicNow()
+    this.prepareFreshEvidence()
+  }
+
+  startStartup(initialStage: DesktopStartupFailureStage): void {
+    if (this.currentStage !== undefined) return
+    this.record('startup.run.started', {
+      appVersion: safeLine(this.options.appVersion),
+      platform: safeLine(this.options.platform),
+      arch: safeLine(this.options.arch),
+    })
+    this.currentStage = initialStage
+    this.currentStageStartedAt = this.monotonicNow()
+    this.recordStartupStage(initialStage, 'started')
+  }
+
+  transitionStartupStage(stage: DesktopStartupFailureStage): void {
+    if (this.startupSettled || this.currentStage === stage) return
+    this.completeCurrentStage()
+    this.currentStage = stage
+    this.currentStageStartedAt = this.monotonicNow()
+    this.recordStartupStage(stage, 'started')
+  }
+
+  startRendererBoot(): void {
+    if (this.rendererStartedAt !== undefined || this.rendererSettled) return
+    this.rendererStartedAt = this.monotonicNow()
+    this.record('renderer.boot.started', {})
+  }
+
+  finishRendererBoot(
+    report: RendererBootReport,
+    failureReason: DesktopLifecycleRendererFailureReason = 'renderer-failed',
+  ): void {
+    if (this.rendererSettled) return
+    this.rendererSettled = true
+    const durationMs = this.durationFrom(this.rendererStartedAt)
+    if (report.status === 'healthy') {
+      this.record('renderer.boot.completed', { rendererStatus: 'healthy' }, durationMs)
+      return
+    }
+    const timeout = failureReason === 'renderer-timeout'
+    this.record(timeout ? 'renderer.boot.timeout' : 'renderer.boot.failed', {
+      rendererStatus: timeout ? 'timeout' : 'failed',
+      failureReason,
+      pluginCount: report.plugins.length,
+      pluginIds: safePluginIds(report.plugins),
+    }, durationMs)
+  }
+
+  failRendererBootIfPending(failureReason: DesktopLifecycleRendererFailureReason): void {
+    if (this.rendererStartedAt === undefined || this.rendererSettled) return
+    this.rendererSettled = true
+    const timeout = failureReason === 'renderer-timeout'
+    this.record(timeout ? 'renderer.boot.timeout' : 'renderer.boot.failed', {
+      rendererStatus: timeout ? 'timeout' : 'failed',
+      failureReason,
+    }, this.durationFrom(this.rendererStartedAt))
+  }
+
+  completeStartup(finalStage: DesktopStartupFailureStage, report: RendererBootReport): void {
+    if (this.startupSettled) return
+    this.startupSettled = true
+    this.completeCurrentStage()
+    this.record('startup.run.completed', {
+      finalStage,
+      rendererStatus: report.status === 'healthy' ? 'healthy' : 'failed',
+    }, this.durationFrom(this.startTime))
+  }
+
+  failStartup(finalStage: DesktopStartupFailureStage, failureReason: DesktopLifecycleFailureReason): void {
+    if (this.startupSettled) return
+    this.startupSettled = true
+    this.failCurrentStage()
+    this.record('startup.run.failed', {
+      finalStage,
+      failureReason,
+    }, this.durationFrom(this.startTime))
+  }
+
+  private completeCurrentStage(): void {
+    const stage = this.currentStage
+    if (stage === undefined) return
+    this.recordStartupStage(stage, 'completed', this.durationFrom(this.currentStageStartedAt))
+    this.currentStage = undefined
+    this.currentStageStartedAt = undefined
+  }
+
+  private failCurrentStage(): void {
+    const stage = this.currentStage
+    if (stage === undefined) return
+    this.recordStartupStage(stage, 'failed', this.durationFrom(this.currentStageStartedAt))
+    this.currentStage = undefined
+    this.currentStageStartedAt = undefined
+  }
+
+  private recordStartupStage(
+    stageId: DesktopStartupFailureStage,
+    outcome: 'started' | 'completed' | 'failed',
+    durationMs?: number,
+  ): void {
+    this.record(
+      `startup.stage.${outcome}` as DesktopLifecycleEventName,
+      {},
+      durationMs,
+      stageId,
+    )
+  }
+
+  private record(
+    eventName: DesktopLifecycleEventName,
+    details: DesktopLifecycleDetails,
+    durationMs?: number,
+    stageId?: DesktopStartupFailureStage,
+  ): void {
+    try {
+      const event = parseDesktopLifecycleEvent({
+        schemaVersion: DESKTOP_LIFECYCLE_SCHEMA_VERSION,
+        timestamp: this.now().toISOString(),
+        monotonicMs: this.durationFrom(this.startTime) ?? 0,
+        ...(durationMs === undefined ? {} : { durationMs }),
+        runId: this.runId,
+        operationId: this.operationId,
+        eventName,
+        ...(stageId === undefined ? {} : { stageId }),
+        details,
+      })
+      this.writeEvent(event)
+    } catch (cause) {
+      this.evidenceUnavailable = true
+      this.reportFailure(cause)
+    }
+  }
+
+  private durationFrom(startedAt: number | undefined): number | undefined {
+    if (startedAt === undefined) return undefined
+    const value = this.monotonicNow() - startedAt
+    return Number.isFinite(value) && value >= 0 ? Number(value.toFixed(3)) : undefined
+  }
+
+  private prepareFreshEvidence(): void {
+    try {
+      const directory = dirname(this.evidencePath)
+      mkdirSync(directory, { recursive: true, mode: PRIVATE_DIRECTORY_MODE })
+      const directoryStats = lstatSync(directory)
+      if (directoryStats.isSymbolicLink() || !directoryStats.isDirectory()) {
+        throw new Error('lifecycle evidence directory is invalid')
+      }
+      try { chmodSync(directory, PRIVATE_DIRECTORY_MODE) } catch {}
+      if (existsSync(this.evidencePath)) {
+        const stats = lstatSync(this.evidencePath)
+        if (stats.isSymbolicLink() || !stats.isFile() || stats.nlink > 1) {
+          throw new Error('lifecycle evidence file is invalid')
+        }
+        unlinkSync(this.evidencePath)
+      }
+      const descriptor = openSync(this.evidencePath, constants.O_CREAT | constants.O_EXCL | constants.O_WRONLY | noFollowFlag(), PRIVATE_FILE_MODE)
+      closeSync(descriptor)
+      try { chmodSync(this.evidencePath, PRIVATE_FILE_MODE) } catch {}
+    } catch (cause) {
+      this.evidenceUnavailable = true
+      this.reportFailure(cause)
+    }
+  }
+
+  private writeEvent(event: DesktopLifecycleEvent): void {
+    if (this.evidenceUnavailable) return
+    const line = `${JSON.stringify(event)}\n`
+    const lineBytes = Buffer.byteLength(line)
+    if (lineBytes > MAX_DESKTOP_LIFECYCLE_EVENT_BYTES) throw new Error('lifecycle event is too large')
+    const existingBytes = this.evidenceSize()
+    if (existingBytes + lineBytes <= MAX_DESKTOP_LIFECYCLE_EVIDENCE_BYTES) {
+      this.appendOwned(line)
+      return
+    }
+    const keepBytes = Math.max(0, MAX_DESKTOP_LIFECYCLE_EVIDENCE_BYTES - lineBytes)
+    const existing = this.readOwned()
+    const tail = keepBytes === 0 ? Buffer.alloc(0) : existing.subarray(Math.max(0, existing.byteLength - keepBytes))
+    const firstNewline = tail.indexOf(0x0a)
+    const retained = firstNewline === -1 ? Buffer.alloc(0) : tail.subarray(firstNewline + 1)
+    this.replaceOwned(Buffer.concat([retained, Buffer.from(line)]))
+  }
+
+  private evidenceSize(): number {
+    const stats = lstatSync(this.evidencePath)
+    if (stats.isSymbolicLink() || !stats.isFile() || stats.nlink > 1) {
+      throw new Error('lifecycle evidence file is invalid')
+    }
+    return stats.size
+  }
+
+  private readOwned(): Buffer {
+    const descriptor = openSync(this.evidencePath, constants.O_RDONLY | noFollowFlag())
+    try {
+      const stats = fstatSync(descriptor)
+      if (!stats.isFile() || stats.nlink > 1) throw new Error('lifecycle evidence file is invalid')
+      return readFileSync(descriptor)
+    } finally {
+      closeSync(descriptor)
+    }
+  }
+
+  private appendOwned(line: string): void {
+    const descriptor = openSync(this.evidencePath, constants.O_WRONLY | constants.O_APPEND | noFollowFlag())
+    try {
+      const stats = fstatSync(descriptor)
+      if (!stats.isFile() || stats.nlink > 1) throw new Error('lifecycle evidence file is invalid')
+      writeSync(descriptor, line)
+    } finally {
+      closeSync(descriptor)
+    }
+  }
+
+  private replaceOwned(content: Buffer): void {
+    const descriptor = openSync(this.evidencePath, constants.O_WRONLY | constants.O_TRUNC | noFollowFlag())
+    try {
+      const stats = fstatSync(descriptor)
+      if (!stats.isFile() || stats.nlink > 1) throw new Error('lifecycle evidence file is invalid')
+      writeFileSync(descriptor, content)
+    } finally {
+      closeSync(descriptor)
+    }
+  }
+
+  private reportFailure(cause: unknown): void {
+    const code = cause !== null
+      && typeof cause === 'object'
+      && 'code' in cause
+      && typeof cause.code === 'string'
+      ? ` (${cause.code})`
+      : ''
+    this.options.logger.error(`dsh-plugin-desktop: failed to persist lifecycle evidence${code}`)
+  }
+}
+
+function noFollowFlag(): number {
+  return process.platform === 'win32' ? 0 : constants.O_NOFOLLOW
+}
+
+function parseEventStage(
+  eventName: DesktopLifecycleEventName,
+  value: unknown,
+): DesktopStartupFailureStage | undefined {
+  const stageEvent = eventName.startsWith('startup.stage.')
+  if (!stageEvent && value === undefined) return undefined
+  if (!stageEvent) throw new Error('event stageId is invalid')
+  return parseStage(value)
+}
+
+function parseDetails(eventName: DesktopLifecycleEventName, value: unknown): DesktopLifecycleDetails {
+  if (value === null || typeof value !== 'object' || Array.isArray(value)) throw new Error('event details are invalid')
+  const details = value as Record<string, unknown>
+  for (const key of Object.keys(details)) {
+    if (!allowedDetailKeys(eventName).has(key)) throw new Error('event detail key is invalid')
+  }
+  if (eventName === 'startup.run.started') return parseStartupStartedDetails(details)
+  if (eventName === 'startup.run.completed') return parseStartupCompletedDetails(details)
+  if (eventName === 'startup.run.failed') return parseStartupFailedDetails(details)
+  if (eventName === 'renderer.boot.completed') return { rendererStatus: parseRendererStatus(details.rendererStatus) }
+  if (eventName === 'renderer.boot.failed' || eventName === 'renderer.boot.timeout') return parseRendererFailedDetails(details)
+  return {}
+}
+
+function allowedDetailKeys(eventName: DesktopLifecycleEventName): ReadonlySet<string> {
+  if (eventName === 'startup.run.started') return new Set(['appVersion', 'arch', 'platform'])
+  if (eventName === 'startup.run.completed') return new Set(['finalStage', 'rendererStatus'])
+  if (eventName === 'startup.run.failed') return new Set(['failureReason', 'finalStage'])
+  if (eventName === 'renderer.boot.completed') return new Set(['rendererStatus'])
+  if (eventName === 'renderer.boot.failed' || eventName === 'renderer.boot.timeout') {
+    return new Set(['failureReason', 'pluginCount', 'pluginIds', 'rendererStatus'])
+  }
+  return new Set()
+}
+
+function parseStartupStartedDetails(details: Record<string, unknown>): DesktopLifecycleDetails {
+  return {
+    appVersion: safeLine(details.appVersion),
+    platform: safeLine(details.platform),
+    arch: safeLine(details.arch),
+  }
+}
+
+function parseStartupCompletedDetails(details: Record<string, unknown>): DesktopLifecycleDetails {
+  return {
+    finalStage: parseStage(details.finalStage),
+    rendererStatus: parseRendererStatus(details.rendererStatus),
+  }
+}
+
+function parseStartupFailedDetails(details: Record<string, unknown>): DesktopLifecycleDetails {
+  return {
+    finalStage: parseStage(details.finalStage),
+    failureReason: parseFailureReason(details.failureReason),
+  }
+}
+
+function parseRendererFailedDetails(details: Record<string, unknown>): DesktopLifecycleDetails {
+  const parsed: Record<string, DesktopLifecycleDetailValue> = {
+    rendererStatus: parseRendererStatus(details.rendererStatus),
+    failureReason: parseFailureReason(details.failureReason),
+  }
+  if (details.pluginCount !== undefined) parsed.pluginCount = parseCount(details.pluginCount)
+  if (details.pluginIds !== undefined) parsed.pluginIds = parsePluginIds(details.pluginIds)
+  return parsed
+}
+
+function safeLine(value: unknown): string {
+  if (typeof value !== 'string'
+    || value.length === 0
+    || value.length > MAX_DETAIL_STRING_LENGTH
+    || /[\0\r\n]/u.test(value)) {
+    throw new Error('detail string is invalid')
+  }
+  return value
+}
+
+function validateId(value: string, label: string): string {
+  if (!ID_PATTERN.test(value)) throw new Error(`lifecycle ${label} is invalid`)
+  return value
+}
+
+function parseStage(value: unknown): DesktopStartupFailureStage {
+  if (typeof value !== 'string' || !STARTUP_STAGES.has(value as DesktopStartupFailureStage)) {
+    throw new Error('startup stage is invalid')
+  }
+  return value as DesktopStartupFailureStage
+}
+
+function parseRendererStatus(value: unknown): DesktopLifecycleRendererStatus {
+  if (typeof value !== 'string' || !RENDERER_STATUSES.has(value)) throw new Error('renderer status is invalid')
+  return value as DesktopLifecycleRendererStatus
+}
+
+function parseFailureReason(value: unknown): DesktopLifecycleFailureReason {
+  if (typeof value !== 'string' || !FAILURE_REASONS.has(value)) throw new Error('failure reason is invalid')
+  return value as DesktopLifecycleFailureReason
+}
+
+function parseCount(value: unknown): number {
+  if (typeof value !== 'number' || !Number.isSafeInteger(value) || value < 0 || value > 10_000) {
+    throw new Error('detail count is invalid')
+  }
+  return value
+}
+
+function parsePluginIds(value: unknown): readonly string[] {
+  if (!Array.isArray(value) || value.length > MAX_PLUGIN_IDS) throw new Error('plugin ids are invalid')
+  return value.map(item => {
+    if (typeof item !== 'string' || !PLUGIN_ID_PATTERN.test(item)) throw new Error('plugin id is invalid')
+    return item
+  })
+}
+
+function safePluginIds(plugins: readonly string[]): readonly string[] {
+  return plugins.filter(plugin => PLUGIN_ID_PATTERN.test(plugin)).slice(0, MAX_PLUGIN_IDS)
+}
+
+function validDuration(value: unknown): boolean {
+  return typeof value === 'number' && Number.isFinite(value) && value >= 0 && value <= 24 * 60 * 60 * 1000
+}

--- a/dsh-plugin-desktop/src/main.ts
+++ b/dsh-plugin-desktop/src/main.ts
@@ -33,6 +33,11 @@ import {
   type DesktopRun,
 } from './crash-evidence.ts'
 import { exportDesktopDiagnostics } from './diagnostic-export.ts'
+import { createDesktopLifecycleRecorder } from './lifecycle-events.ts'
+import type {
+  DesktopLifecycleFailureReason,
+  DesktopLifecycleRendererFailureReason,
+} from './lifecycle-events.ts'
 import { FileExporter } from './file-exporter.ts'
 import { DESKTOP_SETTINGS_NAMESPACE, type DesktopSettings } from './index.ts'
 import { LogFileSink } from './log-files.ts'
@@ -96,6 +101,20 @@ class RendererStartupFailure extends Error {
     super(report.error ?? `Renderer boot failed for ${String(report.plugins.length)} plugin(s)`)
     this.name = 'RendererStartupFailure'
   }
+}
+
+function lifecycleRendererFailureReason(
+  reason: Extract<DesktopInstallRecoveryFailureReason, 'renderer-failed' | 'renderer-timeout'> | undefined,
+): DesktopLifecycleRendererFailureReason {
+  return reason === 'renderer-timeout' ? 'renderer-timeout' : 'renderer-failed'
+}
+
+function lifecycleStartupFailureReason(
+  cause: unknown,
+  runtime: ElectronDesktopRuntime,
+): DesktopLifecycleFailureReason {
+  if (cause instanceof RendererStartupFailure) return cause.reason
+  return runtime.rendererBootFailureReason ?? 'startup-failed'
 }
 
 /** Report profile recovery without changing startup or rollback outcomes. */
@@ -221,6 +240,7 @@ async function start(): Promise<void> {
   })
   const generationId = randomUUID()
   let startupStage: DesktopStartupFailureStage = 'electron-ready'
+  const appVersion = desktopProductVersion()
   try {
     logSink = new LogFileSink(join(app.getPath('userData'), 'logs'), {
       maxFileBytes: 10 * 1024 * 1024,
@@ -228,17 +248,25 @@ async function start(): Promise<void> {
     })
     logSink.enforceDirectoryCap()
     logSink.purgeOlderThan(7)
-    logSink.writeHeader(`--- ${BIN_NAME} ${PRODUCT_NAME} ${desktopProductVersion()} ${process.platform} node ${process.version} run ${Date.now()} ---`)
+    logSink.writeHeader(`--- ${BIN_NAME} ${PRODUCT_NAME} ${appVersion} ${process.platform} node ${process.version} run ${Date.now()} ---`)
   } catch (cause) {
     const detail = cause instanceof Error ? cause.message : String(cause)
     process.stderr.write(`${BIN_NAME}: file logging unavailable: ${maskSecrets(detail)}\n`)
     logSink = undefined
   }
   const electronLogger = new ElectronStderrLogger(logSink)
+  const lifecycleRecorder = createDesktopLifecycleRecorder({
+    userDataDir: app.getPath('userData'),
+    appVersion,
+    platform: process.platform,
+    arch: process.arch,
+    logger: electronLogger,
+  })
+  lifecycleRecorder.startStartup(startupStage)
   try {
     startDesktopCrashReporting(crashReporter, {
       productName: PRODUCT_NAME,
-      version: desktopProductVersion(),
+      version: appVersion,
       platform: process.platform,
       arch: process.arch,
     })
@@ -252,7 +280,7 @@ async function start(): Promise<void> {
       {
         startedAt: new Date().toISOString(),
         pid: process.pid,
-        version: desktopProductVersion(),
+        version: appVersion,
       },
     )
     const previousRun = desktopRun.previousRun
@@ -292,6 +320,10 @@ async function start(): Promise<void> {
     nativeExit.requestRelaunch()
     await shutdown.request(0)
   }, (report) => {
+    lifecycleRecorder.finishRendererBoot(
+      report,
+      lifecycleRendererFailureReason(runtime.rendererBootFailureReason),
+    )
     if (!rendererBootSettled) {
       rendererBootSettled = true
       resolveRendererBoot(report)
@@ -340,7 +372,7 @@ async function start(): Promise<void> {
         failureStage: startupStage,
         failureDetail: maskSecrets(failureDetail),
         exportDiagnostics: async () => await exportDesktopDiagnostics(app.getPath('userData'), {
-          appVersion: desktopProductVersion(),
+          appVersion,
           crashDumpsDir: app.getPath('crashDumps'),
         }),
       })
@@ -385,6 +417,7 @@ async function start(): Promise<void> {
   try {
     await app.whenReady()
     startupStage = 'shell-environment'
+    lifecycleRecorder.transitionStartupStage(startupStage)
     if (process.platform === 'win32') app.setAppUserModelId('ai.deepseek.dsh.desktop')
     if (app.isPackaged && process.cwd() === '/') process.chdir(app.getPath('home'))
     const shellEnvironmentResolution = await resolveDesktopShellEnvironment({
@@ -418,6 +451,7 @@ async function start(): Promise<void> {
     })
 
     startupStage = 'runtime-bootstrap'
+    lifecycleRecorder.transitionStartupStage(startupStage)
     const installRecoveryStatePath = desktopInstallRecoveryStatePath(app.getPath('userData'))
     const environment = loadLayeredEnv(BIN_NAME, process.cwd())
     const electronVersion = process.versions.electron
@@ -438,6 +472,7 @@ async function start(): Promise<void> {
     const selectionStatePath = join(app.getPath('userData'), 'profile-selection', 'state.json')
     const pluginManagementStatePath = join(app.getPath('userData'), 'plugin-management', 'state.json')
     startupStage = 'profile-selection'
+    lifecycleRecorder.transitionStartupStage(startupStage)
     profileStatePath = selectionStatePath
     profileStartup = beginDesktopProfileStartup(selectionStatePath, homeDir)
     const activeProfileName = profileStartup.profileName
@@ -467,6 +502,7 @@ async function start(): Promise<void> {
       installRecovery,
     })
     startupStage = 'install-recovery'
+    lifecycleRecorder.transitionStartupStage(startupStage)
     const recoveryClaim = await installRecovery.claim()
     if (recoveryClaim.action === 'prompt') {
       electronLogger.error(
@@ -479,6 +515,7 @@ async function start(): Promise<void> {
       startupRecoveryController.dispose()
       startupRecoveryController = undefined
       if (recoveryResult === 'restart') nativeExit.requestRelaunch()
+      lifecycleRecorder.failStartup(startupStage, 'startup-failed')
       await shutdown.request(recoveryResult === 'restart' ? 0 : 1)
       return
     } else if (recoveryClaim.action === 'verify') {
@@ -505,6 +542,7 @@ async function start(): Promise<void> {
       )
     }
     startupStage = 'profile-composition'
+    lifecycleRecorder.transitionStartupStage(startupStage)
     const prepared = prepareDesktopProfile(
       process.env.DSH_TELEMETRY_DISABLED,
       homeDir,
@@ -513,6 +551,7 @@ async function start(): Promise<void> {
       pluginManagementStatePath,
     )
     startupStage = 'runtime-bootstrap'
+    lifecycleRecorder.transitionStartupStage(startupStage)
     const dshBootstrapPath = fileURLToPath(new URL('./desktop-cli.js', import.meta.url))
     const dshRuntime = process.platform === 'win32'
       ? installDesktopDshRuntime({
@@ -543,6 +582,7 @@ async function start(): Promise<void> {
       generationId,
     }
     startupStage = 'host-boot'
+    lifecycleRecorder.transitionStartupStage(startupStage)
     const releasePackageResolver = installProfilePackageResolver(prepared.bareModuleBaseUrl)
     const ctx = await boot(
       BIN_NAME,
@@ -612,11 +652,14 @@ async function start(): Promise<void> {
       homeDir: prepared.homeDir,
     })
     startupStage = 'renderer-startup'
+    lifecycleRecorder.transitionStartupStage(startupStage)
+    lifecycleRecorder.startRendererBoot()
     runtime.beginRendererBootMonitoring()
     await runtime.mountScheduled()
     const rendererReport = await rendererBoot
     if (rendererReport.status === 'healthy') {
       startupStage = 'health-commit'
+      lifecycleRecorder.transitionStartupStage(startupStage)
       if (verifyingInstall !== undefined) {
         if (installRecovery === undefined) {
           throw new Error(`${BIN_NAME}: plugin install recovery store is unavailable`)
@@ -664,6 +707,7 @@ async function start(): Promise<void> {
         rendererReport,
       )
     }
+    lifecycleRecorder.completeStartup(startupStage, rendererReport)
     notifySkippedOptionalEntries(runtime, electronLogger, prepared.skippedOptionalEntries)
     notifyWindowsVolumeConcerns(runtime, electronLogger, windowsVolumeConcerns)
     if (profileStartup.rolledBackFrom !== undefined) {
@@ -675,6 +719,8 @@ async function start(): Promise<void> {
     }
   } catch (cause) {
     runtime.stopRendererBootMonitoring()
+    lifecycleRecorder.failRendererBootIfPending(lifecycleRendererFailureReason(runtime.rendererBootFailureReason))
+    lifecycleRecorder.failStartup(startupStage, lifecycleStartupFailureReason(cause, runtime))
     electronLogger.errorCause(cause)
     let exitCode = 1
     let installRecoveryRelaunch = false

--- a/dsh-plugin-desktop/tests/diagnostic-export.spec.ts
+++ b/dsh-plugin-desktop/tests/diagnostic-export.spec.ts
@@ -18,8 +18,39 @@ import {
   exportDiagnosticsZip,
   waitForDiagnosticExportWorker,
 } from '../src/diagnostic-export.ts'
+import {
+  createDesktopLifecycleRecorder,
+  DESKTOP_LIFECYCLE_EVIDENCE_ENTRY,
+  DESKTOP_LIFECYCLE_SUMMARY_ENTRY,
+  desktopLifecycleEvidencePath,
+} from '../src/lifecycle-events.ts'
 
 const APP_VERSION = '2.0.1-test'
+
+function writeLifecycleEvidence(userDataDir: string): string {
+  let tick = 0
+  const ids = ['zip-run', 'zip-operation']
+  const recorder = createDesktopLifecycleRecorder({
+    userDataDir,
+    appVersion: APP_VERSION,
+    platform: process.platform,
+    arch: process.arch,
+    logger: { error() {}, errorCause() {} },
+    now: () => new Date('2026-08-19T00:00:00.000Z'),
+    monotonicNow: () => {
+      tick += 10
+      return tick
+    },
+    randomId: () => ids.shift() ?? 'zip-extra',
+  })
+  recorder.startStartup('electron-ready')
+  recorder.transitionStartupStage('renderer-startup')
+  recorder.startRendererBoot()
+  recorder.finishRendererBoot({ status: 'healthy' })
+  recorder.transitionStartupStage('health-commit')
+  recorder.completeStartup('health-commit', { status: 'healthy' })
+  return desktopLifecycleEvidencePath(userDataDir)
+}
 
 describe('exportDiagnosticsZip', () => {
   it('terminates a diagnostic Worker that does not respond before its deadline', async () => {
@@ -63,6 +94,104 @@ describe('exportDiagnosticsZip', () => {
     expect(zip.readAsText('crash-evidence/active-run.json')).toBe('{"version":"2.0.1"}\n')
     expect(zip.readAsText('system-info.txt')).toContain('included-active-run-marker: true')
     expect(existsSync(join(root, 'logs'))).toBe(true)
+  })
+
+  it('includes lifecycle JSONL and a correlated summary in the diagnostic archive', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'dsh-dx-lifecycle-'))
+    const logs = join(root, 'logs')
+    mkdirSync(logs)
+    writeFileSync(join(logs, 'dsh-2026-08-16.log'), 'after startup\n')
+    const lifecycleEvidencePath = writeLifecycleEvidence(root)
+
+    const out = await exportDiagnosticsZip(logs, root, {
+      appVersion: APP_VERSION,
+      lifecycleEvidencePath,
+    })
+
+    const zip = new AdmZip(out)
+    const names = zip.getEntries().map(entry => entry.entryName)
+    expect(names).toContain(DESKTOP_LIFECYCLE_EVIDENCE_ENTRY)
+    expect(names).toContain(DESKTOP_LIFECYCLE_SUMMARY_ENTRY)
+    expect(zip.readAsText(DESKTOP_LIFECYCLE_EVIDENCE_ENTRY)).toContain('"runId":"zip-run"')
+    expect(JSON.parse(zip.readAsText(DESKTOP_LIFECYCLE_SUMMARY_ENTRY))).toEqual(expect.objectContaining({
+      runId: 'zip-run',
+      operationId: 'zip-operation',
+      finalOutcome: 'completed',
+      rendererStatus: 'healthy',
+    }))
+    expect(zip.readAsText('system-info.txt')).toContain('included-lifecycle-evidence: true')
+    expect(zip.readAsText('system-info.txt')).toContain('included-lifecycle-summary: true')
+  })
+
+  it('shares one byte cap across lifecycle evidence, lifecycle summary, and logs', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'dsh-dx-lifecycle-limit-'))
+    const logs = join(root, 'logs')
+    const lifecycleDir = join(root, 'lifecycle-events')
+    mkdirSync(logs)
+    mkdirSync(lifecycleDir)
+    writeFileSync(join(logs, 'dsh-2026-08-16.log'), 'seven77')
+    writeFileSync(join(lifecycleDir, 'startup.jsonl'), 'bad\n')
+
+    const out = await exportDiagnosticsZip(logs, root, {
+      appVersion: APP_VERSION,
+      lifecycleEvidencePath: join(lifecycleDir, 'startup.jsonl'),
+      maxEvidenceBytes: 10,
+    })
+
+    const zip = new AdmZip(out)
+    const names = zip.getEntries().map(entry => entry.entryName)
+    expect(names).toContain(DESKTOP_LIFECYCLE_EVIDENCE_ENTRY)
+    expect(names).not.toContain(DESKTOP_LIFECYCLE_SUMMARY_ENTRY)
+    expect(names).not.toContain('dsh-2026-08-16.log')
+    expect(zip.readAsText('system-info.txt')).toContain('included-lifecycle-evidence: true')
+    expect(zip.readAsText('system-info.txt')).toContain('omitted-lifecycle-summary: true')
+    expect(zip.readAsText('system-info.txt')).toContain('omitted-log-files: 1')
+  })
+
+  it('skips a linked lifecycle evidence file without failing the diagnostic export', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'dsh-dx-lifecycle-file-link-'))
+    const logs = join(root, 'logs')
+    const target = join(root, 'target.jsonl')
+    const lifecycleDir = join(root, 'lifecycle-events')
+    mkdirSync(logs)
+    mkdirSync(lifecycleDir)
+    writeFileSync(join(logs, 'dsh-2026-08-16.log'), 'owned\n')
+    writeFileSync(target, 'bad\n')
+    symlinkSync(target, join(lifecycleDir, 'startup.jsonl'), 'file')
+
+    const out = await exportDiagnosticsZip(logs, root, {
+      appVersion: APP_VERSION,
+      lifecycleEvidencePath: join(lifecycleDir, 'startup.jsonl'),
+    })
+
+    const zip = new AdmZip(out)
+    const names = zip.getEntries().map(entry => entry.entryName)
+    expect(names).not.toContain(DESKTOP_LIFECYCLE_EVIDENCE_ENTRY)
+    expect(names).not.toContain(DESKTOP_LIFECYCLE_SUMMARY_ENTRY)
+    expect(zip.readAsText('system-info.txt')).toContain('included-lifecycle-evidence: false')
+  })
+
+  it('skips lifecycle evidence reached through a linked parent directory', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'dsh-dx-lifecycle-parent-link-'))
+    const logs = join(root, 'logs')
+    const target = join(root, 'target')
+    const lifecycleDir = join(root, 'lifecycle-events')
+    mkdirSync(logs)
+    mkdirSync(target)
+    writeFileSync(join(logs, 'dsh-2026-08-16.log'), 'owned\n')
+    writeFileSync(join(target, 'startup.jsonl'), 'bad\n')
+    symlinkSync(target, lifecycleDir, process.platform === 'win32' ? 'junction' : 'dir')
+
+    const out = await exportDiagnosticsZip(logs, root, {
+      appVersion: APP_VERSION,
+      lifecycleEvidencePath: join(lifecycleDir, 'startup.jsonl'),
+    })
+
+    const zip = new AdmZip(out)
+    const names = zip.getEntries().map(entry => entry.entryName)
+    expect(names).not.toContain(DESKTOP_LIFECYCLE_EVIDENCE_ENTRY)
+    expect(names).not.toContain(DESKTOP_LIFECYCLE_SUMMARY_ENTRY)
+    expect(zip.readAsText('system-info.txt')).toContain('included-lifecycle-evidence: false')
   })
 
   it('includes local Crashpad minidumps but excludes unrelated crash files', async () => {

--- a/dsh-plugin-desktop/tests/diagnostic-export.spec.ts
+++ b/dsh-plugin-desktop/tests/diagnostic-export.spec.ts
@@ -194,6 +194,27 @@ describe('exportDiagnosticsZip', () => {
     expect(zip.readAsText('system-info.txt')).toContain('included-lifecycle-evidence: false')
   })
 
+  it('allows evidence when user data is reached through a linked ancestor', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'dsh-dx-user-data-link-'))
+    const target = join(root, 'target')
+    const linkedAncestor = join(root, 'linked')
+    const userData = join(linkedAncestor, 'user-data')
+    const logs = join(userData, 'logs')
+    mkdirSync(join(target, 'user-data', 'logs'), { recursive: true })
+    symlinkSync(target, linkedAncestor, process.platform === 'win32' ? 'junction' : 'dir')
+    writeFileSync(join(logs, 'dsh-2026-08-16.log'), 'owned\n')
+    const lifecycleEvidencePath = writeLifecycleEvidence(userData)
+
+    const out = await exportDiagnosticsZip(logs, userData, {
+      appVersion: APP_VERSION,
+      lifecycleEvidencePath,
+    })
+
+    const zip = new AdmZip(out)
+    expect(zip.readAsText(DESKTOP_LIFECYCLE_EVIDENCE_ENTRY)).toContain('"runId":"zip-run"')
+    expect(zip.readAsText('system-info.txt')).toContain('included-lifecycle-evidence: true')
+  })
+
   it('includes local Crashpad minidumps but excludes unrelated crash files', async () => {
     const root = mkdtempSync(join(tmpdir(), 'dsh-dx-dump-'))
     const logs = join(root, 'logs')

--- a/dsh-plugin-desktop/tests/lifecycle-events.spec.ts
+++ b/dsh-plugin-desktop/tests/lifecycle-events.spec.ts
@@ -1,0 +1,381 @@
+import {
+  existsSync,
+  linkSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  symlinkSync,
+  unlinkSync,
+  writeFileSync,
+} from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { describe, expect, it, vi } from 'vitest'
+import type { DesktopLogger } from '../src/desktop-logger.ts'
+import type { DesktopStartupFailureStage } from '../src/startup-recovery-window.ts'
+import {
+  createDesktopLifecycleRecorder,
+  DESKTOP_LIFECYCLE_SCHEMA_VERSION,
+  desktopLifecycleEvidencePath,
+  MAX_DESKTOP_LIFECYCLE_EVENT_BYTES,
+  MAX_DESKTOP_LIFECYCLE_EVIDENCE_BYTES,
+  parseDesktopLifecycleEvent,
+  summarizeDesktopLifecycleEvidence,
+  type DesktopLifecycleEvent,
+  type DesktopLifecycleSummary,
+} from '../src/lifecycle-events.ts'
+
+interface CapturedLogger extends DesktopLogger {
+  readonly error: ReturnType<typeof vi.fn<(message: string) => void>>
+  readonly errorCause: ReturnType<typeof vi.fn<(cause: unknown) => void>>
+}
+
+const FIXED_NOW = new Date('2026-08-19T00:00:00.000Z')
+const VALID_STAGE: DesktopStartupFailureStage = 'electron-ready'
+
+function createLogger(): CapturedLogger {
+  return {
+    error: vi.fn<(message: string) => void>(),
+    errorCause: vi.fn<(cause: unknown) => void>(),
+  }
+}
+
+function tempUserData(prefix: string): string {
+  return mkdtempSync(join(tmpdir(), prefix))
+}
+
+function readEvents(userDataDir: string): DesktopLifecycleEvent[] {
+  const content = readFileSync(desktopLifecycleEvidencePath(userDataDir), 'utf8')
+  return content
+    .split('\n')
+    .filter(line => line.length > 0)
+    .map(line => parseDesktopLifecycleEvent(JSON.parse(line) as unknown))
+}
+
+function baseEvent(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    schemaVersion: DESKTOP_LIFECYCLE_SCHEMA_VERSION,
+    timestamp: FIXED_NOW.toISOString(),
+    monotonicMs: 1,
+    runId: 'run-1',
+    operationId: 'op-1',
+    eventName: 'startup.stage.started',
+    stageId: VALID_STAGE,
+    details: {},
+    ...overrides,
+  }
+}
+
+function eventLine(overrides: Record<string, unknown> = {}): string {
+  return JSON.stringify(baseEvent(overrides))
+}
+
+describe('desktop lifecycle events', () => {
+  it.each([
+    ['schema version', { schemaVersion: 2 }],
+    ['event name', { eventName: 'startup.stage.skipped' }],
+    ['stage id', { stageId: 'network-init' }],
+    ['detail key', { details: { unexpected: 'value' } }],
+    ['duration', { durationMs: -1 }],
+    ['run id', { runId: '../run' }],
+    ['operation id', { operationId: 'operation id' }],
+  ])('rejects an invalid %s', (_label, overrides) => {
+    expect(() => { parseDesktopLifecycleEvent(baseEvent(overrides)) }).toThrow()
+  })
+
+  it('uses injected clocks and ids for one correlated startup run', () => {
+    const userDataDir = tempUserData('dsh-lifecycle-correlated-')
+    const logger = createLogger()
+    const ids = ['run-fixed', 'operation-fixed']
+    const ticks = [100, 101, 110, 111, 120, 121, 130, 131, 200, 201, 250, 251, 300, 301, 400, 401]
+    const recorder = createDesktopLifecycleRecorder({
+      userDataDir,
+      appVersion: '2.0.1-test',
+      platform: 'win32',
+      arch: 'x64',
+      logger,
+      now: () => FIXED_NOW,
+      monotonicNow: () => ticks.shift() ?? 401,
+      randomId: () => ids.shift() ?? 'unexpected-id',
+    })
+
+    recorder.startStartup('electron-ready')
+    recorder.transitionStartupStage('shell-environment')
+    recorder.startRendererBoot()
+    recorder.finishRendererBoot({ status: 'healthy' })
+    recorder.completeStartup('shell-environment', { status: 'healthy' })
+
+    const events = readEvents(userDataDir)
+    expect(events.map(event => event.runId)).toEqual(Array.from({ length: events.length }, () => 'run-fixed'))
+    expect(events.map(event => event.operationId)).toEqual(Array.from({ length: events.length }, () => 'operation-fixed'))
+    expect(events.map(event => event.eventName)).toEqual([
+      'startup.run.started',
+      'startup.stage.started',
+      'startup.stage.completed',
+      'startup.stage.started',
+      'renderer.boot.started',
+      'renderer.boot.completed',
+      'startup.stage.completed',
+      'startup.run.completed',
+    ])
+    expect(events[2]).toMatchObject({ stageId: 'electron-ready', durationMs: 10 })
+    expect(events[5]).toMatchObject({
+      eventName: 'renderer.boot.completed',
+      durationMs: 50,
+      details: { rendererStatus: 'healthy' },
+    })
+    expect(events[6]).toMatchObject({ stageId: 'shell-environment', durationMs: 170 })
+    expect(events[7]).toMatchObject({
+      eventName: 'startup.run.completed',
+      durationMs: 300,
+      details: { finalStage: 'shell-environment', rendererStatus: 'healthy' },
+    })
+    expect(logger.error).not.toHaveBeenCalled()
+  })
+
+  it('records renderer start separately from terminal healthy, failed, and timeout outcomes', () => {
+    const healthyDir = tempUserData('dsh-lifecycle-healthy-')
+    const healthy = createDesktopLifecycleRecorder({
+      userDataDir: healthyDir,
+      appVersion: '2.0.1-test',
+      platform: 'darwin',
+      arch: 'arm64',
+      logger: createLogger(),
+      now: () => FIXED_NOW,
+      monotonicNow: (() => {
+        let tick = 0
+        return () => {
+          tick += 10
+          return tick
+        }
+      })(),
+      randomId: (() => {
+        const ids = ['healthy-run', 'healthy-op']
+        return () => ids.shift() ?? 'healthy-extra'
+      })(),
+    })
+    healthy.startStartup('renderer-startup')
+    healthy.startRendererBoot()
+    expect(readEvents(healthyDir).map(event => event.eventName)).toContain('renderer.boot.started')
+    expect(readEvents(healthyDir).map(event => event.eventName)).not.toContain('renderer.boot.completed')
+    expect(readEvents(healthyDir).map(event => event.eventName)).not.toContain('startup.run.completed')
+    healthy.finishRendererBoot({ status: 'healthy' })
+    healthy.completeStartup('health-commit', { status: 'healthy' })
+    expect(readEvents(healthyDir).find(event => event.eventName === 'renderer.boot.completed')).toMatchObject({
+      eventName: 'renderer.boot.completed',
+      details: { rendererStatus: 'healthy' },
+    })
+    expect(readEvents(healthyDir).at(-1)).toMatchObject({
+      eventName: 'startup.run.completed',
+      details: { finalStage: 'health-commit', rendererStatus: 'healthy' },
+    })
+
+    const failedDir = tempUserData('dsh-lifecycle-failed-')
+    const failed = createDesktopLifecycleRecorder({
+      userDataDir: failedDir,
+      appVersion: '2.0.1-test',
+      platform: 'win32',
+      arch: 'x64',
+      logger: createLogger(),
+      now: () => FIXED_NOW,
+      randomId: (() => {
+        const ids = ['failed-run', 'failed-op']
+        return () => ids.shift() ?? 'failed-extra'
+      })(),
+    })
+    failed.startStartup('renderer-startup')
+    failed.startRendererBoot()
+    failed.finishRendererBoot({
+      status: 'failed',
+      plugins: ['dsh-vision-router', '@scope/plugin-ok', '../escape', 'UpperBad', 'space bad'],
+      error: 'ignored by lifecycle evidence',
+    })
+    failed.failStartup('renderer-startup', 'renderer-failed')
+    expect(readEvents(failedDir).find(event => event.eventName === 'renderer.boot.failed')).toMatchObject({
+      details: {
+        rendererStatus: 'failed',
+        failureReason: 'renderer-failed',
+        pluginCount: 5,
+        pluginIds: ['dsh-vision-router', '@scope/plugin-ok'],
+      },
+    })
+    expect(readEvents(failedDir).at(-1)).toMatchObject({
+      eventName: 'startup.run.failed',
+      details: { finalStage: 'renderer-startup', failureReason: 'renderer-failed' },
+    })
+
+    const timeoutDir = tempUserData('dsh-lifecycle-timeout-')
+    const timeout = createDesktopLifecycleRecorder({
+      userDataDir: timeoutDir,
+      appVersion: '2.0.1-test',
+      platform: 'linux',
+      arch: 'x64',
+      logger: createLogger(),
+      now: () => FIXED_NOW,
+      randomId: (() => {
+        const ids = ['timeout-run', 'timeout-op']
+        return () => ids.shift() ?? 'timeout-extra'
+      })(),
+    })
+    timeout.startStartup('renderer-startup')
+    timeout.startRendererBoot()
+    timeout.finishRendererBoot({ status: 'failed', plugins: [] }, 'renderer-timeout')
+    timeout.failStartup('renderer-startup', 'renderer-timeout')
+    expect(readEvents(timeoutDir).find(event => event.eventName === 'renderer.boot.timeout')).toMatchObject({
+      details: { rendererStatus: 'timeout', failureReason: 'renderer-timeout', pluginCount: 0, pluginIds: [] },
+    })
+    expect(readEvents(timeoutDir).at(-1)).toMatchObject({
+      eventName: 'startup.run.failed',
+      details: { finalStage: 'renderer-startup', failureReason: 'renderer-timeout' },
+    })
+  })
+
+  it('replaces stale run evidence and keeps current evidence within byte caps', () => {
+    const userDataDir = tempUserData('dsh-lifecycle-cap-')
+    const evidencePath = desktopLifecycleEvidencePath(userDataDir)
+    mkdirSync(join(userDataDir, 'lifecycle-events'))
+    writeFileSync(evidencePath, 'stale run evidence\n')
+    const recorder = createDesktopLifecycleRecorder({
+      userDataDir,
+      appVersion: '2.0.1-test',
+      platform: 'win32',
+      arch: 'x64',
+      logger: createLogger(),
+      now: () => FIXED_NOW,
+      randomId: (() => {
+        const ids = ['cap-run', 'cap-op']
+        return () => ids.shift() ?? 'cap-extra'
+      })(),
+    })
+
+    recorder.startStartup('electron-ready')
+    expect(readFileSync(evidencePath, 'utf8')).not.toContain('stale run evidence')
+
+    const stages: DesktopStartupFailureStage[] = [
+      'shell-environment',
+      'runtime-bootstrap',
+      'profile-selection',
+      'install-recovery',
+      'profile-composition',
+      'host-boot',
+      'renderer-startup',
+      'health-commit',
+    ]
+    for (let index = 0; index < 900; index += 1) {
+      recorder.transitionStartupStage(stages[index % stages.length] as DesktopStartupFailureStage)
+    }
+
+    const evidence = readFileSync(evidencePath, 'utf8')
+    expect(Buffer.byteLength(evidence)).toBeLessThanOrEqual(MAX_DESKTOP_LIFECYCLE_EVIDENCE_BYTES)
+    for (const line of evidence.split('\n').filter(item => item.length > 0)) {
+      expect(Buffer.byteLength(line) + 1).toBeLessThanOrEqual(MAX_DESKTOP_LIFECYCLE_EVENT_BYTES)
+      expect(() => { parseDesktopLifecycleEvent(JSON.parse(line) as unknown) }).not.toThrow()
+    }
+  })
+
+  it('treats linked or unsafe evidence targets as best-effort logger-only failures', () => {
+    const linkedParentDir = tempUserData('dsh-lifecycle-parent-link-')
+    const linkedParentTarget = join(linkedParentDir, 'target')
+    mkdirSync(linkedParentTarget)
+    symlinkSync(linkedParentTarget, join(linkedParentDir, 'lifecycle-events'), process.platform === 'win32' ? 'junction' : 'dir')
+    const linkedParentLogger = createLogger()
+    const linkedParent = createDesktopLifecycleRecorder({
+      userDataDir: linkedParentDir,
+      appVersion: '2.0.1-test',
+      platform: 'win32',
+      arch: 'x64',
+      logger: linkedParentLogger,
+      now: () => FIXED_NOW,
+    })
+    expect(() => { linkedParent.startStartup('electron-ready') }).not.toThrow()
+    expect(linkedParentLogger.error).toHaveBeenCalledWith(expect.stringContaining('failed to persist lifecycle evidence'))
+
+    const linkedFileDir = tempUserData('dsh-lifecycle-file-link-')
+    const linkedFileTarget = join(linkedFileDir, 'target.jsonl')
+    mkdirSync(join(linkedFileDir, 'lifecycle-events'))
+    writeFileSync(linkedFileTarget, '')
+    symlinkSync(linkedFileTarget, desktopLifecycleEvidencePath(linkedFileDir), 'file')
+    const linkedFileLogger = createLogger()
+    const linkedFile = createDesktopLifecycleRecorder({
+      userDataDir: linkedFileDir,
+      appVersion: '2.0.1-test',
+      platform: 'win32',
+      arch: 'x64',
+      logger: linkedFileLogger,
+      now: () => FIXED_NOW,
+    })
+    expect(() => { linkedFile.startStartup('electron-ready') }).not.toThrow()
+    expect(linkedFileLogger.error).toHaveBeenCalledWith(expect.stringContaining('failed to persist lifecycle evidence'))
+
+    const hardlinkDir = tempUserData('dsh-lifecycle-hardlink-')
+    const hardlinkTarget = join(hardlinkDir, 'target.jsonl')
+    mkdirSync(join(hardlinkDir, 'lifecycle-events'))
+    writeFileSync(hardlinkTarget, '')
+    linkSync(hardlinkTarget, desktopLifecycleEvidencePath(hardlinkDir))
+    const hardlinkLogger = createLogger()
+    const hardlink = createDesktopLifecycleRecorder({
+      userDataDir: hardlinkDir,
+      appVersion: '2.0.1-test',
+      platform: 'win32',
+      arch: 'x64',
+      logger: hardlinkLogger,
+      now: () => FIXED_NOW,
+    })
+    expect(() => { hardlink.startStartup('electron-ready') }).not.toThrow()
+    expect(hardlinkLogger.error).toHaveBeenCalledWith(expect.stringContaining('failed to persist lifecycle evidence'))
+
+    const unsafeWriteDir = tempUserData('dsh-lifecycle-unsafe-write-')
+    const unsafeWriteLogger = createLogger()
+    const unsafeWrite = createDesktopLifecycleRecorder({
+      userDataDir: unsafeWriteDir,
+      appVersion: '2.0.1-test',
+      platform: 'win32',
+      arch: 'x64',
+      logger: unsafeWriteLogger,
+      now: () => FIXED_NOW,
+    })
+    const unsafeWritePath = desktopLifecycleEvidencePath(unsafeWriteDir)
+    expect(existsSync(unsafeWritePath)).toBe(true)
+    unlinkSync(unsafeWritePath)
+    mkdirSync(unsafeWritePath)
+    expect(() => { unsafeWrite.startStartup('electron-ready') }).not.toThrow()
+    expect(unsafeWriteLogger.error).toHaveBeenCalledWith(expect.stringContaining('failed to persist lifecycle evidence'))
+    expect(unsafeWriteLogger.errorCause).not.toHaveBeenCalled()
+  })
+
+  it('summarizes only one correlated run while counting malformed and mismatched lines', () => {
+    const summaryBuffer = summarizeDesktopLifecycleEvidence(Buffer.from([
+      eventLine(),
+      'not-json',
+      eventLine({ operationId: 'other-op' }),
+      eventLine({ eventName: 'startup.stage.completed', durationMs: 42 }),
+      eventLine({
+        eventName: 'renderer.boot.completed',
+        stageId: undefined,
+        details: { rendererStatus: 'healthy' },
+      }),
+      eventLine({
+        eventName: 'startup.run.completed',
+        stageId: undefined,
+        durationMs: 100,
+        details: { finalStage: 'health-commit', rendererStatus: 'healthy' },
+      }),
+      '',
+    ].join('\n'), 'utf8'))
+
+    expect(summaryBuffer).not.toBeUndefined()
+    const summary = JSON.parse(summaryBuffer?.toString('utf8') ?? '') as DesktopLifecycleSummary
+    expect(summary).toMatchObject({
+      schemaVersion: DESKTOP_LIFECYCLE_SCHEMA_VERSION,
+      eventCount: 4,
+      parseErrorCount: 2,
+      runId: 'run-1',
+      operationId: 'op-1',
+      finalOutcome: 'completed',
+      finalStage: 'health-commit',
+      rendererStatus: 'healthy',
+      totalDurationMs: 100,
+      stages: [{ stageId: 'electron-ready', status: 'completed', durationMs: 42 }],
+    })
+  })
+})

--- a/dsh-plugin-desktop/tests/package.spec.ts
+++ b/dsh-plugin-desktop/tests/package.spec.ts
@@ -284,6 +284,47 @@ describe('published package surface', () => {
     expect(clearVerified).toBeGreaterThan(profileHealthy)
   })
 
+  it('wires lifecycle evidence through key startup stages and terminal outcomes', () => {
+    const main = readFileSync(new URL('src/main.ts', packageRoot), 'utf8')
+    const createRecorder = main.indexOf('const lifecycleRecorder = createDesktopLifecycleRecorder({')
+    const startRun = main.indexOf('lifecycleRecorder.startStartup(startupStage)')
+    const finishRenderer = main.indexOf('lifecycleRecorder.finishRendererBoot(')
+    const rendererStage = main.indexOf("startupStage = 'renderer-startup'")
+    const startRenderer = main.indexOf('lifecycleRecorder.startRendererBoot()')
+    const awaitRenderer = main.indexOf('const rendererReport = await rendererBoot')
+    const healthStage = main.indexOf("startupStage = 'health-commit'")
+    const completeStartup = main.indexOf('lifecycleRecorder.completeStartup(startupStage, rendererReport)')
+    const catchFailure = main.indexOf('} catch (cause) {')
+    const failPendingRenderer = main.indexOf('lifecycleRecorder.failRendererBootIfPending(')
+    const catchFailStartup = main.indexOf('lifecycleRecorder.failStartup(', failPendingRenderer)
+
+    expect(main).toContain("import { createDesktopLifecycleRecorder } from './lifecycle-events.ts'")
+    expect(createRecorder).toBeGreaterThanOrEqual(0)
+    expect(startRun).toBeGreaterThan(createRecorder)
+    for (const stage of [
+      'shell-environment',
+      'runtime-bootstrap',
+      'profile-selection',
+      'install-recovery',
+      'profile-composition',
+      'host-boot',
+      'renderer-startup',
+      'health-commit',
+    ]) {
+      expect(main).toContain(`startupStage = '${stage}'`)
+    }
+    expect(main).toContain('lifecycleRecorder.transitionStartupStage(startupStage)')
+    expect(finishRenderer).toBeGreaterThan(createRecorder)
+    expect(startRenderer).toBeGreaterThan(rendererStage)
+    expect(startRenderer).toBeLessThan(awaitRenderer)
+    expect(healthStage).toBeGreaterThan(awaitRenderer)
+    expect(completeStartup).toBeGreaterThan(healthStage)
+    expect(failPendingRenderer).toBeGreaterThan(catchFailure)
+    expect(catchFailStartup).toBeGreaterThan(failPendingRenderer)
+    expect(main).toContain('lifecycleRendererFailureReason(runtime.rendererBootFailureReason)')
+    expect(main).toContain('lifecycleStartupFailureReason(cause, runtime)')
+  })
+
   it('routes protected and ordinary startup failures through the native recovery window', () => {
     const main = readFileSync(new URL('src/main.ts', packageRoot), 'utf8')
     const windows = [...main.matchAll(/await openStartupRecoveryWindow\(/gu)]


### PR DESCRIPTION
## Scope

Implements WP-OBS-01: record local structured desktop startup lifecycle evidence and include it in diagnostic exports.

## Behavior

- Emits correlated lifecycle JSONL events across startup, renderer startup, and final health/failure.
- Keeps lifecycle evidence local-only with bounded storage, monotonic timing, redaction, and safe-path handling.
- Adds lifecycle JSONL and summary files to diagnostic export.
- Degrades diagnostic export safely when lifecycle storage is unavailable.
- Rejects linked evidence paths inside user data without misclassifying platform path aliases above the owned boundary.

## Verification

- `corepack yarn workspace dsh-plugin-desktop typecheck`
- Lifecycle and diagnostic tests: 28/28 passed
- Lifecycle integration contract test: 1/1 passed
- `corepack yarn check:layout`
- `git diff --check`
- The immutable Linux CI `yarn check` passed on the first PR run.

Local note: a pre-existing installed `@deepseek-ai/dsh-app-boot` artifact lacks the package test''s patch marker. The immutable CI install did not reproduce that local marker failure.

The local `.agents/notes/proposed/` construction documents are intentionally untracked and are not included.