### PR TITLE
fix(desktop): print the pnpm allowBuilds edit when built-in terminal plugin add fails

### DIFF
--- a/dsh-plugin-desktop/src/desktop-cli.ts
+++ b/dsh-plugin-desktop/src/desktop-cli.ts
@@ -1,6 +1,8 @@
 /** Private RunAsNode bootstrap for the packaged DeepSeek Harness CLI. */
 
 import { randomUUID } from 'node:crypto'
+import { readFile } from 'node:fs/promises'
+import { join } from 'node:path'
 import { fileURLToPath, pathToFileURL } from 'node:url'
 import { resolveProfileDir } from '@deepseek-ai/dsh-app-boot'
 import {
@@ -112,6 +114,41 @@ class CapturedDesktopCliExit {
   constructor(readonly code: number) {}
 }
 
+/** The value pnpm ≥11 writes for a dependency build script it blocked until allowed. */
+const BLOCKED_BUILD_PLACEHOLDER = 'set this to true or false'
+
+/**
+ * Build the actionable message when a failed plugin install left pnpm's
+ * blocked-build-scripts placeholder in the profile's `pnpm-workspace.yaml`.
+ * pnpm ≥11 blocks dependency build scripts by default (`strictDepBuilds`),
+ * fails the install with `ERR_PNPM_IGNORED_BUILDS`, and records the blocked
+ * packages as `allowBuilds` entries with a placeholder value before exiting;
+ * only a literal boolean allows a script. The packaged CLI only hints for
+ * git-hosted specs, so registry plugins with native dependencies surface no
+ * pointer to the file pnpm itself wrote.
+ * @param profileDir - the profile directory owning `pnpm-workspace.yaml`.
+ * @returns the actionable message, or undefined when no placeholder exists.
+ */
+export async function blockedBuildsHint(profileDir: string): Promise<string | undefined> {
+  let workspaceYaml: string
+  try {
+    workspaceYaml = await readFile(join(profileDir, 'pnpm-workspace.yaml'), 'utf8')
+  } catch {
+    // No pnpm-workspace.yaml means pnpm never recorded an allowance decision.
+    return undefined
+  }
+  const entries = [...workspaceYaml.matchAll(
+    new RegExp(`^\\s*([^:\\s][^:\\n]*?):\\s*(?:["'])?${BLOCKED_BUILD_PLACEHOLDER}(?:["'])?\\s*$`, 'gm'),
+  )]
+    .map(match => match[1])
+    .filter((name): name is string => name !== undefined && name.length > 0)
+  if (entries.length === 0) return undefined
+  const file = join(profileDir, 'pnpm-workspace.yaml')
+  const allowlist = entries.map(name => `    ${name}: true`).join('\n')
+  return `dsh-desktop: pnpm blocked the build scripts of ${entries.join(', ')} until allowed — add them `
+    + `under allowBuilds in ${file}, then re-run:\n  allowBuilds:\n${allowlist}\n`
+}
+
 /** Run one built-in-terminal add inside the same durable recovery boundary as Market installs. */
 async function loadWithInstallRecovery(
   load: (url: string) => Promise<unknown>,
@@ -155,6 +192,8 @@ async function loadWithInstallRecovery(
       throw cause
     }
   } else {
+    const hint = await blockedBuildsHint(store.profileDir)
+    if (hint !== undefined) process.stderr.write(hint)
     const restored = await store.restoreCurrentInstall(transaction.transactionId, 'install-failed')
     if (restored.status !== 'manual-recovery-required') await store.clear(transaction.transactionId)
   }

--- a/dsh-plugin-desktop/tests/desktop-cli.spec.ts
+++ b/dsh-plugin-desktop/tests/desktop-cli.spec.ts
@@ -4,6 +4,7 @@ import { join } from 'node:path'
 import { pathToFileURL } from 'node:url'
 import { describe, expect, it, vi } from 'vitest'
 import {
+  blockedBuildsHint,
   clearElectronRunAsNode,
   runDesktopDshCli,
   withDefaultDesktopProfile,
@@ -250,6 +251,78 @@ describe('packaged dsh bootstrap', () => {
       expect(packagedDependencyPath(moduleUrl, 'pnpm/bin/pnpm.mjs'))
         .toBe(join(realpathSync(root), 'node_modules', 'pnpm', 'bin', 'pnpm.mjs'))
     } finally {
+      rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  it('prints the allowBuilds edit when pnpm left its blocked-build placeholder', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'dsh-desktop-blocked-builds-hint-'))
+    const profileDir = join(root, 'profiles', 'desktop')
+    try {
+      mkdirSync(profileDir, { recursive: true })
+      writeFileSync(join(profileDir, 'pnpm-workspace.yaml'),
+        'allowBuilds:\n  node-pty: set this to true or false\n  @scope/pkg: set this to true or false\n')
+      const hint = await blockedBuildsHint(profileDir)
+      expect(hint).toContain('node-pty')
+      expect(hint).toContain('@scope/pkg')
+      expect(hint).toContain(join(profileDir, 'pnpm-workspace.yaml'))
+      expect(hint).toContain('allowBuilds:')
+      expect(hint).toContain('    node-pty: true')
+      expect(hint).toContain('    @scope/pkg: true')
+    } finally {
+      rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  it('returns no hint when pnpm recorded no blocked-build placeholder', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'dsh-desktop-blocked-builds-clean-'))
+    const profileDir = join(root, 'profiles', 'desktop')
+    try {
+      mkdirSync(profileDir, { recursive: true })
+      writeFileSync(join(profileDir, 'pnpm-workspace.yaml'), 'allowBuilds:\n  node-pty: true\n')
+      expect(await blockedBuildsHint(profileDir)).toBeUndefined()
+      expect(await blockedBuildsHint(join(root, 'missing'))).toBeUndefined()
+    } finally {
+      rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  it('surfaces the allowBuilds edit before restoring a failed built-in terminal install', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'dsh-desktop-terminal-allowbuilds-'))
+    const homeDir = join(root, 'home')
+    const profileDir = join(homeDir, 'profiles', 'desktop')
+    const statePath = desktopInstallRecoveryStatePath(join(root, 'user-data'))
+    const manifestPath = join(profileDir, 'package.json')
+    const workspacePath = join(profileDir, 'pnpm-workspace.yaml')
+    const originalExitCode = process.exitCode
+    const stderrWrite = vi.spyOn(process.stderr, 'write').mockReturnValue(true)
+    try {
+      mkdirSync(profileDir, { recursive: true })
+      const originalManifest = JSON.stringify({ dependencies: {} })
+      const originalWorkspace = 'packages:\n  - .\n'
+      writeFileSync(manifestPath, originalManifest)
+      writeFileSync(workspacePath, originalWorkspace)
+      await runDesktopDshCli({
+        DSH_HOME: homeDir,
+        DSH_DESKTOP_DEFAULT_PROFILE: 'desktop',
+        [DESKTOP_INSTALL_RECOVERY_STATE_ENV]: statePath,
+      }, async () => {
+        writeFileSync(manifestPath, JSON.stringify({ dependencies: { 'broken-plugin': '0.0.0' } }))
+        writeFileSync(workspacePath, 'allowBuilds:\n  node-pty: set this to true or false\n')
+        process.exit(1)
+      }, [process.execPath, '/app/desktop-cli.js', 'plugin', 'add', 'broken-plugin'])
+
+      expect(readFileSync(manifestPath, 'utf8')).toBe(originalManifest)
+      expect(readFileSync(workspacePath, 'utf8')).toBe(originalWorkspace)
+      expect(existsSync(statePath)).toBe(false)
+      expect(process.exitCode).toBe(1)
+      const written = stderrWrite.mock.calls.map(call => String(call[0])).join('')
+      expect(written).toContain('pnpm blocked the build scripts of node-pty')
+      expect(written).toContain(join(profileDir, 'pnpm-workspace.yaml'))
+      expect(written).toContain('    node-pty: true')
+    } finally {
+      stderrWrite.mockRestore()
+      process.exitCode = originalExitCode
       rmSync(root, { recursive: true, force: true })
     }
   })


### PR DESCRIPTION
## Summary / 摘要

`dsh plugin add`（内置终端路径）安装依赖链含原生模块的插件（如 `dsh-better-sidebar` → `node-pty`）时，pnpm ≥11 默认拦截依赖构建脚本（`strictDepBuilds`），安装以 `ERR_PNPM_IGNORED_BUILDS` 失败：pnpm 在失败前会把被阻止的包以占位值 `set this to true or false` 写入 profile 的 `pnpm-workspace.yaml` 的 `allowBuilds` 下，而打包的 dsh CLI 只对 git 托管 spec 打印修复指引，registry 插件用户得不到任何指向该文件的提示，占位符又不是合法布尔值，重跑依旧失败（详见 #348 的根因分析）。

本 PR 在桌面内置终端的 `plugin add` 失败路径（`desktop-cli.ts` 的 `loadWithInstallRecovery`）上，**在恢复边界回滚丢弃 `pnpm-workspace.yaml` 之前**读取该文件；若包含 pnpm 的占位条目，则向 stderr 打印精确的放行编辑，提示用户加好后重跑。

新增导出函数 `blockedBuildsHint(profileDir)`（纯逻辑，可单测）：读取并扫描 `pnpm-workspace.yaml`，发现占位条目时生成消息。

## Related Issues / 关联 Issue

Related to #348（该 issue 覆盖 CLI 侧与桌面侧同一根因；本 PR 修复桌面内置终端路径）

## Type / 类型

- [x] Bug fix / 问题修复

## Platforms / 影响平台

- [x] Not platform-specific / 与平台无关（修复逻辑与平台无关；已在 macOS Apple Silicon 验证）

## Verification / 验证

- [x] `yarn typecheck` — 通过
- [x] `yarn vitest run tests/desktop-cli.spec.ts` — 12 tests passed（含 3 个新增：纯函数两条 + 集成一条：失败安装打印提示且文件被回滚恢复）
- [x] `yarn check` — 通过（build + typecheck + 619 tests + verify:closure / verify:cli / verify:loader / verify:profile / verify:licenses）
- [ ] 平台打包或启动冒烟 — 未运行（本机为源码 checkout）

## Release Notes / 发布说明

内置终端执行 `dsh plugin add` 安装带原生依赖的插件失败时，打印 `pnpm-workspace.yaml` 的精确 `allowBuilds` 修改指引，而不是只报 pnpm failed。
