### PR TITLE
fix(market): surface package manager install errors

### DIFF
--- a/dsh-community-market/src/client/MarketSettingsTab.tsx
+++ b/dsh-community-market/src/client/MarketSettingsTab.tsx
@@ -137,6 +137,12 @@ function catalogFailureMessage(
   return `${t('catalogFailureSource')}: ${source.name}. ${reason}`
 }
 
+function marketApiErrorMessage(cause: unknown): string | undefined {
+  return cause instanceof Error && cause.name === 'MarketApiError' && cause.message.trim().length > 0
+    ? cause.message.trim()
+    : undefined
+}
+
 function PluginIcon({ item, large = false }: { item: MarketItem; large?: boolean }) {
   const icon = item.media?.icon
   return (
@@ -894,7 +900,8 @@ export function MarketSurface({ initialView = 'installable', readLocale, t, show
         setInstallationsError(t('desktopUnavailable'))
         setOperationError(t('desktopUnavailable'))
       } else {
-        setOperationError(t('executeError'))
+        const detail = marketApiErrorMessage(cause)
+        setOperationError(detail === undefined ? t('executeError') : `${t('executeError')} ${detail}`)
       }
     } finally {
       if (operationRequest.current === request) {

--- a/dsh-community-market/src/install/service.ts
+++ b/dsh-community-market/src/install/service.ts
@@ -901,6 +901,12 @@ export class MarketInstallService {
       } catch (cause) {
         if (!await this.installMayHaveMutatedProfile(profile, candidate.packageName)) throw cause
         await this.rollbackInstall(profile, candidate.packageName, receipt.receiptId)
+        if (cause instanceof MarketInstallError && cause.code === 'operation-failed') {
+          throw new MarketInstallError(
+            'operation-failed',
+            `${cause.message} The partial installation was rolled back.`,
+          )
+        }
         throw new MarketInstallError(
           'operation-failed',
           'The package manager failed after changing the active profile, so the partial installation was rolled back.',

--- a/dsh-community-market/src/install/service.ts
+++ b/dsh-community-market/src/install/service.ts
@@ -23,6 +23,8 @@ const CANDIDATE_TTL_MS = 30 * 60 * 1000
 const MAX_INTENTS = 256
 const MAX_CANDIDATES = 10_000
 const MAX_RECEIPTS = 512
+const MAX_PACKAGE_MANAGER_ERROR_CHARS = 512
+const MAX_PACKAGE_MANAGER_STDERR_CHARS = MAX_PACKAGE_MANAGER_ERROR_CHARS * 8
 const LIFECYCLE_SCRIPTS = ['preinstall', 'install', 'postinstall', 'prepare'] as const
 const BLOCKED_PRODUCT_PACKAGES = new Set(['dsh-plugin-desktop', 'dsh-community-market'])
 const DSH_RUNTIME_VERSION = '0.1.0-rc.7'
@@ -200,6 +202,42 @@ function opaqueToken(): string {
 
 function own(object: object, key: PropertyKey): boolean {
   return Object.prototype.hasOwnProperty.call(object, key)
+}
+
+function capturePackageManagerError(stream: Readable): () => string | undefined {
+  let tail = ''
+  stream.setEncoding('utf8')
+  stream.on('data', (chunk: string) => {
+    tail = `${tail}${chunk}`.slice(-MAX_PACKAGE_MANAGER_STDERR_CHARS)
+  })
+  return () => {
+    const lines = tail
+      .split(/\r?\n/u)
+      .map(line => [...line]
+        .filter(character => {
+          const codePoint = character.codePointAt(0)
+          return codePoint !== undefined && codePoint >= 0x20 && codePoint !== 0x7f
+        })
+        .join('')
+        .trim())
+    const detail = lines.findLast(line => /\bERR_PNPM_[A-Z0-9_]+\b/u.test(line))
+    const errorStart = detail?.search(/\bERR_PNPM_[A-Z0-9_]+\b/u) ?? -1
+    if (detail === undefined || errorStart < 0) return undefined
+    return detail
+      .slice(errorStart)
+      .replace(/\[[0-9;]*m/gu, '')
+      .replace(/(https?:\/\/)(?:[^@\s/]+@)?([^?\s#]+)(?:\?[^\s#]*)?(?:#[^\s]*)?/giu, '$1$2')
+      .replace(/\b(?:npm|ghp|github_pat)_[A-Za-z0-9_]{10,}\b/gu, '[redacted token]')
+      .replace(/\b(Bearer|Basic)\s+\S+/giu, '$1 [redacted]')
+      .slice(0, MAX_PACKAGE_MANAGER_ERROR_CHARS)
+  }
+}
+
+function packageManagerFailure(message: string, detail: string | undefined): MarketInstallError {
+  return new MarketInstallError(
+    'operation-failed',
+    detail === undefined ? message : `${message} pnpm reported: ${detail}`,
+  )
 }
 
 function sha512Integrity(value: unknown): value is string {
@@ -1171,6 +1209,7 @@ export class MarketInstallService {
     }
     catch { throw new MarketInstallError('operation-failed', 'The desktop package manager could not start.') }
     handle.stdout.resume()
+    const readPackageManagerError = capturePackageManagerError(handle.stderr)
     handle.stderr.resume()
     const cancel = () => handle.cancel()
     combinedSignal.addEventListener('abort', cancel, { once: true })
@@ -1178,12 +1217,15 @@ export class MarketInstallService {
     try { outcome = await handle.done }
     catch {
       combinedSignal.throwIfAborted()
-      throw new MarketInstallError('operation-failed', 'The desktop package manager failed.')
+      throw packageManagerFailure('The desktop package manager failed.', readPackageManagerError())
     }
     finally { combinedSignal.removeEventListener('abort', cancel) }
     combinedSignal.throwIfAborted()
     if (outcome.exitCode !== 0 || outcome.signal !== null) {
-      throw new MarketInstallError('operation-failed', 'The desktop package manager did not complete successfully.')
+      throw packageManagerFailure(
+        'The desktop package manager did not complete successfully.',
+        readPackageManagerError(),
+      )
     }
   }
 

--- a/dsh-community-market/tests/market-install.spec.ts
+++ b/dsh-community-market/tests/market-install.spec.ts
@@ -688,7 +688,14 @@ describe('market install service', () => {
           await removeInstalledPlugin(profileDir)
           return { exitCode: 0, signal: null }
         })()
-        return { stdout: Readable.from([]), stderr: Readable.from([]), done, cancel: vi.fn() }
+        return {
+          stdout: Readable.from([]),
+          stderr: Readable.from(args[0] === 'add'
+            ? ['ERR_PNPM_FETCH_401 GET https://registry.example.invalid/package?token=not-a-real-token\n']
+            : []),
+          done,
+          cancel: vi.fn(),
+        }
       },
     })
     const service = new MarketInstallService(
@@ -699,10 +706,13 @@ describe('market install service', () => {
     )
     service.observeCatalog(snapshot())
     const preview = await service.previewInstall('source-1', 'example/dsh-plugin-safe', new AbortController().signal)
-    await expect(service.executeInstall(preview.intent, new AbortController().signal)).rejects.toMatchObject({
+    const execution = service.executeInstall(preview.intent, new AbortController().signal)
+    await expect(execution).rejects.toMatchObject({
       code: 'operation-failed',
-      message: expect.stringContaining('partial installation was rolled back'),
+      message: expect.stringContaining('ERR_PNPM_FETCH_401 GET https://registry.example.invalid/package'),
     })
+    await expect(execution).rejects.toThrow('partial installation was rolled back')
+    await expect(execution).rejects.not.toThrow('not-a-real-token')
     expect(calls).toEqual(['add', 'remove'])
     expect(settings.receipts()).toEqual([])
     expect(JSON.parse(await readFile(join(profileDir, 'package.json'), 'utf8')).dependencies).toEqual({})


### PR DESCRIPTION
## Summary / 摘要

- retain a bounded stderr tail for protected plugin package-manager operations instead of discarding it
- surface only the last `ERR_PNPM_*` diagnostic, with terminal controls, URL credentials/query data, and common token formats removed
- preserve the generic fallback when pnpm emits no recognized diagnostic
- append the Host-approved API error to the existing refresh-before-retry warning in the Market UI

The install and rollback state machine is unchanged. This addresses the error-reporting part of #334; it intentionally does not claim to fix the still-unknown package-manager failure behind that report.

## Related Issues / 关联 Issue

Addresses #334

## Type / 类型

- [x] Bug fix / 问题修复
- [ ] Feature / 新功能
- [ ] Documentation / 文档
- [ ] Release or packaging / 发布或打包
- [ ] Tests only / 仅测试
- [ ] Other / 其他

## Platforms / 影响平台

- [ ] Windows installer / Windows 安装包
- [ ] Windows portable ZIP / Windows 便携版 ZIP
- [ ] macOS Apple Silicon
- [ ] macOS Intel
- [ ] macOS Universal package / macOS 通用安装包
- [ ] Linux
- [x] Not platform-specific / 与平台无关

## Verification / 验证

- [ ] `corepack yarn check:layout`
- [ ] `corepack yarn typecheck`
- [ ] `corepack yarn test`
- [ ] `corepack yarn check`
- [ ] Platform package smoke / 平台打包或启动冒烟
- [ ] Manual test / 人工测试

Focused headless smoke completed:

- `npx --yes esbuild@0.25.12 dsh-community-market/src/install/service.ts --bundle --platform=node --packages=external --format=esm --outfile=/tmp/dsh-market-service-smoke.mjs`
- `npx --yes esbuild@0.25.12 dsh-community-market/src/client/MarketSettingsTab.tsx --bundle --platform=browser --packages=external --format=esm --outfile=/tmp/dsh-market-client-smoke.mjs`
- `git diff --check`

Full Yarn gates were not run because the available runtime is Node 20.20.0 while this repository requires Node 22.19+ or 24+.

## Release Notes / 发布说明

When a protected Plugin Market operation fails with a pnpm diagnostic, the confirmation dialog now shows the sanitized pnpm error after the existing safe-retry guidance.
