### PR TITLE
fix(desktop): enforce volume checks for dropped workspaces

### DIFF
--- a/dsh-plugin-desktop/src/client/index.ts
+++ b/dsh-plugin-desktop/src/client/index.ts
@@ -7,7 +7,7 @@ import type {} from '@deepseek-ai/dsh-client-ui-settings/client'
 import type {} from '@deepseek-ai/dsh-client-ui-theme/client'
 import { applyAdvancedShell } from './advanced-shell.ts'
 import { startRendererBootReporter } from './boot-health.ts'
-import { installDesktopDirectoryPickerBridge } from './directory-picker.ts'
+import { installDesktopDirectoryPickerBridge, requestDesktopDirectoryValidation } from './directory-picker.ts'
 import { parseDesktopClientEnvironment } from './environment.ts'
 import { installWorkspaceFolderDrop } from './workspace-folder-drop.ts'
 
@@ -42,6 +42,9 @@ export function apply(ctx: ClientContext): void {
     () => installWorkspaceFolderDrop({
       create: input => ctx.workspaces.create(input),
       startSession: workspaceId => { ctx.workspaces.startSession(workspaceId) },
+      ...(environment.platform === 'win32'
+        ? { validateDirectory: (path: string) => requestDesktopDirectoryValidation(path) }
+        : {}),
     }),
     'dsh-plugin-desktop: workspace folder drop',
   )

--- a/dsh-plugin-desktop/src/client/workspace-folder-drop.ts
+++ b/dsh-plugin-desktop/src/client/workspace-folder-drop.ts
@@ -7,6 +7,7 @@ export const WORKSPACE_DROP_TARGET = '[data-dsh-workspace-drop-target]'
 export interface WorkspaceFolderDropActions {
   create(input: { path: string }): Promise<WorkspaceView>
   startSession(workspaceId: WorkspaceId): void
+  validateDirectory?(path: string): Promise<boolean>
 }
 
 type DropState = 'ready' | 'busy' | 'error'
@@ -62,6 +63,9 @@ export async function adoptWorkspaceFolder(
 ): Promise<void> {
   const path = bridge.getPathForFile(file).trim()
   if (path.length === 0) throw new Error('DSH Desktop could not read this folder path')
+  if (actions.validateDirectory !== undefined && !await actions.validateDirectory(path)) {
+    throw new Error('DSH Desktop rejected this workspace location')
+  }
   const workspace = await actions.create({ path })
   actions.startSession(workspace.workspaceId)
 }

--- a/dsh-plugin-desktop/tests/client-workspace-folder-drop.spec.ts
+++ b/dsh-plugin-desktop/tests/client-workspace-folder-drop.spec.ts
@@ -54,4 +54,20 @@ describe('desktop workspace folder drop', () => {
       .rejects.toThrow('could not read this folder path')
     expect(actions.create).not.toHaveBeenCalled()
   })
+
+  it('rejects a workspace when desktop validation denies its volume', async () => {
+    const actions: WorkspaceFolderDropActions = {
+      create: vi.fn(),
+      startSession: vi.fn(),
+      validateDirectory: vi.fn(async () => false),
+    }
+
+    await expect(adoptWorkspaceFolder(
+      { name: 'repo' } as File,
+      { getPathForFile: () => 'E:\\repo' },
+      actions,
+    )).rejects.toThrow('DSH Desktop rejected this workspace location')
+    expect(actions.validateDirectory).toHaveBeenCalledWith('E:\\repo')
+    expect(actions.create).not.toHaveBeenCalled()
+  })
 })


### PR DESCRIPTION
Summary:
- Route Windows workspace folder drops through the existing desktop volume validator.
- Stop workspace creation when the host rejects an unsafe volume.
- Preserve non-Windows folder-drop behavior.

Verification:
- Focused directory admission tests: 18 passed.
- Desktop tests: 582 passed, 11 skipped.
- Desktop typecheck passed.
- Desktop build passed.