### PR TITLE
feat(market): accept reviewed npm install targets from dshfind

### DIFF
--- a/dsh-community-market/src/adapters/dshfind.ts
+++ b/dsh-community-market/src/adapters/dshfind.ts
@@ -20,6 +20,8 @@ const GITHUB_OWNER_PATTERN = /^[a-z0-9][a-z0-9-]{0,99}$/iu
 const GITHUB_REPOSITORY_PATTERN = /^[a-z0-9._-]{1,100}$/iu
 const CATEGORY_PATTERN = /^[a-z0-9][a-z0-9._:-]*$/u
 const DATA_VERSION_PATTERN = /^sha256:[0-9a-f]{64}$/u
+const NPM_PACKAGE_PATTERN = /^(?:@[a-z0-9][a-z0-9._-]*\/)?[a-z0-9][a-z0-9._-]*$/u
+const STABLE_SEMVER_PATTERN = /^(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)$/u
 const UNSAFE_TEXT_PATTERN = /[\u0000-\u001f\u007f-\u009f\u202a-\u202e\u2066-\u2069]/u
 
 type CatalogItem = CatalogSnapshot['items'][number]
@@ -182,6 +184,38 @@ function keywords(value: unknown, languageValue: unknown): readonly string[] | u
   return result.length === 0 ? undefined : result
 }
 
