### PR TITLE
feat(desktop): add tray restart command

### DIFF
--- a/README.i18n.yaml
+++ b/README.i18n.yaml
@@ -1,5 +1,5 @@
 # Bilingual-pair consistency record: the git blob hash of each side as of the last
 # confirmed-consistent state. Both languages carry equal authority. Update both files
 # and re-record their hashes after editing either side.
-README.md: cdd2abd88446712ab64db64eb6507f57814f2369
-README.en.md: 6767d0388cf3aaa0b446968f8bd3c0f7ffac3d96
+README.md: 0e8eab39dee9e273e276856de7509b6fe4601a71
+README.en.md: 3fe96e0a7adbcb345674e0da34386877dd8e05e2

--- a/dsh-plugin-desktop/src/electron-runtime.ts
+++ b/dsh-plugin-desktop/src/electron-runtime.ts
@@ -719,6 +719,14 @@ export class ElectronDesktopRuntime implements DesktopRuntime {
         },
       },
       { type: 'separator' },
+      {
+        label: desktopTrayLabel(this.locale, 'restart'),
+        click: () => {
+          void this.requestRestart().catch((cause: unknown) => {
+            this.logError(`dsh-plugin-desktop: failed to restart: ${cause instanceof Error ? cause.message : String(cause)}`)
+          })
+        },
+      },
       { label: desktopTrayLabel(this.locale, 'quit'), click: () => { spec.requestQuit(0) } },
     )
     return template

--- a/dsh-plugin-desktop/src/tray-locale.ts
+++ b/dsh-plugin-desktop/src/tray-locale.ts
@@ -11,6 +11,7 @@ export type DesktopTrayLabelKey =
   | 'openTerminal'
   | 'profile'
   | 'quit'
+  | 'restart'
   | 'switchToAdvanced'
   | 'switchToCompatibility'
   | 'unavailableForDesktop'
@@ -26,6 +27,7 @@ const labels: Record<DesktopLocale, Record<DesktopTrayLabelKey, (value: string) 
     openTerminal: () => 'Open DSH Terminal',
     profile: profileName => `Profile: ${profileName}`,
     quit: () => 'Quit',
+    restart: () => 'Restart DSH Desktop',
     switchToAdvanced: () => 'Switch to Advanced Mode',
     switchToCompatibility: () => 'Switch to Compatibility Mode',
     unavailableForDesktop: profileName => `${profileName} (Unavailable for Desktop)`,
@@ -40,6 +42,7 @@ const labels: Record<DesktopLocale, Record<DesktopTrayLabelKey, (value: string) 
     openTerminal: () => '打开 DSH 终端',
     profile: profileName => `配置文件：${profileName}`,
     quit: () => '退出',
+    restart: () => '重新启动 DSH Desktop',
     switchToAdvanced: () => '切换到高级模式',
     switchToCompatibility: () => '切换到兼容模式',
     unavailableForDesktop: profileName => `${profileName}（不可用于桌面端）`,

