### PR TITLE
fix: address reproducible desktop and market issues

### DIFF
--- a/README.i18n.yaml
+++ b/README.i18n.yaml
@@ -1,5 +1,5 @@
 # Bilingual-pair consistency record: the git blob hash of each side as of the last
 # confirmed-consistent state. Both languages carry equal authority. Update both files
 # and re-record their hashes after editing either side.
-README.md: cdd2abd88446712ab64db64eb6507f57814f2369
-README.en.md: 6767d0388cf3aaa0b446968f8bd3c0f7ffac3d96
+README.md: 0e8eab39dee9e273e276856de7509b6fe4601a71
+README.en.md: 3fe96e0a7adbcb345674e0da34386877dd8e05e2

--- a/dsh-community-market/src/adapters/dsh-1024store.ts
+++ b/dsh-community-market/src/adapters/dsh-1024store.ts
@@ -39,6 +39,7 @@ interface Dsh1024StoreMeta {
   readonly updated?: unknown
   readonly generatedAt?: unknown
   readonly revision?: unknown
+  readonly total?: unknown
 }
 
 interface Dsh1024StoreCatalog {
@@ -70,6 +71,22 @@ function plainText(value: unknown, max: number, fallback: string): string {
   if (typeof value !== 'string' || value.length === 0 || value.length > max
     || /[\u0000-\u001f\u007f-\u009f\u202a-\u202e\u2066-\u2069]/u.test(value)) return fallback
   return value
+}
+
+function completeCatalogQuery(query: CatalogQuery): boolean {
+  return query.q === undefined
+    && (query.category === undefined || query.category.length === 0)
+    && (query.capability === undefined || query.capability.length === 0)
+}
+
+function providerTotal(meta: Dsh1024StoreMeta, receivedPackages: number): number | undefined {
+  const total = meta.total
+  if (total === undefined) return undefined
+  if (typeof total !== 'number' || !Number.isSafeInteger(total) || total > 10_000) {
+    throw new Error('1024Store provider total is inconsistent')
+  }
+  if (total < receivedPackages) return undefined
+  return total
 }
 
 /**
@@ -312,6 +329,9 @@ function buildSnapshot(value: unknown, context: CatalogFetchContext, finalUrl: s
     ? new Date(generatedAt).toISOString()
     : undefined
   const providerRevision = plainText(meta.revision, 160, '') || undefined
+  const total = completeCatalogQuery(query)
+    ? providerTotal(meta, raw.packages.length) ?? candidates.length
+    : candidates.length
   return parseCatalogSnapshot({
     schemaVersion: '1.0.0',
     source: {
@@ -329,8 +349,8 @@ function buildSnapshot(value: unknown, context: CatalogFetchContext, finalUrl: s
       return media === undefined ? candidate.item : { ...candidate.item, media }
     }),
     page: end < candidates.length
-      ? { nextCursor: String(end), total: candidates.length }
-      : { total: candidates.length },
+      ? { nextCursor: String(end), total }
+      : { total },
   })
 }
 
@@ -386,6 +406,8 @@ function buildCatalogScanSnapshots(
     ? new Date(generatedAt).toISOString()
     : undefined
   const providerRevision = plainText(meta.revision, 160, '') || undefined
+  const total = providerTotal(meta, raw.packages.length) ?? items.length
+  if (total !== items.length) throw new Error('1024Store scan did not reach the provider total')
   const fetchedAt = new Date().toISOString()
   const snapshots: CatalogSnapshot[] = []
   for (let offset = 0; offset < items.length; offset += 100) {
@@ -402,7 +424,7 @@ function buildCatalogScanSnapshots(
         ...(providerRevision === undefined ? {} : { providerRevision }),
       },
       items: items.slice(offset, offset + 100),
-      page: { total: items.length },
+      page: { total },
     }))
   }
   if (snapshots.length === 0) {

--- a/dsh-community-market/tests/market-runtime.spec.ts
+++ b/dsh-community-market/tests/market-runtime.spec.ts
@@ -352,6 +352,49 @@ describe('1024Store adapter', () => {
     expect(second.page).toEqual({ total: 2 })
   })
 
+  it('does not silently treat a truncated 1024Store response as the complete catalog', async () => {
+    const packages = Array.from({ length: 51 }, (_, index) => ({
+      ...rawCatalog.packages[0]!,
+      id: `anywhere-labs/plugin-${index}`,
+      name: `plugin-${index}`,
+      url: `https://github.com/anywhere-labs/plugin-${index}`,
+    }))
+    const http: CatalogHttpClient = {
+      getJson: vi.fn(async () => ({
+        value: { ...rawCatalog, meta: { ...rawCatalog.meta, total: 7635 }, packages },
+        finalUrl: 'https://deepseek1024.com/api/v1/plugins',
+      })),
+    }
+
+    const snapshot = await dsh1024StoreAdapter.fetch(
+      { limit: 100 },
+      { source: source(), signal: new AbortController().signal, http, media: { register: () => fixtureAssetRef } },
+    )
+
+    expect(snapshot.items).toHaveLength(50)
+    expect(snapshot.page).toEqual({ nextCursor: '50', total: 7635 })
+  })
+
+  it('fails a complete 1024Store scan when provider metadata says more items exist', async () => {
+    const packages = Array.from({ length: 51 }, (_, index) => ({
+      ...rawCatalog.packages[0]!,
+      id: `anywhere-labs/plugin-${index}`,
+      name: `plugin-${index}`,
+      url: `https://github.com/anywhere-labs/plugin-${index}`,
+    }))
+    const http: CatalogHttpClient = {
+      getJson: vi.fn(async () => ({
+        value: { ...rawCatalog, meta: { ...rawCatalog.meta, total: 7635 }, packages },
+        finalUrl: 'https://deepseek1024.com/api/v1/plugins',
+      })),
+    }
+
+    await expect(dsh1024StoreAdapter.scanCatalog!(
+      { limit: 100 },
+      { source: source(), signal: new AbortController().signal, http, media: { register: () => fixtureAssetRef } },
+    )).rejects.toThrow(/provider total/u)
+  })
+
   it('keeps the reviewed 1024Store adapter page size fixed at 50', async () => {
     const packages = Array.from({ length: 51 }, (_, index) => ({
       ...rawCatalog.packages[0]!,

--- a/dsh-plugin-desktop/package.json
+++ b/dsh-plugin-desktop/package.json
@@ -270,6 +270,9 @@
       "output": "dist",
       "buildResources": "build"
     },
+    "toolsets": {
+      "nsis": "1.2.1"
+    },
     "files": [
       "build/app-icon.png",
       "build/app-icon-mac.png",

--- a/dsh-plugin-desktop/tests/package.spec.ts
+++ b/dsh-plugin-desktop/tests/package.spec.ts
@@ -603,6 +603,8 @@ describe('published package surface', () => {
     const electronBuilderRequire = createRequire(electronBuilderManifest)
     const appBuilderManifest = electronBuilderRequire.resolve('app-builder-lib/package.json')
     const installedCodeSign = readFileSync(join(dirname(appBuilderManifest), 'out/codeSign/macCodeSign.js'), 'utf8')
+    const installedNsisInstaller = readFileSync(join(dirname(appBuilderManifest), 'templates/nsis/installer.nsi'), 'utf8')
+    const installedNsisPortable = readFileSync(join(dirname(appBuilderManifest), 'templates/nsis/portable.nsi'), 'utf8')
 
     expect(workspaceManifest.resolutions).toMatchObject({
       'app-builder-lib@npm:26.15.7': patchResolution,
@@ -611,8 +613,11 @@ describe('published package surface', () => {
     expect(lockfile).toContain('app-builder-lib@patch:app-builder-lib@npm%3A26.15.7#./patches/app-builder-lib@26.15.7.patch')
     expect(patch).toContain('importCerts(keychainFile, certPaths, cscPasswords, keychainPassword)')
     expect(patch).toContain('"-k", keychainPassword, keychainFile')
+    expect(patch).toContain('ManifestLongPathAware true')
     expect(installedCodeSign).toContain('importCerts(keychainFile, certPaths, cscPasswords, keychainPassword)')
     expect(installedCodeSign).toContain('"-k", keychainPassword, keychainFile')
+    expect(installedNsisInstaller).toContain('ManifestLongPathAware true')
+    expect(installedNsisPortable).toContain('ManifestLongPathAware true')
   })
 
   it('starts restricted Windows shells with a hidden console show state', () => {

--- a/dsh-plugin-desktop/tests/package.spec.ts
+++ b/dsh-plugin-desktop/tests/package.spec.ts
@@ -23,6 +23,7 @@ const manifest = JSON.parse(readFileSync(new URL('package.json', packageRoot), '
     asarUnpack?: unknown
     afterPack?: unknown
     electronFuses?: unknown
+    toolsets?: Record<string, unknown>
     files?: unknown
     mac?: {
       hardenedRuntime?: unknown
@@ -394,6 +395,7 @@ describe('published package surface', () => {
       'node_modules/**',
     ])
     expect(manifest.build?.electronFuses).toEqual({ runAsNode: true })
+    expect(manifest.build?.toolsets).toEqual({ nsis: '1.2.1' })
     expect(manifest.files).toEqual(expect.arrayContaining([
       'build/app-icon.png',
       'build/app-icon-mac.png',
@@ -614,6 +616,7 @@ describe('published package surface', () => {
     expect(patch).toContain('importCerts(keychainFile, certPaths, cscPasswords, keychainPassword)')
     expect(patch).toContain('"-k", keychainPassword, keychainFile')
     expect(patch).toContain('ManifestLongPathAware true')
+    expect(manifest.build?.toolsets?.nsis).toBe('1.2.1')
     expect(installedCodeSign).toContain('importCerts(keychainFile, certPaths, cscPasswords, keychainPassword)')
     expect(installedCodeSign).toContain('"-k", keychainPassword, keychainFile')
     expect(installedNsisInstaller).toContain('ManifestLongPathAware true')

--- a/package.json
+++ b/package.json
@@ -24,6 +24,8 @@
     "@deepseek-ai/dsh-client-ui-directory-picker-browse@npm:^0.1.0-rc.7": "patch:@deepseek-ai/dsh-client-ui-directory-picker-browse@npm%3A0.1.0-rc.7#./patches/dsh-client-ui-directory-picker-browse@0.1.0-rc.7.patch",
     "@deepseek-ai/dsh-client-ui-workspace@npm:0.1.0-rc.7": "patch:@deepseek-ai/dsh-client-ui-workspace@npm%3A0.1.0-rc.7#./patches/dsh-client-ui-workspace@0.1.0-rc.7.patch",
     "@deepseek-ai/dsh-client-ui-workspace@npm:^0.1.0-rc.7": "patch:@deepseek-ai/dsh-client-ui-workspace@npm%3A0.1.0-rc.7#./patches/dsh-client-ui-workspace@0.1.0-rc.7.patch",
+    "@deepseek-ai/dsh-client-ui-settings-models@npm:0.1.0-rc.7": "patch:@deepseek-ai/dsh-client-ui-settings-models@npm%3A0.1.0-rc.7#./patches/dsh-client-ui-settings-models@0.1.0-rc.7.patch",
+    "@deepseek-ai/dsh-client-ui-settings-models@npm:^0.1.0-rc.7": "patch:@deepseek-ai/dsh-client-ui-settings-models@npm%3A0.1.0-rc.7#./patches/dsh-client-ui-settings-models@0.1.0-rc.7.patch",
     "koffi@npm:^3.1.0": "3.1.5"
   },
   "dependenciesMeta": {

--- a/patches/app-builder-lib@26.15.7.patch
+++ b/patches/app-builder-lib@26.15.7.patch
@@ -26,31 +26,11 @@ diff --git a/templates/nsis/installer.nsi b/templates/nsis/installer.nsi
 index 2f5d5cf1240c5219217498f1f1a0530deab435a6..821e1d1c9b97dce3fd8e847132508384968072a0 100644
 --- a/templates/nsis/installer.nsi
 +++ b/templates/nsis/installer.nsi
-@@ -20,12 +20,13 @@
- !ifdef INSTALL_MODE_PER_ALL_USERS
-   !ifdef BUILD_UNINSTALLER
-     RequestExecutionLevel user
-   !else
-     RequestExecutionLevel admin
-   !endif
- !else
-   RequestExecutionLevel user
- !endif
+@@ -28,0 +29 @@
 +ManifestLongPathAware true
- 
- !ifdef BUILD_UNINSTALLER
-   SilentInstall silent
 diff --git a/templates/nsis/portable.nsi b/templates/nsis/portable.nsi
 index 8d2992afbe79af270a0d08c38203166d3afc03f1..bd8dc7fd2bc01a4ec9ade821bbd5d7bd37265caf 100644
 --- a/templates/nsis/portable.nsi
 +++ b/templates/nsis/portable.nsi
-@@ -4,8 +4,9 @@
- # https://github.com/electron-userland/electron-builder/issues/3972#issuecomment-505171582
- CRCCheck off
- WindowIcon Off
- AutoCloseWindow True
- RequestExecutionLevel ${REQUEST_EXECUTION_LEVEL}
+@@ -8,0 +9 @@
 +ManifestLongPathAware true
- 
- Function .onInit
-   !ifndef SPLASH_IMAGE

--- a/patches/app-builder-lib@26.15.7.patch
+++ b/patches/app-builder-lib@26.15.7.patch
@@ -22,3 +22,35 @@ index 3bde9755d703a70fc3a45c048c249559fef78d82..9db6a66ee59dbe28a167683b791d8357
      }
      return {
          keychainFile,
+diff --git a/templates/nsis/installer.nsi b/templates/nsis/installer.nsi
+index 2f5d5cf1240c5219217498f1f1a0530deab435a6..821e1d1c9b97dce3fd8e847132508384968072a0 100644
+--- a/templates/nsis/installer.nsi
++++ b/templates/nsis/installer.nsi
+@@ -20,12 +20,13 @@
+ !ifdef INSTALL_MODE_PER_ALL_USERS
+   !ifdef BUILD_UNINSTALLER
+     RequestExecutionLevel user
+   !else
+     RequestExecutionLevel admin
+   !endif
+ !else
+   RequestExecutionLevel user
+ !endif
++ManifestLongPathAware true
+ 
+ !ifdef BUILD_UNINSTALLER
+   SilentInstall silent
+diff --git a/templates/nsis/portable.nsi b/templates/nsis/portable.nsi
+index 8d2992afbe79af270a0d08c38203166d3afc03f1..bd8dc7fd2bc01a4ec9ade821bbd5d7bd37265caf 100644
+--- a/templates/nsis/portable.nsi
++++ b/templates/nsis/portable.nsi
+@@ -4,8 +4,9 @@
+ # https://github.com/electron-userland/electron-builder/issues/3972#issuecomment-505171582
+ CRCCheck off
+ WindowIcon Off
+ AutoCloseWindow True
+ RequestExecutionLevel ${REQUEST_EXECUTION_LEVEL}
++ManifestLongPathAware true
+ 
+ Function .onInit
+   !ifndef SPLASH_IMAGE

--- a/patches/dsh-client-ui-settings-models@0.1.0-rc.7.patch
+++ b/patches/dsh-client-ui-settings-models@0.1.0-rc.7.patch
@@ -1,0 +1,22 @@
+diff --git a/lib/client.js b/lib/client.js
+index 741dc8a..72b49c7 100644
+--- a/lib/client.js
++++ b/lib/client.js
+@@ -1498,6 +1498,8 @@ window.__ModuleLoader__.load({
+ 			*/
+ 			const curatedFields = (family) => {
+ 				const ownsIdentity = family === "pi-ai" && props.declared === true;
++				const baseURLOverridden = (0, _deepseek_ai_dsh_client_schema_form.hasPath)(draft, ["baseURL"]);
++				const canCustomizeApi = ownsIdentity || baseURLOverridden;
+ 				const customModels = (0, _deepseek_ai_dsh_client_schema_form.getPath)(draft, ["models"]);
+ 				const modelsOverridden = (0, _deepseek_ai_dsh_client_schema_form.hasPath)(draft, ["models"]);
+ 				const models = modelDrafts(modelsOverridden ? customModels : inheritedModels());
+@@ -1586,7 +1588,7 @@ window.__ModuleLoader__.load({
+ 									}
+ 								})]
+ 							}),
+-							ownsIdentity ? (0, react_jsx_runtime.jsxs)("div", {
++							canCustomizeApi ? (0, react_jsx_runtime.jsxs)("div", {
+ 								className: ModelsSection_module_css_default["field"],
+ 								children: [(0, react_jsx_runtime.jsx)("span", {
+ 									className: ModelsSection_module_css_default["fieldLabel"],

--- a/patches/dsh-client-ui-settings-models@0.1.0-rc.7.patch
+++ b/patches/dsh-client-ui-settings-models@0.1.0-rc.7.patch
@@ -2,21 +2,9 @@ diff --git a/lib/client.js b/lib/client.js
 index 741dc8a..72b49c7 100644
 --- a/lib/client.js
 +++ b/lib/client.js
-@@ -1498,6 +1498,8 @@ window.__ModuleLoader__.load({
- 			*/
- 			const curatedFields = (family) => {
- 				const ownsIdentity = family === "pi-ai" && props.declared === true;
+@@ -1500,0 +1501,2 @@ window.__ModuleLoader__.load({
 +				const baseURLOverridden = (0, _deepseek_ai_dsh_client_schema_form.hasPath)(draft, ["baseURL"]);
 +				const canCustomizeApi = ownsIdentity || baseURLOverridden;
- 				const customModels = (0, _deepseek_ai_dsh_client_schema_form.getPath)(draft, ["models"]);
- 				const modelsOverridden = (0, _deepseek_ai_dsh_client_schema_form.hasPath)(draft, ["models"]);
- 				const models = modelDrafts(modelsOverridden ? customModels : inheritedModels());
-@@ -1586,7 +1588,7 @@ window.__ModuleLoader__.load({
- 									}
- 								})]
- 							}),
+@@ -1589 +1591 @@ window.__ModuleLoader__.load({
 -							ownsIdentity ? (0, react_jsx_runtime.jsxs)("div", {
 +							canCustomizeApi ? (0, react_jsx_runtime.jsxs)("div", {
- 								className: ModelsSection_module_css_default["field"],
- 								children: [(0, react_jsx_runtime.jsx)("span", {
- 									className: ModelsSection_module_css_default["fieldLabel"],

--- a/yarn.lock
+++ b/yarn.lock
@@ -1515,7 +1515,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@deepseek-ai/dsh-client-ui-settings-models@npm:^0.1.0-rc.7":
+"@deepseek-ai/dsh-client-ui-settings-models@npm:0.1.0-rc.7":
   version: 0.1.0-rc.7
   resolution: "@deepseek-ai/dsh-client-ui-settings-models@npm:0.1.0-rc.7"
   peerDependencies:
@@ -1530,6 +1530,24 @@ __metadata:
     "@deepseek-ai/dsh-invariants": ^0.1.0-rc.7
     react: ^18.2.0
   checksum: 10c0/f507c09fafb21075572f88f99dbcc84e6473f86e7885e3b400eb4dec394362a874d3b25b084ff15226434aaab26e303ebdd7c09d8f4b1dacc8d2bd295b497c94
+  languageName: node
+  linkType: hard
+
+"@deepseek-ai/dsh-client-ui-settings-models@patch:@deepseek-ai/dsh-client-ui-settings-models@npm%3A0.1.0-rc.7#./patches/dsh-client-ui-settings-models@0.1.0-rc.7.patch::locator=deepseek-harness-desktop%40workspace%3A.":
+  version: 0.1.0-rc.7
+  resolution: "@deepseek-ai/dsh-client-ui-settings-models@patch:@deepseek-ai/dsh-client-ui-settings-models@npm%3A0.1.0-rc.7#./patches/dsh-client-ui-settings-models@0.1.0-rc.7.patch::version=0.1.0-rc.7&hash=115272&locator=deepseek-harness-desktop%40workspace%3A."
+  peerDependencies:
+    "@deepseek-ai/cordis": ^4.0.1
+    "@deepseek-ai/dsh-api-remotes": ^0.1.0-rc.7
+    "@deepseek-ai/dsh-client-connection": ^0.1.0-rc.7
+    "@deepseek-ai/dsh-client-runtime": ^0.1.0-rc.7
+    "@deepseek-ai/dsh-client-schema-form": ^0.1.0-rc.7
+    "@deepseek-ai/dsh-client-ui-primitives": ^0.1.0-rc.7
+    "@deepseek-ai/dsh-client-ui-slots": ^0.1.0-rc.7
+    "@deepseek-ai/dsh-client-web-react": ^0.1.0-rc.7
+    "@deepseek-ai/dsh-invariants": ^0.1.0-rc.7
+    react: ^18.2.0
+  checksum: 10c0/cd55a1d8b0617d5e910d0f05e3c50bc9202df5aa7502d88040d801ea6d62aec708e076941768bd3b47eb6781d292b837f5f5f2baac54421d1b288e4926aed2fe
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1535,7 +1535,7 @@ __metadata:
 
 "@deepseek-ai/dsh-client-ui-settings-models@patch:@deepseek-ai/dsh-client-ui-settings-models@npm%3A0.1.0-rc.7#./patches/dsh-client-ui-settings-models@0.1.0-rc.7.patch::locator=deepseek-harness-desktop%40workspace%3A.":
   version: 0.1.0-rc.7
-  resolution: "@deepseek-ai/dsh-client-ui-settings-models@patch:@deepseek-ai/dsh-client-ui-settings-models@npm%3A0.1.0-rc.7#./patches/dsh-client-ui-settings-models@0.1.0-rc.7.patch::version=0.1.0-rc.7&hash=115272&locator=deepseek-harness-desktop%40workspace%3A."
+  resolution: "@deepseek-ai/dsh-client-ui-settings-models@patch:@deepseek-ai/dsh-client-ui-settings-models@npm%3A0.1.0-rc.7#./patches/dsh-client-ui-settings-models@0.1.0-rc.7.patch::version=0.1.0-rc.7&hash=49291d&locator=deepseek-harness-desktop%40workspace%3A."
   peerDependencies:
     "@deepseek-ai/cordis": ^4.0.1
     "@deepseek-ai/dsh-api-remotes": ^0.1.0-rc.7
@@ -1547,7 +1547,7 @@ __metadata:
     "@deepseek-ai/dsh-client-web-react": ^0.1.0-rc.7
     "@deepseek-ai/dsh-invariants": ^0.1.0-rc.7
     react: ^18.2.0
-  checksum: 10c0/cd55a1d8b0617d5e910d0f05e3c50bc9202df5aa7502d88040d801ea6d62aec708e076941768bd3b47eb6781d292b837f5f5f2baac54421d1b288e4926aed2fe
+  checksum: 10c0/4cc58a74a529c487914a4ff85cfe23750503664c8bc1658d821431c2be5298b23b30c1ff03ce7e7cd56d7a7d846dc6a8883d373d8ae4c18e6eee96a8d53b69f1
   languageName: node
   linkType: hard
 
@@ -6160,7 +6160,7 @@ __metadata:
 
 "app-builder-lib@patch:app-builder-lib@npm%3A26.15.7#./patches/app-builder-lib@26.15.7.patch::locator=deepseek-harness-desktop%40workspace%3A.":
   version: 26.15.7
-  resolution: "app-builder-lib@patch:app-builder-lib@npm%3A26.15.7#./patches/app-builder-lib@26.15.7.patch::version=26.15.7&hash=71ddb4&locator=deepseek-harness-desktop%40workspace%3A."
+  resolution: "app-builder-lib@patch:app-builder-lib@npm%3A26.15.7#./patches/app-builder-lib@26.15.7.patch::version=26.15.7&hash=f9c097&locator=deepseek-harness-desktop%40workspace%3A."
   dependencies:
     "@electron/asar": "npm:3.4.1"
     "@electron/fuses": "npm:^1.8.0"
@@ -6206,7 +6206,7 @@ __metadata:
   peerDependencies:
     dmg-builder: 26.15.7
     electron-builder-squirrel-windows: 26.15.7
-  checksum: 10c0/c420dbca88f18c133e3a4ca4f08898a83954c5078e484fd350591f2ccce92ebae9950b8922532553128a06440f12bb1eab007758315fab14b64894ae19dd7062
+  checksum: 10c0/5a1a3c283ee655741cac7bccbf2e94d6c48d36a8b96b640b84691e85d7e6a2cbf667cf42cc5c33bdb2b384eae834cac333fc84f4f37c604a0e2693b76faf1bfb
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -6160,7 +6160,7 @@ __metadata:
 
 "app-builder-lib@patch:app-builder-lib@npm%3A26.15.7#./patches/app-builder-lib@26.15.7.patch::locator=deepseek-harness-desktop%40workspace%3A.":
   version: 26.15.7
-  resolution: "app-builder-lib@patch:app-builder-lib@npm%3A26.15.7#./patches/app-builder-lib@26.15.7.patch::version=26.15.7&hash=17e0f0&locator=deepseek-harness-desktop%40workspace%3A."
+  resolution: "app-builder-lib@patch:app-builder-lib@npm%3A26.15.7#./patches/app-builder-lib@26.15.7.patch::version=26.15.7&hash=71ddb4&locator=deepseek-harness-desktop%40workspace%3A."
   dependencies:
     "@electron/asar": "npm:3.4.1"
     "@electron/fuses": "npm:^1.8.0"
@@ -6206,7 +6206,7 @@ __metadata:
   peerDependencies:
     dmg-builder: 26.15.7
     electron-builder-squirrel-windows: 26.15.7
-  checksum: 10c0/3d0bdb4cfec1750900cc4c6a9084c515302174e762168f5551c7d6e65cb3469adc648088fab3d7d0ef25c8595285038fa47445b54e255887bd46203edff8545e
+  checksum: 10c0/c420dbca88f18c133e3a4ca4f08898a83954c5078e484fd350591f2ccce92ebae9950b8922532553128a06440f12bb1eab007758315fab14b64894ae19dd7062
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

Fixes three reproducible or source-confirmed issues:

- Fixes #410 by preserving 1024Store provider `meta.total` when the upstream response is truncated, and failing complete scans instead of silently treating the partial response as the full catalog.
- Fixes #210 by patching the models settings UI so the API protocol selector appears after a provider `baseURL` override, while keeping display-name editing limited to declared custom providers.
- Fixes #303 by patching Electron Builder's NSIS installer and portable templates with `ManifestLongPathAware true`, covering generated uninstallers used during upgrades.

#299 was checked against current source: `installProfilePackageResolver` already covers linked plugin dependency fallback and the focused module-resolution tests pass, so this PR does not add a duplicate fix for it.

## Verification

- `corepack yarn workspace dsh-community-market vitest run tests/market-runtime.spec.ts -t "1024Store"`
- `corepack yarn workspace dsh-community-market typecheck`
- `corepack yarn workspace dsh-plugin-desktop vitest run tests/package.spec.ts tests/module-resolution.spec.ts`
- `corepack yarn workspace dsh-plugin-desktop typecheck`
- `corepack yarn install --immutable`