### PR TITLE
fix(desktop): persist macOS tray position across relaunches

### DIFF
--- a/dsh-plugin-desktop/src/electron-shell-generation.ts
+++ b/dsh-plugin-desktop/src/electron-shell-generation.ts
@@ -1,3 +1,6 @@
+import { spawnSync } from 'node:child_process'
+import { readFileSync, writeFileSync } from 'node:fs'
+import { dirname, join, resolve } from 'node:path'
 import {
   app,
   BrowserWindow,
@@ -16,6 +19,53 @@ import { desktopWindowOptions } from './window-options.ts'
 
 const MIN_ZOOM_LEVEL = -4
 const MAX_ZOOM_LEVEL = 4
+
+/** Stable UUID used as the macOS NSStatusItem autosave name so the user-dragged status bar position survives relaunches. */
+export const TRAY_GUID = 'a1b2c3d4-e5f6-4a5b-8c9d-0e1f2a3b4c5d'
+
+/** Fallback bundle identifier used when the running executable is not inside an app bundle. */
+const DESKTOP_BUNDLE_ID = 'ai.deepseek.dsh.desktop'
+
+/** CFPreferences key macOS uses to persist one NSStatusItem autosave position. */
+const trayPositionKey = (): string => `NSStatusItem Preferred Position ${TRAY_GUID}`
+
+let cachedBundleIdentifier: string | undefined
+
+/** Resolve the running app's CFBundleIdentifier so the defaults domain matches what macOS writes. */
+function applicationBundleIdentifier(): string {
+  if (cachedBundleIdentifier === undefined) {
+    try {
+      const bundleRoot = resolve(dirname(process.execPath), '..', '..')
+      const plist = readFileSync(join(bundleRoot, 'Info.plist'), 'utf8')
+      const match = /<key>CFBundleIdentifier<\/key>\s*<string>([^<]+)<\/string>/.exec(plist)
+      cachedBundleIdentifier = match !== null ? match[1] : DESKTOP_BUNDLE_ID
+    } catch {
+      cachedBundleIdentifier = DESKTOP_BUNDLE_ID
+    }
+  }
+  return cachedBundleIdentifier ?? DESKTOP_BUNDLE_ID
+}
+
+/** Read the current macOS autosaved tray position from the app preferences domain. */
+function readSavedTrayPosition(): number | undefined {
+  const result = spawnSync(
+    '/usr/bin/defaults',
+    ['read', applicationBundleIdentifier(), trayPositionKey()],
+    { encoding: 'utf8', timeout: 2_000 },
+  )
+  if (result.error !== undefined || result.status !== 0) return undefined
+  const value = Number.parseInt(result.stdout.trim(), 10)
+  return Number.isFinite(value) ? value : undefined
+}
+
+/** Write the macOS autosave position so the next tray creation restores the previous spot. */
+function writeSavedTrayPosition(value: number): void {
+  spawnSync(
+    '/usr/bin/defaults',
+    ['write', applicationBundleIdentifier(), trayPositionKey(), '-int', String(value)],
+    { encoding: 'utf8', timeout: 2_000 },
+  )
+}
 
 function clampedZoomLevel(level: number): number {
   return Math.min(MAX_ZOOM_LEVEL, Math.max(MIN_ZOOM_LEVEL, level))
@@ -49,6 +99,35 @@ export class ElectronShellGeneration {
   private cleanupListeners: (() => void) | undefined
 
   constructor(private readonly options: ElectronShellGenerationOptions) {}
+
+  private trayPositionBackupPath(): string {
+    return join(app.getPath('userData'), 'tray-autosave-position')
+  }
+
+  /** Preserve the current macOS tray position before the item is destroyed. */
+  private backupTrayPosition(): void {
+    if (this.options.platform.platform !== 'darwin') return
+    const position = readSavedTrayPosition()
+    if (position === undefined) return
+    try {
+      writeFileSync(this.trayPositionBackupPath(), String(position), { mode: 0o600 })
+    } catch {
+      // Best-effort: losing the backup only means the icon starts at the default slot.
+    }
+  }
+
+  /** Reapply the last known macOS tray position before the item is recreated. */
+  private restoreTrayPosition(): void {
+    if (this.options.platform.platform !== 'darwin') return
+    let position: number | undefined
+    try {
+      const value = Number.parseInt(readFileSync(this.trayPositionBackupPath(), 'utf8').trim(), 10)
+      position = Number.isFinite(value) ? value : undefined
+    } catch {
+      position = undefined
+    }
+    if (position !== undefined) writeSavedTrayPosition(position)
+  }
 
   async mount(beforeInteractive?: () => void): Promise<void> {
     if (this.mounted || this.window !== undefined) {
@@ -169,7 +248,8 @@ export class ElectronShellGeneration {
 
     try {
       await window.loadURL(spec.url)
-      tray = new Tray(prepareTrayIcon(spec.trayIcons, platform.platform))
+      this.restoreTrayPosition()
+      tray = new Tray(prepareTrayIcon(spec.trayIcons, platform.platform), TRAY_GUID)
       this.tray = tray
       tray.setToolTip(spec.productName)
       this.refreshTrayMenu()
@@ -219,6 +299,7 @@ export class ElectronShellGeneration {
 
     this.cleanupListeners?.()
     this.cleanupListeners = undefined
+    this.backupTrayPosition()
     tray?.destroy()
     if (!window.isDestroyed()) window.destroy()
   }

--- a/dsh-plugin-desktop/tests/electron-runtime.spec.ts
+++ b/dsh-plugin-desktop/tests/electron-runtime.spec.ts
@@ -1,5 +1,7 @@
+import { mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
 import { basename, dirname, join } from 'node:path'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { TRAY_GUID } from '../src/electron-shell-generation.ts'
 import type { DesktopShellSpec } from '../src/runtime.ts'
 
 const terminal = vi.hoisted(() => ({ open: vi.fn() }))
@@ -34,6 +36,12 @@ const childProcess = vi.hoisted(() => {
     },
     reset() { listeners.clear() },
     spawn: vi.fn(() => child),
+    spawnSync: vi.fn((command: string, args: string[]) => {
+      if (command === '/usr/bin/defaults' && args[0] === 'read') {
+        return { status: 0, stdout: '123\n', stderr: '', signal: null, error: undefined }
+      }
+      return { status: 0, stdout: '', stderr: '', signal: null, error: undefined }
+    }),
   }
 })
 
@@ -57,6 +65,7 @@ vi.mock('../src/update-download.ts', () => ({
 vi.mock('node:child_process', async (importOriginal) => ({
   ...await importOriginal<typeof import('node:child_process')>(),
   spawn: childProcess.spawn,
+  spawnSync: childProcess.spawnSync,
 }))
 
 const electron = vi.hoisted(() => {
@@ -122,14 +131,16 @@ const electron = vi.hoisted(() => {
 
   class Tray {
     readonly image: unknown
+    readonly guid: string | undefined
     readonly setToolTip = vi.fn()
     readonly setContextMenu = vi.fn()
     readonly on = vi.fn()
     readonly off = vi.fn()
     readonly destroy = vi.fn()
 
-    constructor(image: unknown) {
+    constructor(image: unknown, guid?: string) {
       this.image = image
+      this.guid = guid
       trays.push(this)
     }
   }
@@ -318,6 +329,7 @@ describe('Electron compatibility runtime', () => {
     expect(electron.app.dock.setIcon).toHaveBeenCalledWith(electron.appIcon)
     expect(electron.templateIcon.setTemplateImage).toHaveBeenCalledWith(true)
     expect(electron.trays[0]?.image).toBe(electron.templateIcon)
+    expect(electron.trays[0]?.guid).toBe(TRAY_GUID)
     expect(electron.menuTemplates[0]).toEqual(expect.arrayContaining([
       expect.objectContaining({ label: 'Switch to Advanced Mode', enabled: true }),
     ]))
@@ -331,6 +343,39 @@ describe('Electron compatibility runtime', () => {
     await release()
     expect(electron.browserWindowOff).toHaveBeenCalledWith('page-title-updated', titleListener)
     expect(electron.trays[0]?.off).toHaveBeenCalledWith('click', expect.any(Function))
+  })
+
+  it('backs up and restores the macOS tray position around shell generation', async () => {
+    vi.spyOn(process, 'platform', 'get').mockReturnValue('darwin')
+    const userData = electron.app.getPath('userData')
+    mkdirSync(userData, { recursive: true })
+    const backupPath = join(userData, 'tray-autosave-position')
+    writeFileSync(backupPath, '432\n', { mode: 0o600 })
+
+    const { ElectronDesktopRuntime } = await import('../src/electron-runtime.ts')
+    const runtime = new ElectronDesktopRuntime(async () => {})
+    const release = runtime.schedule(spec)
+
+    await runtime.mountScheduled()
+
+    const writeCall = childProcess.spawnSync.mock.calls.find(([, args]) =>
+      args[0] === 'write' && args[1] === 'ai.deepseek.dsh.desktop')
+    expect(writeCall?.[1]).toEqual([
+      'write',
+      'ai.deepseek.dsh.desktop',
+      `NSStatusItem Preferred Position ${TRAY_GUID}`,
+      '-int',
+      '432',
+    ])
+
+    await release()
+
+    const readCall = childProcess.spawnSync.mock.calls.find(([, args]) =>
+      args[0] === 'read' && args[1] === 'ai.deepseek.dsh.desktop')
+    expect(readCall).toBeDefined()
+    expect(readFileSync(backupPath, 'utf8')).toBe('123')
+
+    rmSync(userData, { recursive: true, force: true })
   })
 
   it('uses the Windows caption, hidden menu bar, removed menu, and fixed blue tray image', async () => {


### PR DESCRIPTION
## Summary

On macOS the tray icon's status bar position is not remembered across relaunches. Two layers cause this:

1. **No autosave identity** — the `Tray` was created without the `guid` argument, so Electron never set an `NSStatusItem` autosave name and macOS had nothing to identify the item with.
2. **Saved position wiped on quit** — even with an autosave name, `tray.destroy()` calls `removeStatusItem`, which makes macOS delete the saved `NSStatusItem Preferred Position` record at every quit. The next launch therefore always starts at the default slot, and user-dragged positions are lost.

## Changes

- Pass a stable UUID (`TRAY_GUID`) as the `Tray` constructor's second argument, which Electron's macOS implementation maps to `NSStatusItem.autosaveName`.
- Before destroying the tray (`release()`), back up the current `NSStatusItem Preferred Position <guid>` value (read via `/usr/bin/defaults`) to `userData/tray-autosave-position`.
- Before creating the tray (`mount()`), restore that value into the app preferences domain so macOS places the icon at the last user position.
- macOS-only; failures are best-effort and never affect startup.

This mirrors the approach used by status bar apps such as BtBar, which persist `NSStatusItem Preferred Position` across launches.

## Verification

Verified end-to-end against the packaged macOS build with real user-style Cmd-drags:

| stage | tray X (main display) | saved position key |
|---|---|---|
| after drag | 1065 | 956 |
| after quit | — | deleted (backed up to file) |
| after relaunch | **1066** | restored 956 |

A second drag → quit → relaunch cycle also restored the dragged position.

## Tests

- `tests/electron-runtime.spec.ts` mocks `spawnSync` and adds a round-trip test covering backup + restore wiring.
- `yarn workspace dsh-plugin-desktop typecheck` passes; full test suite: 565 passed, 3 skipped.