--- a/dsh-plugin-desktop/tests/electron-runtime.spec.ts
+++ b/dsh-plugin-desktop/tests/electron-runtime.spec.ts
@@ -597,6 +597,7 @@ describe('Electron desktop runtime', () => {
       .toEqual(expect.arrayContaining([
         '打开 DSH Desktop',
         '切换到高级模式',
+        '重新启动 DSH Desktop',
         '退出',
       ]))
 
@@ -606,6 +607,7 @@ describe('Electron desktop runtime', () => {
       .toEqual(expect.arrayContaining([
         'Open DSH Desktop',
         'Switch to Advanced Mode',
+        'Restart DSH Desktop',
         'Quit',
       ]))
 
@@ -616,6 +618,7 @@ describe('Electron desktop runtime', () => {
       .toEqual(expect.arrayContaining([
         '打开 DSH Desktop',
         '切换到高级模式',
+        '重新启动 DSH Desktop',
         '退出',
       ]))
 
@@ -952,6 +955,35 @@ describe('Electron desktop runtime', () => {
     await release()
   })
 
+  it('restarts from the tray and logs asynchronous restart failures', async () => {
+    vi.spyOn(process, 'platform', 'get').mockReturnValue('win32')
+    const { ElectronDesktopRuntime } = await import('../src/electron-runtime.ts')
+    const restart = vi.fn()
+      .mockResolvedValueOnce(undefined)
+      .mockRejectedValueOnce(new Error('restart unavailable'))
+    const logger = { error: vi.fn(), errorCause: vi.fn() }
+    const runtime = new ElectronDesktopRuntime(restart, undefined, logger)
+    const release = runtime.schedule(spec)
+
+    await runtime.mountScheduled()
+    const items = electron.menuTemplates.at(-1) as Array<{ label?: string, click?: () => void }>
+    const restartIndex = items.findIndex(item => item.label === 'Restart DSH Desktop')
+    const quitIndex = items.findIndex(item => item.label === 'Quit')
+    expect(restartIndex).toBe(quitIndex - 1)
+
+    items[restartIndex]?.click?.()
+    await vi.waitFor(() => { expect(restart).toHaveBeenCalledTimes(1) })
+    items[restartIndex]?.click?.()
+    await vi.waitFor(() => {
+      expect(logger.error).toHaveBeenCalledWith(
+        'dsh-plugin-desktop: failed to restart: restart unavailable',
+      )
+    })
+    expect(restart).toHaveBeenCalledTimes(2)
+
+    await release()
+  })
+
   it('rebuilds ordered effect-scoped tray contributions without replacing native commands', async () => {
     vi.spyOn(process, 'platform', 'get').mockReturnValue('darwin')
     const { ElectronDesktopRuntime } = await import('../src/electron-runtime.ts')
@@ -986,6 +1018,7 @@ describe('Electron desktop runtime', () => {
       'Earlier Tool', 'Later Tool', undefined,
       'Check for Updates…', undefined,
       'Switch to Advanced Mode', undefined,
+      'Restart DSH Desktop',
       'Quit',
     ])
     expect(electron.menuTemplates.at(-1)).toEqual(expect.arrayContaining([


### PR DESCRIPTION
## Summary / 摘要

- Add a localized Restart DSH Desktop command immediately above Quit in the native tray menu.
- 在原生托盘菜单的“退出”上方增加本地化的“重新启动 DSH Desktop”命令。
- Reuse the existing orderly desktop restart lifecycle and log asynchronous restart failures without leaving an unhandled rejection.
- Cover English and Chinese menu rebuilding, menu order, successful invocation, and failure logging.
- Refresh the two stale root bilingual hashes introduced by recent master documentation-only pushes. This is isolated in its own commit because code PRs run the layout gate that those pushes skipped.

## Related Issues / 关联 Issue

Fixes #335

## Type / 类型

- [ ] Bug fix / 问题修复
- [x] Feature / 新功能
- [x] Documentation / 文档
- [ ] Release or packaging / 发布或打包
- [ ] Tests only / 仅测试
- [ ] Other / 其他

## Platforms / 影响平台

- [ ] Windows installer / Windows 安装包
- [ ] Windows portable ZIP / Windows 便携版 ZIP
- [ ] macOS Apple Silicon
- [ ] macOS Intel
- [ ] macOS Universal package / macOS 通用安装包
- [ ] Linux
- [x] Not platform-specific / 与平台无关

## Verification / 验证

- [x] `corepack yarn check:layout`
- [x] `corepack yarn typecheck`
- [x] `corepack yarn test`
- [x] `corepack yarn check`
- [ ] Platform package smoke / 平台打包或启动冒烟
- [ ] Manual test / 人工测试

Focused Electron runtime tests: 52 passed. Full repository gate: Market 272 passed; Desktop 652 passed with 3 skipped; builds, runtime closure, and license verification passed.

No graphical/manual platform check was run; tray menu behavior and restart lifecycle are covered headlessly.

## Release Notes / 发布说明

Users can restart DSH Desktop directly from the native tray menu after installing or updating plugins or changing profile configuration.

用户在安装或更新插件、修改 profile 配置后，可以直接通过原生托盘菜单重启 DSH Desktop。