### PR TITLE
fix(desktop): keep hidden macOS window recoverable

### DIFF
--- a/README.i18n.yaml
+++ b/README.i18n.yaml
@@ -1,5 +1,5 @@
 # Bilingual-pair consistency record: the git blob hash of each side as of the last
 # confirmed-consistent state. Both languages carry equal authority. Update both files
 # and re-record their hashes after editing either side.
-README.md: cdd2abd88446712ab64db64eb6507f57814f2369
-README.en.md: 6767d0388cf3aaa0b446968f8bd3c0f7ffac3d96
+README.md: 0e8eab39dee9e273e276856de7509b6fe4601a71
+README.en.md: 3fe96e0a7adbcb345674e0da34386877dd8e05e2

--- a/dsh-plugin-desktop/src/electron-platform.ts
+++ b/dsh-plugin-desktop/src/electron-platform.ts
@@ -1,7 +1,13 @@
-import { app } from 'electron'
+import { app, Menu } from 'electron'
 import type { BrowserWindow, NativeImage } from 'electron'
 import type { DesktopPlatform } from './runtime.ts'
 import type { DesktopDownloadPlatform } from './update-download.ts'
+
+export interface ElectronApplicationMenuOptions {
+  readonly productName: string
+  readonly openDesktopLabel: string
+  readonly showDesktop: () => void
+}
 
 /** Native presentation and capability differences selected once at startup. */
 export interface ElectronPlatformStrategy {
@@ -11,6 +17,7 @@ export interface ElectronPlatformStrategy {
   readonly canToggleShellMode: boolean
   configureApplication(icon: NativeImage): void
   configureWindow(window: BrowserWindow): void
+  installApplicationMenu(options: ElectronApplicationMenuOptions): () => void
   refreshThemeMaterial(window: BrowserWindow): void
 }
 
@@ -24,6 +31,10 @@ class WindowsPlatformStrategy implements ElectronPlatformStrategy {
 
   configureWindow(window: BrowserWindow): void {
     window.removeMenu()
+  }
+
+  installApplicationMenu(_options: ElectronApplicationMenuOptions): () => void {
+    return () => {}
   }
 
   refreshThemeMaterial(window: BrowserWindow): void {
@@ -43,6 +54,36 @@ class MacPlatformStrategy implements ElectronPlatformStrategy {
 
   configureWindow(_window: BrowserWindow): void {}
 
+  installApplicationMenu(options: ElectronApplicationMenuOptions): () => void {
+    const previousMenu = Menu.getApplicationMenu()
+    const menu = Menu.buildFromTemplate([
+      {
+        label: options.productName,
+        submenu: [
+          { role: 'about' },
+          { type: 'separator' },
+          { label: options.openDesktopLabel, click: options.showDesktop },
+          { type: 'separator' },
+          { role: 'services' },
+          { type: 'separator' },
+          { role: 'hide' },
+          { role: 'hideOthers' },
+          { role: 'unhide' },
+          { type: 'separator' },
+          { role: 'quit' },
+        ],
+      },
+      { role: 'fileMenu' },
+      { role: 'editMenu' },
+      { role: 'viewMenu' },
+      { role: 'windowMenu' },
+    ])
+    Menu.setApplicationMenu(menu)
+    return () => {
+      if (Menu.getApplicationMenu() === menu) Menu.setApplicationMenu(previousMenu)
+    }
+  }
+
   refreshThemeMaterial(_window: BrowserWindow): void {}
 }
 
@@ -55,6 +96,10 @@ class LinuxPlatformStrategy implements ElectronPlatformStrategy {
   configureApplication(_icon: NativeImage): void {}
 
   configureWindow(_window: BrowserWindow): void {}
+
+  installApplicationMenu(_options: ElectronApplicationMenuOptions): () => void {
+    return () => {}
+  }
 
   refreshThemeMaterial(_window: BrowserWindow): void {}
 }

--- a/dsh-plugin-desktop/src/electron-runtime.ts
+++ b/dsh-plugin-desktop/src/electron-runtime.ts
@@ -222,6 +222,7 @@ export class ElectronDesktopRuntime implements DesktopRuntime {
         spec,
         preloadPath: desktopPreloadPath(),
         isQuitting: () => this.quitting,
+        applicationMenuOpenLabel: () => desktopTrayLabel(this.locale, 'openDesktop', spec.productName),
         buildTrayTemplate: () => this.buildTrayTemplate(spec),
         stopRendererBootMonitoring: () => { this.stopRendererBootMonitoring() },
         abortRendererBootMonitoring: cause => { this.rendererHealthGate?.stop(cause) },
@@ -386,7 +387,7 @@ export class ElectronDesktopRuntime implements DesktopRuntime {
     const locale = preference ?? desktopLocaleFromLanguageTag(app.getLocale())
     if (locale === this.currentLocale) return
     this.currentLocale = locale
-    this.rebuildTrayMenu()
+    this.rebuildNativeMenus()
   }
 
   /** @inheritdoc */
@@ -728,5 +729,11 @@ export class ElectronDesktopRuntime implements DesktopRuntime {
     const spec = this.scheduled
     if (spec === undefined) return
     this.generation?.refreshTrayMenu()
+  }
+
+  private rebuildNativeMenus(): void {
+    const spec = this.scheduled
+    if (spec === undefined) return
+    this.generation?.refreshMenus()
   }
 }

--- a/dsh-plugin-desktop/src/electron-shell-generation.ts
+++ b/dsh-plugin-desktop/src/electron-shell-generation.ts
@@ -35,6 +35,7 @@ export interface ElectronShellGenerationOptions {
   readonly spec: DesktopShellSpec
   readonly preloadPath: string
   readonly isQuitting: () => boolean
+  readonly applicationMenuOpenLabel: () => string
   readonly buildTrayTemplate: () => Electron.MenuItemConstructorOptions[]
   readonly stopRendererBootMonitoring: () => void
   readonly abortRendererBootMonitoring: (cause: unknown) => void
@@ -49,6 +50,7 @@ export class ElectronShellGeneration {
   private mounted = false
   private released = false
   private attentionCount = 0
+  private releaseApplicationMenu: (() => void) | undefined
   private cleanupListeners: (() => void) | undefined
 
   constructor(private readonly options: ElectronShellGenerationOptions) {}
@@ -178,7 +180,7 @@ export class ElectronShellGeneration {
       tray = new Tray(prepareTrayIcon(spec.trayIcons, platform.platform))
       this.tray = tray
       tray.setToolTip(spec.productName)
-      this.refreshTrayMenu()
+      this.refreshMenus()
       tray.on('click', show)
       beforeInteractive?.()
       this.mounted = true
@@ -219,9 +221,23 @@ export class ElectronShellGeneration {
       : await dialog.showOpenDialog(window, options)
   }
 
+  refreshMenus(): void {
+    this.refreshApplicationMenu()
+    this.refreshTrayMenu()
+  }
+
   refreshTrayMenu(): void {
     if (this.tray === undefined) return
     this.tray.setContextMenu(Menu.buildFromTemplate(this.options.buildTrayTemplate()))
+  }
+
+  private refreshApplicationMenu(): void {
+    this.releaseApplicationMenu?.()
+    this.releaseApplicationMenu = this.options.platform.installApplicationMenu({
+      productName: this.options.spec.productName,
+      openDesktopLabel: this.options.applicationMenuOpenLabel(),
+      showDesktop: () => { this.show() },
+    })
   }
 
   refreshThemeMaterial(): void {
@@ -235,13 +251,16 @@ export class ElectronShellGeneration {
 
     const window = this.window
     const tray = this.tray
+    const releaseApplicationMenu = this.releaseApplicationMenu
     this.clearAttention()
     this.window = undefined
     this.tray = undefined
+    this.releaseApplicationMenu = undefined
     if (window === undefined) return
 
     this.cleanupListeners?.()
     this.cleanupListeners = undefined
+    releaseApplicationMenu?.()
     tray?.destroy()
     if (!window.isDestroyed()) window.destroy()
   }

--- a/dsh-plugin-desktop/tests/electron-platform.spec.ts
+++ b/dsh-plugin-desktop/tests/electron-platform.spec.ts
@@ -1,16 +1,38 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { electronPlatformStrategy } from '../src/electron-platform.ts'
 
-const electron = vi.hoisted(() => ({
-  app: {
-    dock: {
-      setIcon: vi.fn(),
+const electron = vi.hoisted(() => {
+  const previousApplicationMenu = { name: 'previous application menu' }
+  let applicationMenu: unknown = previousApplicationMenu
+  const menuTemplates: unknown[][] = []
+  return {
+    app: {
+      dock: {
+        setIcon: vi.fn(),
+      },
     },
-  },
-}))
+    Menu: {
+      buildFromTemplate: vi.fn((template: unknown[]) => {
+        menuTemplates.push(template)
+        return { template }
+      }),
+      getApplicationMenu: vi.fn(() => applicationMenu),
+      setApplicationMenu: vi.fn((menu: unknown) => { applicationMenu = menu }),
+    },
+    menuTemplates,
+    previousApplicationMenu,
+    replaceApplicationMenu(menu: unknown) { applicationMenu = menu },
+    resetApplicationMenu() {
+      applicationMenu = previousApplicationMenu
+      menuTemplates.length = 0
+    },
+    currentApplicationMenu: () => applicationMenu,
+  }
+})
 
 vi.mock('electron', () => ({
   app: electron.app,
+  Menu: electron.Menu,
 }))
 
 function createWindow(): {
@@ -25,7 +47,8 @@ function createWindow(): {
 
 describe('electronPlatformStrategy', () => {
   beforeEach(() => {
-    electron.app.dock.setIcon.mockClear()
+    electron.resetApplicationMenu()
+    vi.clearAllMocks()
   })
 
   it('selects the Windows adapter and configures native window chrome', () => {
@@ -40,17 +63,25 @@ describe('electronPlatformStrategy', () => {
 
     strategy.configureApplication(icon)
     strategy.configureWindow(window as never)
+    const disposeMenu = strategy.installApplicationMenu({
+      productName: 'DSH Desktop',
+      openDesktopLabel: 'Open DSH Desktop',
+      showDesktop: vi.fn(),
+    })
     strategy.refreshThemeMaterial(window as never)
+    disposeMenu()
 
     expect(electron.app.dock.setIcon).not.toHaveBeenCalled()
+    expect(electron.Menu.setApplicationMenu).not.toHaveBeenCalled()
     expect(window.removeMenu).toHaveBeenCalledTimes(1)
     expect(window.setBackgroundMaterial).toHaveBeenCalledWith('mica')
   })
 
-  it('selects the macOS adapter and updates the dock icon only', () => {
+  it('selects the macOS adapter and installs a recoverable application menu', () => {
     const strategy = electronPlatformStrategy('darwin')
     const window = createWindow()
     const icon = {} as Parameters<typeof strategy.configureApplication>[0]
+    const showDesktop = vi.fn()
 
     expect(strategy.platform).toBe('darwin')
     expect(strategy.updateDownloadPlatform).toBe('darwin')
@@ -59,11 +90,58 @@ describe('electronPlatformStrategy', () => {
 
     strategy.configureApplication(icon)
     strategy.configureWindow(window as never)
+    const disposeMenu = strategy.installApplicationMenu({
+      productName: 'DSH Desktop',
+      openDesktopLabel: 'Open DSH Desktop',
+      showDesktop,
+    })
     strategy.refreshThemeMaterial(window as never)
 
     expect(electron.app.dock.setIcon).toHaveBeenCalledWith(icon)
     expect(window.removeMenu).not.toHaveBeenCalled()
     expect(window.setBackgroundMaterial).not.toHaveBeenCalled()
+    expect(electron.Menu.setApplicationMenu).toHaveBeenCalledOnce()
+
+    const applicationMenu = electron.menuTemplates[0]?.[0] as {
+      label?: string
+      submenu?: Array<{ label?: string, role?: string, type?: string, click?: () => void }>
+    }
+    expect(applicationMenu.label).toBe('DSH Desktop')
+    expect(applicationMenu.submenu).toEqual(expect.arrayContaining([
+      expect.objectContaining({ role: 'about' }),
+      expect.objectContaining({ label: 'Open DSH Desktop' }),
+      expect.objectContaining({ role: 'services' }),
+      expect.objectContaining({ role: 'hide' }),
+      expect.objectContaining({ role: 'quit' }),
+    ]))
+    expect(electron.menuTemplates[0]?.slice(1)).toEqual([
+      { role: 'fileMenu' },
+      { role: 'editMenu' },
+      { role: 'viewMenu' },
+      { role: 'windowMenu' },
+    ])
+
+    applicationMenu.submenu?.find(item => item.label === 'Open DSH Desktop')?.click?.()
+    expect(showDesktop).toHaveBeenCalledOnce()
+
+    disposeMenu()
+    expect(electron.currentApplicationMenu()).toBe(electron.previousApplicationMenu)
+  })
+
+  it('does not overwrite an application menu that replaced the macOS generation menu', () => {
+    const strategy = electronPlatformStrategy('darwin')
+    const disposeMenu = strategy.installApplicationMenu({
+      productName: 'DSH Desktop',
+      openDesktopLabel: 'Open DSH Desktop',
+      showDesktop: vi.fn(),
+    })
+    const replacementMenu = { name: 'replacement application menu' }
+    electron.replaceApplicationMenu(replacementMenu)
+
+    disposeMenu()
+
+    expect(electron.currentApplicationMenu()).toBe(replacementMenu)
+    expect(electron.Menu.setApplicationMenu).toHaveBeenCalledOnce()
   })
 
   it('selects the Linux adapter without desktop chrome tweaks', () => {
@@ -77,9 +155,16 @@ describe('electronPlatformStrategy', () => {
 
     strategy.configureApplication({} as never)
     strategy.configureWindow(window as never)
+    const disposeMenu = strategy.installApplicationMenu({
+      productName: 'DSH Desktop',
+      openDesktopLabel: 'Open DSH Desktop',
+      showDesktop: vi.fn(),
+    })
     strategy.refreshThemeMaterial(window as never)
+    disposeMenu()
 
     expect(electron.app.dock.setIcon).not.toHaveBeenCalled()
+    expect(electron.Menu.setApplicationMenu).not.toHaveBeenCalled()
     expect(window.removeMenu).not.toHaveBeenCalled()
     expect(window.setBackgroundMaterial).not.toHaveBeenCalled()
   })

--- a/dsh-plugin-desktop/tests/electron-runtime.spec.ts
+++ b/dsh-plugin-desktop/tests/electron-runtime.spec.ts
@@ -66,6 +66,8 @@ const electron = vi.hoisted(() => {
   const browserWindowOn = vi.fn()
   const browserWindowOff = vi.fn()
   const loadURL = vi.fn(async (_url: string) => {})
+  const previousApplicationMenu = { name: 'previous application menu' }
+  let applicationMenu: unknown = previousApplicationMenu
   const menuTemplates: unknown[][] = []
   const notifications: Notification[] = []
   let zoomLevel = 0
@@ -183,15 +185,20 @@ const electron = vi.hoisted(() => {
     Menu: {
       buildFromTemplate: vi.fn((template: unknown[]) => {
         menuTemplates.push(template)
-        return {}
+        return { template }
       }),
+      getApplicationMenu: vi.fn(() => applicationMenu),
+      setApplicationMenu: vi.fn((menu: unknown) => { applicationMenu = menu }),
     },
     menuTemplates,
+    previousApplicationMenu,
     nativeImage: { createFromPath },
     nativeTheme,
     net: { fetch: vi.fn() },
     Notification,
     notifications,
+    currentApplicationMenu: () => applicationMenu,
+    resetApplicationMenu: () => { applicationMenu = previousApplicationMenu },
     resetZoomLevel: () => { zoomLevel = 0 },
     shell: {
       openExternal: vi.fn(async () => {}),
@@ -247,6 +254,7 @@ describe('Electron desktop runtime', () => {
     electron.trays.length = 0
     electron.menuTemplates.length = 0
     electron.notifications.length = 0
+    electron.resetApplicationMenu()
     childProcess.reset()
     vi.clearAllMocks()
     updater.download.mockReset()
@@ -276,7 +284,7 @@ describe('Electron desktop runtime', () => {
     vi.restoreAllMocks()
   })
 
-  it('uses the native macOS frame, Dock icon, and template tray image', async () => {
+  it('uses the native macOS frame, recoverable application menu, and template tray image', async () => {
     vi.spyOn(process, 'platform', 'get').mockReturnValue('darwin')
     const { ElectronDesktopRuntime } = await import('../src/electron-runtime.ts')
     const runtime = new ElectronDesktopRuntime(async () => {})
@@ -322,8 +330,35 @@ describe('Electron desktop runtime', () => {
     expect(electron.app.dock.setIcon).toHaveBeenCalledWith(electron.appIcon)
     expect(electron.templateIcon.setTemplateImage).toHaveBeenCalledWith(true)
     expect(electron.trays[0]?.image).toBe(electron.templateIcon)
-    expect(electron.menuTemplates[0]).toEqual(expect.arrayContaining([
+    const applicationMenuTemplate = electron.menuTemplates[0]
+    const applicationMenu = applicationMenuTemplate?.[0] as {
+      label?: string
+      submenu?: Array<{ label?: string, click?: () => void }>
+    }
+    expect(applicationMenu.label).toBe('DSH Desktop')
+    expect(applicationMenu.submenu).toEqual(expect.arrayContaining([
+      expect.objectContaining({ label: 'Open DSH Desktop' }),
+    ]))
+    expect(applicationMenuTemplate?.slice(1)).toEqual([
+      { role: 'fileMenu' },
+      { role: 'editMenu' },
+      { role: 'viewMenu' },
+      { role: 'windowMenu' },
+    ])
+    expect(electron.menuTemplates[1]).toEqual(expect.arrayContaining([
       expect.objectContaining({ label: 'Switch to Advanced Mode', enabled: true }),
+    ]))
+
+    applicationMenu.submenu?.find(item => item.label === 'Open DSH Desktop')?.click?.()
+    expect(electron.browserWindows[0]?.show).toHaveBeenCalledOnce()
+    expect(electron.browserWindows[0]?.focus).toHaveBeenCalledOnce()
+
+    runtime.setLocalePreference('zh')
+    const localizedApplicationMenu = electron.menuTemplates.at(-2)?.[0] as {
+      submenu?: Array<{ label?: string }>
+    }
+    expect(localizedApplicationMenu.submenu).toEqual(expect.arrayContaining([
+      expect.objectContaining({ label: '打开 DSH Desktop' }),
     ]))
 
     const titleListener = electron.browserWindowOn.mock.calls.find(([event]) => event === 'page-title-updated')?.[1]
@@ -335,6 +370,7 @@ describe('Electron desktop runtime', () => {
     await release()
     expect(electron.browserWindowOff).toHaveBeenCalledWith('page-title-updated', titleListener)
     expect(electron.trays[0]?.off).toHaveBeenCalledWith('click', expect.any(Function))
+    expect(electron.currentApplicationMenu()).toBe(electron.previousApplicationMenu)
   })
 
   it('uses the Windows caption, hidden menu bar, removed menu, and fixed blue tray image', async () => {
@@ -881,6 +917,7 @@ describe('Electron desktop runtime', () => {
     expect(electron.browserWindows[0]?.destroy).toHaveBeenCalledOnce()
     expect(electron.app.off).toHaveBeenCalledWith('activate', expect.any(Function))
     expect(electron.trays[0]?.off).toHaveBeenCalledWith('click', expect.any(Function))
+    expect(electron.currentApplicationMenu()).toBe(electron.previousApplicationMenu)
 
     await expect(release()).rejects.toThrow('interactive wiring failed')
     expect(electron.trays[0]?.destroy).toHaveBeenCalledOnce()
@@ -943,7 +980,8 @@ describe('Electron desktop runtime', () => {
     const release = runtime.schedule({ ...spec, requestModeChange })
 
     await runtime.mountScheduled()
-    const item = (electron.menuTemplates[0] as Array<{ label?: string, click?: () => void }>)
+    const item = electron.menuTemplates
+      .flatMap(template => template as Array<{ label?: string, click?: () => void }>)
       .find(candidate => candidate.label === 'Switch to Advanced Mode')
     expect(item).toBeDefined()
     item?.click?.()
@@ -1602,9 +1640,10 @@ describe('Electron desktop runtime', () => {
       transparent: true,
       vibrancy: 'sidebar',
     }))
-    expect(electron.menuTemplates[0]).toEqual(expect.arrayContaining([
-      expect.objectContaining({ label: 'Switch to Compatibility Mode', enabled: true }),
-    ]))
+    expect(electron.menuTemplates.some(template => template.some(item => (
+      (item as { label?: string, enabled?: boolean }).label === 'Switch to Compatibility Mode'
+      && (item as { enabled?: boolean }).enabled === true
+    )))).toBe(true)
 
     runtime.setThemeSource('system')
     expect(electron.nativeTheme.themeSource).toBe('system')


### PR DESCRIPTION
## Summary / 摘要

- Add a localized Open DSH Desktop command to the native macOS application menu, so a close-to-hidden window remains recoverable when the tray/status item is outside the visible menu-bar area.
- 在 macOS 原生应用菜单中增加本地化的“打开 DSH Desktop”命令；即使托盘/状态栏图标被菜单栏溢出区域隐藏，用户仍能恢复关闭后隐藏的窗口。
- Reuse the existing generation-owned show path used by Dock activation and tray clicks. The command restores a minimized window, shows and focuses it, and clears pending attention state.
- Keep application-menu ownership generation-scoped: rebuild localized copy when locale changes, restore the previous menu on release or failed startup, and do not overwrite a menu that another owner has since installed.
- Refresh the two stale root bilingual hashes introduced by the latest master documentation-only push. This is isolated in its own commit because code PRs run the layout gate that the documentation-only push skipped.

## Related Issues / 关联 Issue

Fixes #407

## Type / 类型

- [x] Bug fix / 问题修复
- [ ] Feature / 新功能
- [x] Documentation / 文档
- [ ] Release or packaging / 发布或打包
- [ ] Tests only / 仅测试
- [ ] Other / 其他

## Platforms / 影响平台

- [ ] Windows installer / Windows 安装包
- [ ] Windows portable ZIP / Windows 便携版 ZIP
- [x] macOS Apple Silicon
- [x] macOS Intel
- [x] macOS Universal package / macOS 通用安装包
- [ ] Linux
- [ ] Not platform-specific / 与平台无关

## Verification / 验证

- [x] corepack yarn check:layout
- [x] corepack yarn typecheck
- [x] corepack yarn test
- [x] corepack yarn check
- [ ] Platform package smoke / 平台打包或启动冒烟
- [ ] Manual test / 人工测试

Focused Electron tests: 56 passed. Full repository gate: Market 272 passed; Desktop 652 passed with 3 skipped; runtime closure and license verification passed.

No graphical/manual macOS check was run; native calls and lifecycle behavior are covered headlessly.

## Release Notes / 发布说明

macOS users can reopen DSH Desktop from the application menu when its tray icon is not visible.

macOS 用户在托盘图标不可见时，可以通过应用菜单重新打开 DSH Desktop。