### PR TITLE
fix: improve plugin install compatibility and diagnostics

### DIFF
--- a/dsh-community-market/src/api-types.ts
+++ b/dsh-community-market/src/api-types.ts
@@ -69,6 +69,12 @@ export interface MarketCatalogResponse {
   readonly fetchedAt: string
 }
 
+/** Bounded catalog failure identity returned by the Host without upstream details. */
+export type MarketCatalogErrorCode =
+  | 'catalog-timeout'
+  | 'catalog-invalid-response'
+  | 'catalog-unavailable'
+
 export interface MarketCatalogMetadata {
   readonly scannedAt: string
   readonly expiresAt: string

--- a/dsh-community-market/src/client/MarketSettingsTab.tsx
+++ b/dsh-community-market/src/client/MarketSettingsTab.tsx
@@ -121,6 +121,22 @@ function isDesktopUnavailable(cause: unknown): boolean {
     && (cause as { status?: unknown }).status === 503
 }
 
+function catalogFailureMessage(
+  cause: unknown,
+  source: MarketSourceView,
+  t: MarketSettingsTabProps['t'],
+): string {
+  const code = cause !== null && typeof cause === 'object' && 'code' in cause
+    ? (cause as { code?: unknown }).code
+    : undefined
+  const reason = code === 'catalog-timeout'
+    ? t('catalogFailureTimeout')
+    : code === 'catalog-invalid-response'
+      ? t('catalogFailureInvalidResponse')
+      : t('catalogFailureUnavailable')
+  return `${t('catalogFailureSource')}: ${source.name}. ${reason}`
+}
+
 function PluginIcon({ item, large = false }: { item: MarketItem; large?: boolean }) {
   const icon = item.media?.icon
   return (
@@ -330,7 +346,7 @@ export function MarketSurface({ initialView = 'installable', readLocale, t, show
       if (!request.signal.aborted && readRequest.current === request) {
         const retained = applyCatalog(next)
         if (retained === undefined) {
-          setError(t('catalogError'))
+          setError(catalogFailureMessage({ code: 'catalog-invalid-response' }, selected, t))
           return
         }
         if (!forceRefresh
@@ -348,8 +364,10 @@ export function MarketSurface({ initialView = 'installable', readLocale, t, show
           if (!request.signal.aborted && readRequest.current === request) applyCatalog(refreshed)
         }
       }
-    } catch {
-      if (!request.signal.aborted && readRequest.current === request && !catalogApplied) setError(t('catalogError'))
+    } catch (cause) {
+      if (!request.signal.aborted && readRequest.current === request && !catalogApplied) {
+        setError(catalogFailureMessage(cause, selected, t))
+      }
     } finally {
       if (readRequest.current === request) {
         readRequest.current = undefined

--- a/dsh-community-market/src/client/locales.ts
+++ b/dsh-community-market/src/client/locales.ts
@@ -139,6 +139,10 @@ export const zh = {
   sourceNotice: '可以添加多个来源，但每次只使用一个。请使用您信任的插件来源。',
   sourceError: '来源操作失败',
   catalogError: '暂时无法加载插件目录',
+  catalogFailureSource: '来源',
+  catalogFailureTimeout: '目录请求超时。',
+  catalogFailureInvalidResponse: '来源返回了无法识别的目录数据。',
+  catalogFailureUnavailable: '当前无法连接该目录来源。',
   retry: '重试',
 } as const
 
@@ -285,5 +289,9 @@ export const en: Record<MarketLocaleKey, string> = {
   sourceNotice: 'You can add multiple sources, but only one is used at a time. Use only plugin sources you trust.',
   sourceError: 'Source operation failed',
   catalogError: 'The plugin catalog is temporarily unavailable',
+  catalogFailureSource: 'Source',
+  catalogFailureTimeout: 'The catalog request timed out.',
+  catalogFailureInvalidResponse: 'The source returned catalog data that could not be read.',
+  catalogFailureUnavailable: 'The catalog source could not be reached.',
   retry: 'Retry',
 }

--- a/dsh-community-market/src/host/routes.ts
+++ b/dsh-community-market/src/host/routes.ts
@@ -9,6 +9,7 @@ import { parseCatalogSnapshot, parseCatalogSource, validateLocalSourceRecords } 
 import type { CatalogHttpClient } from '../contracts/types.js'
 import type {
   MarketBuiltInProvider,
+  MarketCatalogErrorCode,
   MarketCatalogMetadata,
   MarketCatalogResponse,
   MarketInstallationView,
@@ -17,7 +18,9 @@ import type {
   MarketSourceMutation,
   MarketStateResponse,
 } from '../api-types.js'
+import { CatalogContractError } from '../contracts/errors.js'
 import {
+  CatalogNetworkError,
   createCachedCatalogHttpClient,
   createRestrictedHttpClient,
   restrictedHttpClient,
@@ -129,6 +132,22 @@ function sendInstallError(res: ServerResponse, cause: unknown): void {
             : cause.code === 'operation-failed' ? 502
               : 500
   sendJson(res, status, { error: cause.message, code: cause.code })
+}
+
+function sendCatalogFailure(res: ServerResponse, cause: unknown): void {
+  let code: MarketCatalogErrorCode = 'catalog-unavailable'
+  if (cause instanceof CatalogNetworkError && cause.code === 'timeout') code = 'catalog-timeout'
+  else if (
+    cause instanceof CatalogNetworkError && cause.code === 'response'
+    || cause instanceof CatalogContractError
+  ) code = 'catalog-invalid-response'
+  const status = code === 'catalog-timeout' ? 504 : 502
+  const error = code === 'catalog-timeout'
+    ? 'catalog request timed out'
+    : code === 'catalog-invalid-response'
+      ? 'catalog response was invalid'
+      : 'catalog source unavailable'
+  sendJson(res, status, { error, code })
 }
 
 function catalogMetadata(index: CatalogFullIndex): MarketCatalogMetadata {
@@ -890,6 +909,12 @@ export function registerMarketRoutes(
               sourceRecordId: sourceRecordIds[0]!,
               ...(cursors.length === 0 ? {} : { cursor: cursors[0]! }),
             }
+        const activeSource = scope === undefined
+          ? undefined
+          : (await service.listSources()).find(source => (
+              source.enabled && source.sourceRecordId === scope.sourceRecordId
+            ))
+        if (scope !== undefined && activeSource === undefined) throw new Error('catalog source is not active')
         const localeKey = locale ?? ''
         const previewSourceRecordId = q === undefined
           && categories.length === 0
@@ -904,22 +929,26 @@ export function registerMarketRoutes(
           : catalogPreviewKey(previewSourceRecordId, localeKey)
         if (force) refreshPreviewKey = previewKey
         if (!force && previewKey !== undefined && !servedCatalogPreviews.has(previewKey)) {
-          const sources = await service.listSources()
-          const source = sources.find(value => value.sourceRecordId === previewSourceRecordId && value.enabled)
-          const cached = source === undefined
+          const cached = activeSource === undefined
             ? undefined
-            : cachedCatalogResponse(settingsScope.get().catalogCache, source, localeKey)
+            : cachedCatalogResponse(settingsScope.get().catalogCache, activeSource, localeKey)
           if (cached !== undefined) {
             servedCatalogPreviews.add(previewKey)
             if (!signal.aborted && !res.destroyed) sendJson(res, 200, cached)
             return
           }
         }
-        const index = await service.scanCatalog(signal, {
-          force,
-          ...(locale === null || locale === '' ? {} : { locale }),
-          ...(scope === undefined ? {} : { expectedSourceRecordId: scope.sourceRecordId }),
-        })
+        let index: CatalogFullIndex | undefined
+        try {
+          index = await service.scanCatalog(signal, {
+            force,
+            ...(locale === null || locale === '' ? {} : { locale }),
+            ...(scope === undefined ? {} : { expectedSourceRecordId: scope.sourceRecordId }),
+          })
+        } catch (cause) {
+          if (!signal.aborted && !res.destroyed) sendCatalogFailure(res, cause)
+          return
+        }
         signal.throwIfAborted()
         const response = buildCatalogResponse(index, query, scope)
         if (!signal.aborted && !res.destroyed) sendJson(res, 200, response)

--- a/dsh-community-market/tests/client-overlay.spec.tsx
+++ b/dsh-community-market/tests/client-overlay.spec.tsx
@@ -241,7 +241,8 @@ describe('community market overlay', () => {
     renderOpenOverlay()
 
     expect(await screen.findByRole('heading', { name: 'catalogError' })).toBeTruthy()
-    expect(screen.getAllByText('catalogError')).toHaveLength(2)
+    expect(screen.getByText('catalogFailureSource: DSH 1024Store. catalogFailureUnavailable')).toBeTruthy()
+    expect(screen.queryByText('market offline')).toBeNull()
     fireEvent.click(screen.getByRole('button', { name: 'retry' }))
 
     expect(await screen.findByText('Better Sidebar')).toBeTruthy()

--- a/dsh-community-market/tests/market-runtime.spec.ts
+++ b/dsh-community-market/tests/market-runtime.spec.ts
@@ -630,6 +630,31 @@ describe('standard source registration trust boundary', () => {
 })
 
 describe('catalog Host route pagination boundary', () => {
+  it.each([
+    ['timeout', 504, 'catalog-timeout'],
+    ['response', 502, 'catalog-invalid-response'],
+    ['http', 502, 'catalog-unavailable'],
+  ] as const)('returns a bounded %s failure code for catalog diagnostics', async (networkCode, status, code) => {
+    const scanCatalog = vi.spyOn(DefaultCatalogService.prototype, 'scanCatalog')
+      .mockRejectedValue(new CatalogNetworkError(networkCode))
+    try {
+      const response = await requestMarketCatalog(
+        [source()],
+        `${marketRoutes.catalog}?sourceRecordId=${source().sourceRecordId}`,
+      )
+
+      expect(response.statusCode).toBe(status)
+      expect(response.body).toEqual({
+        error: networkCode === 'timeout'
+          ? 'catalog request timed out'
+          : networkCode === 'response' ? 'catalog response was invalid' : 'catalog source unavailable',
+        code,
+      })
+    } finally {
+      scanCatalog.mockRestore()
+    }
+  })
+
   it('uses the Host limit of 50 and preserves repeated category parameters', async () => {
     const index = catalogIndex()
     const scanCatalog = vi.spyOn(DefaultCatalogService.prototype, 'scanCatalog').mockResolvedValue(index)

--- a/dsh-community-market/tests/market-settings-tab.spec.tsx
+++ b/dsh-community-market/tests/market-settings-tab.spec.tsx
@@ -1502,6 +1502,20 @@ describe('MarketSettingsTab', () => {
     expect(signal?.aborted).toBe(true)
   })
 
+  it('identifies the selected source and a bounded catalog failure reason', async () => {
+    vi.mocked(readMarketState).mockResolvedValue(enabledState)
+    vi.mocked(readMarketCatalog).mockRejectedValue({
+      status: 504,
+      code: 'catalog-timeout',
+      message: 'private upstream URL and response detail',
+    })
+    render(<MarketSettingsTab {...props} />)
+
+    expect(await screen.findByRole('heading', { name: en.catalogError })).toBeTruthy()
+    expect(screen.getByText('Source: Fixture catalog. The catalog request timed out.')).toBeTruthy()
+    expect(screen.queryByText(/private upstream URL/u)).toBeNull()
+  })
+
   it('does not let reads interrupt a pending source selection and aborts it on unmount', async () => {
     const second = makeSecondSource(false)
     vi.mocked(readMarketState).mockResolvedValue({ sources: [firstSource, second], builtIns: [], desktopActions })

--- a/dsh-plugin-desktop/docs/plugin-services.i18n.yaml
+++ b/dsh-plugin-desktop/docs/plugin-services.i18n.yaml
@@ -1,5 +1,5 @@
 # Bilingual-pair consistency record: the git blob hash of each side as of the last
 # confirmed-consistent state. Both languages carry equal authority. Update both files
 # and re-record their hashes with git hash-object after editing either side.
-plugin-services.md: 7373fba2dceac663a56f2c8f6a6083bde28f8331
-plugin-services.zh.md: 108ae9f4f31f794d9ecd7b8639e63bba566a4c22
+plugin-services.md: 806df449c7bbaaa0554ff4152bee7d752558d607
+plugin-services.zh.md: 1c180df559889f775f3e59b6aaae7b5b3907d953

--- a/dsh-plugin-desktop/docs/plugin-services.md
+++ b/dsh-plugin-desktop/docs/plugin-services.md
@@ -88,6 +88,17 @@ interface DesktopPnpm {
     invokingDir: string,
     signal?: AbortSignal,
   ): DesktopPnpmHandle
+  /** @deprecated Use installPlugin(). */
+  runPluginInstall(
+    args: readonly string[],
+    invokingDir: string,
+    recovery: {
+      readonly packageName: string
+      readonly packageVersion: string
+      readonly receiptId: string
+    },
+    signal?: AbortSignal,
+  ): Promise<DesktopPnpmHandle>
   installPlugin(request: {
     readonly pnpmOptions?: readonly string[]
     readonly invokingDir: string
@@ -120,6 +131,7 @@ The actual stream type is Node's `Readable`. Command methods validate non-empty,
 | --- | --- | --- |
 | `run(args, signal?)` | Runs the packaged pnpm JavaScript entry directly, with the active profile directory as `cwd`. | Low-level pnpm work whose caller deliberately does not need DSH plugin reconciliation. |
 | `runPlugin(args, invokingDir, signal?)` | Runs packaged `dsh plugin --profile <active> ...` with the absolute caller directory as CLI `cwd`; upstream DSH changes into the profile for pnpm. | Plugin remove, update, collection repair, or dependency repair. It rejects `add`. |
+| `runPluginInstall(args, invokingDir, recovery, signal?)` | Accepts the v2.0.1 `add` shape only when its single exact target equals the recovery receipt, then delegates to `installPlugin()`. | Deprecated compatibility for released plugin managers; do not use in new integrations. |
 | `installPlugin(request)` | Snapshots the profile, generates the exact `name@version` target, then runs the enforced `dsh plugin ... add` operation and seals or restores the snapshot before `done` settles. | The only supported Desktop plugin-install path. |
 
 `run()` is not a shorter spelling of `runPlugin()`. Direct pnpm does not promise first-use profile initialization, caller-relative `file:` or `link:` source anchoring, or successful `dsh.profile.bundles` reconciliation. A package can appear in dependencies yet fail to join the Loader layer stack if a plugin manager uses the wrong method.
@@ -133,6 +145,8 @@ The actual stream type is Node's `Readable`. Command methods validate non-empty,
 ```
 
 `installPlugin()` owns the recoverable `add` lifecycle. The caller supplies pnpm flags, an absolute invoking directory, and a durable receipt identity. Desktop generates the exact `${packageName}@${packageVersion}` target, snapshots the profile manifest and lockfiles before spawning, restores them after a failed command, and seals the post-install image after success. `receiptId` links the caller's durable receipt ledger to the Desktop WAL. After startup rollback, remove that exact receipt first and only then call `acknowledgeRecoveredInstall(receiptId)`; acknowledgment is idempotent. `rollbackPluginInstall(receiptId)` is limited to the current generation's matching transaction.
+
+`runPluginInstall()` remains available only to avoid breaking v2.0.1 plugin managers. It accepts `['add', ...flags, exactTarget]` only when `exactTarget` is precisely `${recovery.packageName}@${recovery.packageVersion}` and every intermediate argument is a flag. A different command, target, extra positional package, or malformed argument is rejected before any process starts.
 
 The service starts at most one package operation per generation. A second call while one is active throws synchronously. It exposes output instead of choosing a progress UI, and it has no built-in timeout. The consumer owns deadlines, reads both streams, reports progress, calls `cancel()` or aborts its signal when needed, awaits `done`, and checks both `exitCode` and `signal`.
 

--- a/dsh-plugin-desktop/docs/plugin-services.zh.md
+++ b/dsh-plugin-desktop/docs/plugin-services.zh.md
@@ -88,6 +88,17 @@ interface DesktopPnpm {
     invokingDir: string,
     signal?: AbortSignal,
   ): DesktopPnpmHandle
+  /** @deprecated 请使用 installPlugin()。 */
+  runPluginInstall(
+    args: readonly string[],
+    invokingDir: string,
+    recovery: {
+      readonly packageName: string
+      readonly packageVersion: string
+      readonly receiptId: string
+    },
+    signal?: AbortSignal,
+  ): Promise<DesktopPnpmHandle>
   installPlugin(request: {
     readonly pnpmOptions?: readonly string[]
     readonly invokingDir: string
@@ -120,6 +131,7 @@ interface DesktopPnpmHandle {
 | --- | --- | --- |
 | `run(args, signal?)` | 直接执行已打包 pnpm JavaScript entry，以激活 profile 目录为 `cwd`。 | 调用方明确不需要 DSH 插件 reconcile 的低层 pnpm 工作。 |
 | `runPlugin(args, invokingDir, signal?)` | 以调用方绝对目录为 CLI `cwd`，执行已打包 `dsh plugin --profile <active> ...`；上游 DSH 会为 pnpm 进入 profile。 | 插件 remove、update、collection 修复或 dependency 修复。它会拒绝 `add`。 |
+| `runPluginInstall(args, invokingDir, recovery, signal?)` | 仅当 v2.0.1 `add` 形式中的唯一精确目标与恢复 receipt 一致时接受调用，随后委托给 `installPlugin()`。 | 为已发布插件管理器保留的废弃兼容入口；新集成不得使用。 |
 | `installPlugin(request)` | 先快照 profile，生成精确 `name@version` 目标，再执行强制的 `dsh plugin ... add`；`done` settle 前会封存或恢复快照。 | Desktop 唯一受支持的插件安装路径。 |
 
 `run()` 不是 `runPlugin()` 的短写。直接 pnpm 不承诺首次 profile 初始化、调用方相对 `file:` 或 `link:` source 锚定，也不承诺成功后的 `dsh.profile.bundles` reconcile。插件管理器若使用错误方法，package 可能已经出现在 dependency 中，却没有加入 Loader layer stack。
@@ -133,6 +145,8 @@ interface DesktopPnpmHandle {
 ```
 
 `installPlugin()` 拥有可恢复的 `add` 生命周期。调用方提供 pnpm flag、绝对调用目录和持久 receipt 身份。Desktop 会生成精确的 `${packageName}@${packageVersion}` 目标，在 spawn 前快照 profile manifest 与 lockfile，命令失败后恢复，成功后封存安装后图像。`receiptId` 把调用方的持久 receipt ledger 与 Desktop WAL 关联起来。启动回滚后，必须先删除精确 receipt，然后才调用 `acknowledgeRecoveredInstall(receiptId)`；确认操作是幂等的。`rollbackPluginInstall(receiptId)` 仅适用于当前 generation 中匹配的 transaction。
+
+`runPluginInstall()` 仅为避免破坏 v2.0.1 插件管理器而保留。它只接受 `['add', ...flags, exactTarget]`，其中 `exactTarget` 必须精确等于 `${recovery.packageName}@${recovery.packageVersion}`，中间参数必须全部是 flag。命令、目标不符，存在额外位置参数，或参数格式错误时，都会在启动进程前拒绝。
 
 Service 在每个 generation 同时最多启动一个 package operation；已有 operation 活跃时再次调用会同步抛错。它只暴露输出，不选择 progress UI，也没有内置 timeout。Consumer 拥有 deadline、读取两个 stream、报告 progress、在需要时调用 `cancel()` 或 abort signal、等待 `done`，并同时检查 `exitCode` 与 `signal`。
 

--- a/dsh-plugin-desktop/src/pnpm.ts
+++ b/dsh-plugin-desktop/src/pnpm.ts
@@ -88,6 +88,13 @@ export interface DesktopPluginInstallRequest {
 export interface DesktopPnpm {
   run(args: readonly string[], signal?: AbortSignal): DesktopPnpmHandle
   runPlugin(args: readonly string[], invokingDir: string, signal?: AbortSignal): DesktopPnpmHandle
+  /** @deprecated Use `installPlugin()` so Desktop constructs the exact package target. */
+  runPluginInstall(
+    args: readonly string[],
+    invokingDir: string,
+    recovery: DesktopPluginInstallRecovery,
+    signal?: AbortSignal,
+  ): Promise<DesktopPnpmHandle>
   installPlugin(request: DesktopPluginInstallRequest): Promise<DesktopPnpmHandle>
   recoveredInstallReceiptIds(): Promise<readonly string[]>
   acknowledgeRecoveredInstall(receiptId: string): Promise<void>
@@ -239,6 +246,30 @@ class DesktopPnpmService extends Service implements DesktopPnpm {
         ...resolvedArgs,
       ],
       cwd: invokingDir,
+      ...(signal === undefined ? {} : { signal }),
+    })
+  }
+
+  /** Preserve the v2.0.1 install surface without allowing callers to choose another target. */
+  async runPluginInstall(
+    args: readonly string[],
+    invokingDir: string,
+    recovery: DesktopPluginInstallRecovery,
+    signal?: AbortSignal,
+  ): Promise<DesktopPnpmHandle> {
+    const resolvedArgs = validatedArgs(args)
+    const expectedTarget = `${recovery.packageName}@${recovery.packageVersion}`
+    if (
+      resolvedArgs[0] !== 'add'
+      || resolvedArgs.at(-1) !== expectedTarget
+      || resolvedArgs.slice(1, -1).some(argument => !argument.startsWith('-'))
+    ) {
+      throw new Error(`${BIN_NAME}: recoverable plugin install requires the exact receipt target`)
+    }
+    return await this.installPlugin({
+      pnpmOptions: resolvedArgs.slice(1, -1),
+      invokingDir,
+      recovery,
       ...(signal === undefined ? {} : { signal }),
     })
   }

--- a/dsh-plugin-desktop/tests/pnpm.spec.ts
+++ b/dsh-plugin-desktop/tests/pnpm.spec.ts
@@ -271,6 +271,66 @@ describe('desktop pnpm Host service', () => {
     }
   })
 
+  it('keeps the v2.0.1 recoverable install interface for an exact receipt target', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'dsh-desktop-pnpm-legacy-install-'))
+    const selectedBootstrap = bootstrap(root)
+    const child = controlledSubprocess()
+    try {
+      mkdirSync(selectedBootstrap.activeProfileDir, { recursive: true })
+      writeFileSync(join(selectedBootstrap.activeProfileDir, 'package.json'), '{}\n')
+      const harness = await createHarness([child], selectedBootstrap)
+
+      const operation = await harness.service.runPluginInstall(
+        ['add', '--save-exact', 'legacy-plugin@1.2.3'],
+        '/workspace',
+        {
+          packageName: 'legacy-plugin',
+          packageVersion: '1.2.3',
+          receiptId: 'receipt:legacy-install-0001',
+        },
+      )
+
+      expect(harness.spawn.mock.calls[0]?.[0].argv).toEqual([
+        selectedBootstrap.appExecutable,
+        '--expose-internals',
+        selectedBootstrap.dshBootstrapPath,
+        'plugin',
+        '--profile',
+        selectedBootstrap.activeProfileName,
+        'add',
+        '--save-exact',
+        'legacy-plugin@1.2.3',
+      ])
+      finish(child)
+      await operation.done
+      await harness.dispose()
+    } finally {
+      rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  it('rejects legacy recoverable installs that do not match the receipt target', async () => {
+    const harness = await createHarness([])
+    const recovery = {
+      packageName: 'legacy-plugin',
+      packageVersion: '1.2.3',
+      receiptId: 'receipt:legacy-install-invalid-0001',
+    }
+
+    await expect(harness.service.runPluginInstall(
+      ['add', 'other-plugin@1.2.3'],
+      '/workspace',
+      recovery,
+    )).rejects.toThrow('requires the exact receipt target')
+    await expect(harness.service.runPluginInstall(
+      ['add', 'extra-plugin@1.0.0', 'legacy-plugin@1.2.3'],
+      '/workspace',
+      recovery,
+    )).rejects.toThrow('requires the exact receipt target')
+    expect(harness.spawn).not.toHaveBeenCalled()
+    await harness.dispose()
+  })
+
   it('validates operation arguments and the plugin invocation directory before spawning', async () => {
     const harness = await createHarness([])
 


### PR DESCRIPTION
## Summary

- preserve the v2.0.1 recoverable install interface for exact receipt-bound npm targets
- classify built-in catalog failures into bounded timeout, invalid-response, and unavailable codes
- show the selected catalog source and localized failure reason without exposing upstream details

## Verification

- `corepack yarn workspace dsh-plugin-desktop vitest run tests/pnpm.spec.ts` (10 passed)
- `corepack yarn workspace dsh-plugin-desktop typecheck`
- `corepack yarn workspace dsh-community-market test` (272 passed)
- `corepack yarn workspace dsh-community-market typecheck`

## Related issues

- #327: compatibility building block; dshmarket still needs to adopt the recoverable install API
- #346: improves diagnostics; dshfind install targets were fixed separately in #356
- #351: improves diagnostics needed to identify the affected market and source