+/**
+ * Convert only one provider-reviewed npm target into non-executable catalog
+ * identity. dshfind's install.cmd semantics bind install.pkg_name, so a
+ * target whose spec disagrees with a supplied pkg_name is self-contradictory
+ * and is not trusted. The Host still revalidates the exact version against
+ * the npm registry before it can create an install intent.
+ */
+function reviewedNpmTarget(
+  install: Record<string, unknown> | undefined,
+): { spec: string; revision: string } | undefined {
+  if (install === undefined || !Array.isArray(install.methods)) return undefined
+  const packageName = typeof install.pkg_name === 'string' ? install.pkg_name : undefined
+  const targets = new Map<string, { spec: string; revision: string }>()
+  for (const value of install.methods) {
+    const method = record(value)
+    if (method === undefined) continue
+    if (
+      method.kind !== 'npm'
+      || method.verification !== 'verified'
+      || method.code !== 'repository_backlink'
+      || method.requiresBuildAllowance !== false
+      || typeof method.spec !== 'string'
+      || typeof method.revision !== 'string'
+      || !NPM_PACKAGE_PATTERN.test(method.spec)
+      || !STABLE_SEMVER_PATTERN.test(method.revision)
+      || (packageName !== undefined && method.spec !== packageName)
+    ) continue
+    targets.set(`${method.spec}@${method.revision}`, { spec: method.spec, revision: method.revision })
+  }
+  return targets.size === 1 ? targets.values().next().value : undefined
+}
+
 function normalizeItem(value: unknown, context: CatalogFetchContext): CatalogItem | undefined {
   const raw = record(value)
   if (raw === undefined) return undefined
@@ -208,6 +242,7 @@ function normalizeItem(value: unknown, context: CatalogFetchContext): CatalogIte
   const pushedAt = typeof raw.pushed_at === 'string' && Number.isFinite(Date.parse(raw.pushed_at))
     ? new Date(Date.parse(raw.pushed_at)).toISOString()
     : undefined
+  const npmTarget = reviewedNpmTarget(record(raw.install))
 
   return {
     id,
@@ -223,8 +258,15 @@ function normalizeItem(value: unknown, context: CatalogFetchContext): CatalogIte
       url: `https://github.com/${identity.owner.toLowerCase()}`,
     },
     ...(pushedAt === undefined ? {} : { updatedAt: pushedAt }),
-    // dshfind currently has no exact package version. Its install.cmd and
-    // install.pkg_name are intentionally not executable catalog identity.
+    // install.cmd and install.pkg_name stay non-executable catalog identity.
+    // A package target is exposed only when the provider-reviewed
+    // install.methods carry exactly one verified exact-version npm target;
+    // the Host still rechecks that version against the npm registry itself
+    // before it can create an install intent at preview time.
+    ...(npmTarget === undefined ? {} : {
+      package: { registry: 'npm' as const, name: npmTarget.spec },
+      latestVersion: npmTarget.revision,
+    }),
     provenance: {
       sourceRecordId: context.source.sourceRecordId,
       providerId: context.source.providerId,

--- a/dsh-community-market/src/adapters/dshfind.ts
+++ b/dsh-community-market/src/adapters/dshfind.ts
@@ -22,6 +22,8 @@ const CATEGORY_PATTERN = /^[a-z0-9][a-z0-9._:-]*$/u
 const DATA_VERSION_PATTERN = /^sha256:[0-9a-f]{64}$/u
 const NPM_PACKAGE_PATTERN = /^(?:@[a-z0-9][a-z0-9._-]*\/)?[a-z0-9][a-z0-9._-]*$/u
 const STABLE_SEMVER_PATTERN = /^(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)$/u
+const MAX_NPM_PACKAGE_LENGTH = 214
+const MAX_NPM_VERSION_LENGTH = 64
 const UNSAFE_TEXT_PATTERN = /[\u0000-\u001f\u007f-\u009f\u202a-\u202e\u2066-\u2069]/u
 
 type CatalogItem = CatalogSnapshot['items'][number]
@@ -207,6 +209,8 @@ function reviewedNpmTarget(
       || method.requiresBuildAllowance !== false
       || typeof method.spec !== 'string'
       || typeof method.revision !== 'string'
+      || method.spec.length > MAX_NPM_PACKAGE_LENGTH
+      || method.revision.length > MAX_NPM_VERSION_LENGTH
       || !NPM_PACKAGE_PATTERN.test(method.spec)
       || !STABLE_SEMVER_PATTERN.test(method.revision)
       || (packageName !== undefined && method.spec !== packageName)

--- a/dsh-community-market/tests/dshfind-adapter.spec.ts
+++ b/dsh-community-market/tests/dshfind-adapter.spec.ts
@@ -324,6 +324,8 @@ describe('dshfind install target normalization', () => {
     ['a prerelease version', { ...baseInstall, methods: [{ ...reviewedMethod, revision: '1.2.4-rc.1' }] }],
     ['a mutable tag instead of a version', { ...baseInstall, methods: [{ ...reviewedMethod, revision: 'latest' }] }],
     ['an invalid package name', { ...baseInstall, methods: [{ ...reviewedMethod, spec: 'Not A Package!' }] }],
+    ['an overlong package name', { ...baseInstall, pkg_name: undefined, methods: [{ ...reviewedMethod, spec: `dsh-${'a'.repeat(211)}` }] }],
+    ['an overlong version', { ...baseInstall, methods: [{ ...reviewedMethod, revision: `${'1'.repeat(63)}.2.3` }] }],
     ['a spec disagreeing with pkg_name', { ...baseInstall, methods: [{ ...reviewedMethod, spec: 'other-package' }] }],
     ['ambiguous reviewed targets', {
       ...baseInstall,

--- a/dsh-community-market/tests/dshfind-adapter.spec.ts
+++ b/dsh-community-market/tests/dshfind-adapter.spec.ts
@@ -265,3 +265,76 @@ describe('dshfind adapter', () => {
     expect(getJson).toHaveBeenCalledOnce()
   })
 })
+
+describe('dshfind install target normalization', () => {
+  const reviewedMethod = {
+    kind: 'npm',
+    verification: 'verified',
+    code: 'repository_backlink',
+    requiresBuildAllowance: false,
+    spec: 'dsh-plugin-0',
+    revision: '1.2.3',
+  }
+  const baseInstall = {
+    cmd: 'provider command text',
+    kind: 'npm',
+    pkg_name: 'dsh-plugin-0',
+    npm_published: true,
+  }
+
+  async function scanInstall(install: unknown) {
+    const adapter = createDshfindAdapter({ interPageDelayMs: 0 })
+    const http: CatalogHttpClient = {
+      getJson: vi.fn(async url => ({
+        value: rawPage([{ ...rawItem(0), install }], 1, 1),
+        finalUrl: url,
+      })),
+    }
+    const snapshots = await adapter.scanCatalog!({}, {
+      source: source(),
+      signal: new AbortController().signal,
+      http,
+      media: { register: vi.fn() },
+    })
+    return snapshots.flatMap(snapshot => snapshot.items)
+  }
+
+  it('exposes one reviewed exact npm target without exposing the provider command', async () => {
+    const items = await scanInstall({
+      ...baseInstall,
+      methods: [reviewedMethod, { ...reviewedMethod }],
+    })
+
+    expect(items).toHaveLength(1)
+    expect(items[0]).toMatchObject({
+      id: 'owner/plugin-0',
+      repository: { url: 'https://github.com/owner/plugin-0' },
+      package: { registry: 'npm', name: 'dsh-plugin-0' },
+      latestVersion: '1.2.3',
+    })
+    expect(JSON.stringify(items)).not.toContain('provider command text')
+  })
+
+  it.each([
+    ['missing methods', baseInstall],
+    ['a non-object install', 'npm install dsh-plugin-0'],
+    ['an unverified method', { ...baseInstall, methods: [{ ...reviewedMethod, verification: 'unverified' }] }],
+    ['a wrong verification code', { ...baseInstall, methods: [{ ...reviewedMethod, code: 'unlinked_package' }] }],
+    ['a build allowance requirement', { ...baseInstall, methods: [{ ...reviewedMethod, requiresBuildAllowance: true }] }],
+    ['a prerelease version', { ...baseInstall, methods: [{ ...reviewedMethod, revision: '1.2.4-rc.1' }] }],
+    ['a mutable tag instead of a version', { ...baseInstall, methods: [{ ...reviewedMethod, revision: 'latest' }] }],
+    ['an invalid package name', { ...baseInstall, methods: [{ ...reviewedMethod, spec: 'Not A Package!' }] }],
+    ['a spec disagreeing with pkg_name', { ...baseInstall, methods: [{ ...reviewedMethod, spec: 'other-package' }] }],
+    ['ambiguous reviewed targets', {
+      ...baseInstall,
+      pkg_name: undefined,
+      methods: [reviewedMethod, { ...reviewedMethod, spec: 'another-package', revision: '2.0.0' }],
+    }],
+  ] as const)('does not expose an install identity for %s', async (_label, install) => {
+    const items = await scanInstall(install)
+
+    expect(items).toHaveLength(1)
+    expect(items[0]).not.toHaveProperty('package')
+    expect(items[0]).not.toHaveProperty('latestVersion')
+  })
+})


### PR DESCRIPTION
## Summary

The built-in dshfind catalog adapter has been browse-only because the dshfind API previously offered no exact package version or repository-backlink evidence (`dshfind.ts` carried a comment to that effect). dshfind now publishes that evidence, so the adapter can surface installable plugins exactly the way the reviewed 1024Store adapter does.

**Provider side (already live):** every item in `https://api.dshfind.com/v1/plugins` may now carry `install.methods[]`, shaped after the reviewed 1024Store `installMethods[]` contract:

```json
"methods": [
  { "kind": "npm", "verification": "verified", "code": "repository_backlink",
    "requiresBuildAllowance": false, "spec": "dsh-better-sidebar", "revision": "0.13.1" }
]
```

dshfind emits exactly one entry only when the package is npm-published, the npm package's `repository` field links back to the cataloged GitHub repository, and an exact stable version exists on npm (currently ~1290 plugins). Otherwise the field is omitted entirely.

## Changes

- `adapters/dshfind.ts`: new `reviewedNpmTarget()` mirroring the 1024Store gate (same `NPM_PACKAGE_PATTERN` / `STABLE_SEMVER_PATTERN`, same unique-target rule), reading `install.methods` instead of a top-level `installMethods`. One dshfind-specific addition: `spec` must equal `install.pkg_name` when the latter is a string, so contradictory provider data never becomes an install candidate. When a target passes, the item gains `package` + `latestVersion`; without evidence the item is unchanged (browse-only). Provider command text (`install.cmd`) still never enters the catalog.
- `tests/dshfind-adapter.spec.ts`: positive cases (including duplicate-method dedup) plus ten negative cases (missing methods, unverified, wrong code, build allowance, prerelease/tag revision, illegal name, spec/pkg_name mismatch, multiple distinct targets).

## Trust model

Unchanged. The adapter only converts provider-reviewed evidence into *non-executable catalog identity*; the Host still revalidates name/version/repository/integrity against the official npm registry at preview, and execute re-runs the full verification.

## Verification

- `yarn workspace dsh-community-market typecheck` — clean
- `yarn workspace dsh-community-market test` — 256 tests pass (17 in dshfind-adapter.spec.ts)
- End-to-end in the desktop dev environment against the live dshfind API: built-in dshfind source lists ~1290 installable plugins; install preview/execute completed for a sampled plugin.