### PR TITLE
fix(market): allow reviewed hosts through IPv6 fake-IP proxy ranges

### DIFF
--- a/dsh-community-market/src/media/restricted-image.ts
+++ b/dsh-community-market/src/media/restricted-image.ts
@@ -11,6 +11,11 @@ const FIRST_BYTE_TIMEOUT_MS = 12_000
 const TOTAL_TIMEOUT_MS = 30_000
 const SYNTHETIC_PROXY_NETWORK = '198.18.0.0'
 const SYNTHETIC_PROXY_PREFIX = 15
+// Default IPv6 fake-IP pool of mihomo and Clash Verge (fake-ip-range6). Reviewed
+// hosts are allowed to resolve here so a local proxy's fake-IP DNS does not
+// break catalog media downloads when IPv6 is enabled.
+const SYNTHETIC_PROXY_NETWORK6 = 'fdfe:dcba:9876::'
+const SYNTHETIC_PROXY_PREFIX6 = 64
 
 export type MarketMediaErrorCode =
   | 'invalid-candidate'
@@ -46,7 +51,7 @@ interface MediaHttpResponse {
 }
 
 export interface RestrictedImageFetcherOptions {
-  /** Exact, product-reviewed hosts allowed to resolve through an RFC 2544 fake-IP proxy. */
+  /** Exact, product-reviewed hosts allowed to resolve through RFC 2544 fake-IP proxy ranges (IPv4 and IPv6). */
   readonly syntheticProxyHostnames?: readonly string[]
   readonly lookupAddresses?: (hostname: string) => Promise<readonly MediaPinnedAddress[]>
   readonly request?: (
@@ -76,6 +81,7 @@ for (const [network, prefix] of [
 
 const syntheticProxyAddresses = new BlockList()
 syntheticProxyAddresses.addSubnet(SYNTHETIC_PROXY_NETWORK, SYNTHETIC_PROXY_PREFIX, 'ipv4')
+syntheticProxyAddresses.addSubnet(SYNTHETIC_PROXY_NETWORK6, SYNTHETIC_PROXY_PREFIX6, 'ipv6')
 for (const [network, prefix] of [
   ['::', 128],
   ['::1', 128],
@@ -133,8 +139,8 @@ function assertSafeAddress(address: string, allowSyntheticProxyAddress = false):
   const family = isIP(normalized)
   const addressFamily = family === 4 ? 'ipv4' : 'ipv6'
   const allowedSyntheticAddress = allowSyntheticProxyAddress
-    && family === 4
-    && syntheticProxyAddresses.check(normalized, 'ipv4')
+    && (family === 4 && syntheticProxyAddresses.check(normalized, 'ipv4')
+      || family === 6 && syntheticProxyAddresses.check(normalized, 'ipv6'))
   if (family === 0 || blockedAddresses.check(normalized, addressFamily) && !allowedSyntheticAddress) {
     throw new MarketMediaError('blocked-address')
   }

--- a/dsh-community-market/src/network/restricted-http.ts
+++ b/dsh-community-market/src/network/restricted-http.ts
@@ -11,6 +11,11 @@ const FIRST_BYTE_TIMEOUT_MS = 12_000
 const TOTAL_TIMEOUT_MS = 30_000
 const SYNTHETIC_PROXY_NETWORK = '198.18.0.0'
 const SYNTHETIC_PROXY_PREFIX = 15
+// Default IPv6 fake-IP pool of mihomo and Clash Verge (fake-ip-range6). Reviewed
+// hostnames are allowed to resolve here so a local proxy's fake-IP DNS does not
+// break catalog fetches or install verification when IPv6 is enabled.
+const SYNTHETIC_PROXY_NETWORK6 = 'fdfe:dcba:9876::'
+const SYNTHETIC_PROXY_PREFIX6 = 64
 
 export class CatalogNetworkError extends Error {
   constructor(readonly code: 'invalid-url' | 'blocked-address' | 'redirect' | 'timeout' | 'http' | 'response') {
@@ -58,7 +63,8 @@ interface RestrictedHttpResponse {
 export interface RestrictedHttpClientOptions {
   /**
    * Exact, reviewed hostnames that may resolve through a local proxy's
-   * RFC 2544 fake-IP range. User-provided catalog hosts must never be added.
+   * RFC 2544 fake-IP ranges (IPv4 and IPv6). User-provided catalog hosts must
+   * never be added.
    */
   readonly syntheticProxyHostnames?: readonly string[]
   readonly lookupAddresses?: (hostname: string) => Promise<readonly PinnedAddress[]>
@@ -74,14 +80,15 @@ export interface RestrictedHttpClientOptions {
 
 const syntheticProxyAddresses = new BlockList()
 syntheticProxyAddresses.addSubnet(SYNTHETIC_PROXY_NETWORK, SYNTHETIC_PROXY_PREFIX, 'ipv4')
+syntheticProxyAddresses.addSubnet(SYNTHETIC_PROXY_NETWORK6, SYNTHETIC_PROXY_PREFIX6, 'ipv6')
 
 function assertSafeAddress(address: string, allowSyntheticProxyAddress = false): 4 | 6 {
   const normalized = address.replace(/^\[|\]$/gu, '').split('%', 1)[0]!
   const family = isIP(normalized)
   const addressFamily = family === 4 ? 'ipv4' : 'ipv6'
   const allowedSyntheticAddress = allowSyntheticProxyAddress
-    && family === 4
-    && syntheticProxyAddresses.check(normalized, 'ipv4')
+    && (family === 4 && syntheticProxyAddresses.check(normalized, 'ipv4')
+      || family === 6 && syntheticProxyAddresses.check(normalized, 'ipv6'))
   if (family === 0 || blockedAddresses.check(normalized, addressFamily) && !allowedSyntheticAddress) {
     throw new CatalogNetworkError('blocked-address')
   }

--- a/dsh-community-market/tests/market-runtime.spec.ts
+++ b/dsh-community-market/tests/market-runtime.spec.ts
@@ -1553,6 +1553,63 @@ describe('restricted HTTP boundary', () => {
     )).rejects.toMatchObject({ code: 'blocked-address' })
   })
 
+  it('allows IPv4 and IPv6 fake-IP DNS together for a reviewed hostname', async () => {
+    const lookupAddresses = vi.fn(async () => [
+      { address: '198.18.0.38', family: 4 as const },
+      { address: 'fdfe:dcba:9876::1b', family: 6 as const },
+    ])
+    const request = vi.fn(async () => ({
+      body: Buffer.from('{"packages":[]}'),
+      headers: { 'content-type': 'application/json' },
+      statusCode: 200,
+    }))
+    const trusted = createRestrictedHttpClient({
+      syntheticProxyHostnames: ['deepseek1024.com'],
+      lookupAddresses,
+      request,
+    })
+
+    await expect(trusted.getJson(
+      'https://deepseek1024.com/api/v1/plugins',
+      new AbortController().signal,
+    )).resolves.toMatchObject({ value: { packages: [] } })
+    expect(request).toHaveBeenCalledOnce()
+
+    const strict = createRestrictedHttpClient({ lookupAddresses, request })
+    await expect(strict.getJson(
+      'https://deepseek1024.com/api/v1/plugins',
+      new AbortController().signal,
+    )).rejects.toMatchObject({ code: 'blocked-address' })
+  })
+
+  it('allows a reviewed hostname pinned to an IPv6-only fake-IP address', async () => {
+    const lookupAddresses = vi.fn(async () => [
+      { address: 'fdfe:dcba:9876::2c', family: 6 as const },
+    ])
+    const request = vi.fn(async () => ({
+      body: Buffer.from('{"packages":[]}'),
+      headers: { 'content-type': 'application/json' },
+      statusCode: 200,
+    }))
+    const trusted = createRestrictedHttpClient({
+      syntheticProxyHostnames: ['api.dshfind.com'],
+      lookupAddresses,
+      request,
+    })
+
+    await expect(trusted.getJson(
+      'https://api.dshfind.com/v1/plugins',
+      new AbortController().signal,
+    )).resolves.toMatchObject({ value: { packages: [] } })
+    expect(request).toHaveBeenCalledOnce()
+
+    const strict = createRestrictedHttpClient({ lookupAddresses, request })
+    await expect(strict.getJson(
+      'https://api.dshfind.com/v1/plugins',
+      new AbortController().signal,
+    )).rejects.toMatchObject({ code: 'blocked-address' })
+  })
+
   it('caches a completed fixed-catalog response and collapses concurrent reads', async () => {
     let now = 1_000
     let release: ((value: { value: object; finalUrl: string }) => void) | undefined

--- a/dsh-community-market/tests/media-service.spec.ts
+++ b/dsh-community-market/tests/media-service.spec.ts
@@ -258,6 +258,33 @@ describe('restricted market image fetcher', () => {
     )).rejects.toMatchObject({ code: 'blocked-address' })
   })
 
+  it('allows IPv4 and IPv6 fake-IP proxy addresses together for a reviewed hostname', async () => {
+    const request = vi.fn(async () => ({
+      statusCode: 200,
+      headers: { 'content-type': 'image/png' },
+      body: Buffer.from('network boundary only'),
+    }))
+    const lookupAddresses = vi.fn(async (_hostname: string) => [
+      { address: '198.18.0.42', family: 4 as const },
+      { address: 'fdfe:dcba:9876::2a', family: 6 as const },
+    ])
+    const allowedFetcher = createRestrictedImageFetcher({
+      syntheticProxyHostnames: ['github.com'],
+      lookupAddresses,
+      request,
+    })
+    await expect(allowedFetcher(
+      candidate({ allowedHostnames: ['github.com'] }),
+      new AbortController().signal,
+    )).resolves.toMatchObject({ contentType: 'image/png' })
+
+    const blockedFetcher = createRestrictedImageFetcher({ lookupAddresses, request })
+    await expect(blockedFetcher(
+      candidate({ allowedHostnames: ['github.com'] }),
+      new AbortController().signal,
+    )).rejects.toMatchObject({ code: 'blocked-address' })
+  })
+
   it('rejects redirects outside the reviewed hostname set and non-image responses', async () => {
     const lookupAddresses = vi.fn(async (_hostname: string) => [{ address: '93.184.216.34', family: 4 as const }])
     const redirectFetcher = createRestrictedImageFetcher({


### PR DESCRIPTION
### Problem

The restricted HTTP and image clients block a local proxy's fake-IP ranges to prevent SSRF, but only covered the IPv4 pool (`198.18.0.0/15`). When IPv6 is enabled, mihomo and Clash Verge also return IPv6 fake-IP addresses from `fdfe:dcba:9876::/64` (the `fake-ip-range6` default). Because `resolvePinnedAddress` validates **every** DNS entry, a single IPv6 fake-IP entry made even the reviewed whitelisted hostnames (`deepseek1024.com`, `api.dshfind.com`, `registry.npmjs.org`, media hosts) fail with `blocked-address`.

With the most common desktop proxy setup (Clash Verge Rev / mihomo built-in enhanced mode, IPv6 enabled), the plugin catalog could not be fetched and npm install verification failed, with the underlying error masked as `400 invalid catalog query`.

### Fix

- Add the default IPv6 fake-IP pool `fdfe:dcba:9876::/64` to the synthetic proxy ranges in both `src/network/restricted-http.ts` and `src/media/restricted-image.ts`.
- Apply the synthetic address allowance per address family (IPv4 and IPv6) instead of IPv4-only.
- The exception still applies only to the exact, product-reviewed hostnames already configured; user-provided catalog sources keep the full blocklist, so the SSRF posture is unchanged.

### Tests

- `tests/market-runtime.spec.ts`: a reviewed hostname resolving to mixed IPv4+IPv6 fake-IP addresses (exact reproduction of the Clash Verge default) now passes; IPv6-only fake-IP passes; non-reviewed hostnames remain blocked.
- `tests/media-service.spec.ts`: same mixed fake-IP case for the image fetcher.
- Full suite: 258 tests pass; typecheck passes.

### Notes

Users who configure a custom `fake-ip-range` / `fake-ip-range6` outside the two default pools can still use the proxy's `fake-ip-filter` to opt those hosts out (documented workaround).