### PR TITLE
feat(desktop): add workspace pinning

### DIFF
--- a/README.i18n.yaml
+++ b/README.i18n.yaml
@@ -1,5 +1,5 @@
 # Bilingual-pair consistency record: the git blob hash of each side as of the last
 # confirmed-consistent state. Both languages carry equal authority. Update both files
 # and re-record their hashes after editing either side.
-README.md: cdd2abd88446712ab64db64eb6507f57814f2369
-README.en.md: 6767d0388cf3aaa0b446968f8bd3c0f7ffac3d96
+README.md: 0e8eab39dee9e273e276856de7509b6fe4601a71
+README.en.md: 3fe96e0a7adbcb345674e0da34386877dd8e05e2

--- a/dsh-plugin-desktop/tests/package.spec.ts
+++ b/dsh-plugin-desktop/tests/package.spec.ts
@@ -179,7 +179,7 @@ describe('published package surface', () => {
     }
   })
 
-  it('marks the upstream Workspace browser as the desktop folder-drop target', () => {
+  it('patches the upstream Workspace browser with desktop drop and pin behavior', () => {
     const patchPath = './patches/dsh-client-ui-workspace@0.1.0-rc.7.patch'
     expect(workspaceManifest.resolutions).toMatchObject({
       '@deepseek-ai/dsh-client-ui-workspace@npm:0.1.0-rc.7': expect.stringContaining(patchPath),
@@ -190,8 +190,17 @@ describe('published package surface', () => {
       'node_modules/@deepseek-ai/dsh-client-ui-workspace/lib/client.js',
       packageRoot,
     ), 'utf8')
-    expect(patch).toContain('data-dsh-workspace-drop-target')
-    expect(installedClient).toContain('data-dsh-workspace-drop-target')
+    for (const marker of [
+      'data-dsh-workspace-drop-target',
+      'pinnedWorkspaceIds',
+      'toggleWorkspacePin',
+      'workspaceDragMove',
+      'menu.pinWorkspace',
+      'menu.unpinWorkspace',
+    ]) {
+      expect(patch).toContain(marker)
+      expect(installedClient).toContain(marker)
+    }
   })
 
   it('builds public Host plugins and their private native bootstraps', () => {

--- a/dsh-plugin-desktop/tests/workspace-pinning-patch.spec.ts
+++ b/dsh-plugin-desktop/tests/workspace-pinning-patch.spec.ts
@@ -1,0 +1,408 @@
+import { pathToFileURL } from 'node:url'
+import { beforeAll, describe, expect, it, vi } from 'vitest'
+
+interface JsxNode {
+  readonly type: unknown
+  readonly props: Record<string, any>
+  readonly key?: unknown
+}
+
+interface StoreHandle {
+  readonly persist: string
+  create(): {
+    getSnapshot(): Record<string, any>
+    actions: Record<string, (...args: any[]) => void>
+  }
+}
+
+interface BrowserRegistration {
+  readonly component: (props: Record<string, any>) => JsxNode
+  readonly store: StoreHandle
+}
+
+interface HookRuntime {
+  render<T>(component: (props: Record<string, any>) => T, props: Record<string, any>): T
+  useState<T>(initial: T | (() => T)): [T, (value: T | ((current: T) => T)) => void]
+  useRef<T>(initial: T): { current: T }
+}
+
+const Fragment = Symbol('Fragment')
+const jsx = (type: unknown, props: Record<string, any> | null, key?: unknown): JsxNode => ({
+  type,
+  props: props ?? {},
+  ...(key === undefined ? {} : { key }),
+})
+const primitiveTypes = new Map<string, symbol>()
+const primitiveType = (name: string): symbol => {
+  const current = primitiveTypes.get(name)
+  if (current !== undefined) return current
+  const created = Symbol(name)
+  primitiveTypes.set(name, created)
+  return created
+}
+const primitives = new Proxy({}, {
+  get: (_target, property) => primitiveType(String(property)),
+})
+
+let activeHooks: HookRuntime | undefined
+const react = {
+  useCallback: <T>(callback: T): T => callback,
+  useEffect: (): void => {},
+  useMemo: <T>(factory: () => T): T => factory(),
+  useRef: <T>(initial: T): { current: T } => {
+    if (activeHooks === undefined) throw new Error('hook called outside a component')
+    return activeHooks.useRef(initial)
+  },
+  useState: <T>(initial: T | (() => T)): [T, (value: T | ((current: T) => T)) => void] => {
+    if (activeHooks === undefined) throw new Error('hook called outside a component')
+    return activeHooks.useState(initial)
+  },
+}
+
+function hookRuntime(): HookRuntime {
+  const state: unknown[] = []
+  const refs: Array<{ current: unknown }> = []
+  let stateCursor = 0
+  let refCursor = 0
+  return {
+    render<T>(component: (props: Record<string, any>) => T, props: Record<string, any>): T {
+      stateCursor = 0
+      refCursor = 0
+      activeHooks = this
+      try {
+        return component(props)
+      } finally {
+        activeHooks = undefined
+      }
+    },
+    useState<T>(initial: T | (() => T)) {
+      const index = stateCursor++
+      if (!(index in state)) state[index] = typeof initial === 'function' ? (initial as () => T)() : initial
+      return [
+        state[index] as T,
+        (value: T | ((current: T) => T)) => {
+          state[index] = typeof value === 'function'
+            ? (value as (current: T) => T)(state[index] as T)
+            : value
+        },
+      ]
+    },
+    useRef<T>(initial: T) {
+      const index = refCursor++
+      refs[index] ??= { current: initial }
+      return refs[index] as { current: T }
+    },
+  }
+}
+
+function defineStore(spec: {
+  init: () => Record<string, any>
+  persist: string
+  actions: Record<string, (draft: Record<string, any>, ...args: any[]) => void>
+}): StoreHandle {
+  return {
+    persist: spec.persist,
+    create: () => {
+      const state = spec.init()
+      const actions = Object.fromEntries(Object.entries(spec.actions).map(([name, action]) => [
+        name,
+        (...args: any[]) => { action(state, ...args) },
+      ]))
+      return { getSnapshot: () => state, actions }
+    },
+  }
+}
+
+function indexSubagentDescendants(summaries: Record<string, any>) {
+  const indexed = new Map<string, { count: number; runningCount: number }>()
+  for (const descendant of Object.values(summaries)) {
+    if (descendant.origin !== 'subagent') continue
+    const seen = new Set<string>()
+    let current = descendant
+    while (current?.origin === 'subagent' && current.parentId !== undefined && !seen.has(current.id)) {
+      seen.add(current.id)
+      const aggregate = indexed.get(current.parentId)
+      if (aggregate === undefined) {
+        indexed.set(current.parentId, {
+          count: 1,
+          runningCount: descendant.running ? 1 : 0,
+        })
+      } else {
+        aggregate.count += 1
+        if (descendant.running) aggregate.runningCount += 1
+      }
+      current = summaries[current.parentId]
+    }
+  }
+  return indexed
+}
+
+function allNodes(value: unknown, seen = new Set<object>()): JsxNode[] {
+  if (Array.isArray(value)) return value.flatMap(item => allNodes(item, seen))
+  if (value === null || typeof value !== 'object' || seen.has(value)) return []
+  seen.add(value)
+  const record = value as Record<string, unknown>
+  const own = 'type' in record && 'props' in record ? [value as JsxNode] : []
+  return [...own, ...Object.values(record).flatMap(item => allNodes(item, seen))]
+}
+
+const workspace = (workspaceId: string) => ({
+  workspaceId,
+  path: `/projects/${workspaceId}`,
+  title: workspaceId,
+  sessionIds: [],
+  createdAt: '2026-01-01T00:00:00.000Z',
+  updatedAt: '2026-01-01T00:00:00.000Z',
+})
+
+const sessionState = {
+  ids: [],
+  byId: {},
+  current: undefined,
+  phase: 'ready',
+  subagentsByParent: {},
+  jobsBySession: {},
+  currentAddress: undefined,
+}
+
+let registration: BrowserRegistration
+let dictionaries: Record<'en' | 'zh', Record<string, string>>
+
+beforeAll(async () => {
+  let definition: {
+    factory: (require: (name: string) => unknown) => { apply: (ctx: Record<string, any>) => void }
+  } | undefined
+  ;(globalThis as Record<string, any>).window = {
+    __ModuleLoader__: {
+      load: (next: typeof definition) => { definition = next },
+    },
+  }
+  const clientUrl = pathToFileURL(
+    new URL('../node_modules/@deepseek-ai/dsh-client-ui-workspace/lib/client.js', import.meta.url).pathname,
+  )
+  await import(`${clientUrl.href}?workspace-pinning-test`)
+  delete (globalThis as Record<string, any>).window
+  if (definition === undefined) throw new Error('workspace client bundle did not register')
+
+  const module = definition.factory((name) => {
+    if (name === '@deepseek-ai/dsh-client-runtime/client') {
+      return { defineStore, indexSubagentDescendants }
+    }
+    if (name === 'react/jsx-runtime') return { Fragment, jsx, jsxs: jsx }
+    if (name === 'react') return react
+    if (name === '@deepseek-ai/dsh-client-ui-primitives') return primitives
+    throw new Error(`unexpected workspace bundle dependency: ${name}`)
+  })
+  const registrations = new Map<string, BrowserRegistration>()
+  module.apply({
+    effect: (effect: () => unknown) => effect(),
+    locale: {
+      register: (_namespace: string, next: typeof dictionaries) => {
+        dictionaries = next
+        return () => {}
+      },
+    },
+    sessions: {},
+    workspaces: {},
+    slots: {
+      entries: () => [],
+      subscribe: () => () => {},
+      inject: (_name: string, effect: () => unknown) => effect(),
+      register: (
+        spec: { name: string; store?: StoreHandle },
+        component: BrowserRegistration['component'],
+      ) => {
+        if (spec.store !== undefined) registrations.set(spec.name, { component, store: spec.store })
+        return () => {}
+      },
+    },
+  })
+  const browser = registrations.get('sidebar.workspaces')
+  if (browser === undefined) throw new Error('workspace browser did not register')
+  registration = browser
+})
+
+function translate(locale: 'en' | 'zh') {
+  return (key: string, values?: Record<string, unknown>): string => {
+    let value = dictionaries[locale][key] ?? key
+    for (const [name, replacement] of Object.entries(values ?? {})) {
+      value = value.replace(`{${name}}`, String(replacement))
+    }
+    return value
+  }
+}
+
+function browserProps(
+  items: Array<ReturnType<typeof workspace>>,
+  pinnedWorkspaceIds: string[],
+  overrides: Record<string, any> = {},
+) {
+  const state = {
+    groupBy: 'workspace',
+    orderBy: 'manual',
+    groupExpansion: {},
+    pinnedWorkspaceIds,
+    sessionOrderByAccount: {},
+    sessionUpdatedAtByAccount: {},
+  }
+  return {
+    wide: true,
+    expandSidebar: vi.fn(),
+    useSessions: (selector: (snapshot: typeof sessionState) => unknown) => selector(sessionState),
+    useWorkspaces: (selector: (snapshot: Record<string, unknown>) => unknown) => selector({
+      items,
+      archivedSessionIds: [],
+      phase: 'ready',
+    }),
+    useStore: (selector: (snapshot: typeof state) => unknown) => selector(state),
+    actions: {
+      retainAccountKeys: vi.fn(),
+      setGroupExpanded: vi.fn(),
+      syncSessionOrderAccount: vi.fn(),
+      setSessionOrder: vi.fn(),
+      toggleWorkspacePin: vi.fn(),
+    },
+    startSession: vi.fn(),
+    open: vi.fn(),
+    renameSession: vi.fn(),
+    forkSession: vi.fn(),
+    renameWorkspace: vi.fn(),
+    deleteWorkspace: vi.fn(),
+    insertWorkspaceBefore: vi.fn(async () => {}),
+    archiveSession: vi.fn(),
+    insertSessionBefore: vi.fn(),
+    createWorkspace: vi.fn(),
+    searchSessions: vi.fn(),
+    searchResultLimit: 20,
+    useDirectoryFlow: (selector: (occupied: boolean) => unknown) => selector(true),
+    renderSlot: vi.fn(),
+    t: translate('en'),
+    ...overrides,
+  }
+}
+
+function sessionTreeElement(props: Record<string, any>): JsxNode {
+  const browser = hookRuntime().render(registration.component, props)
+  const sessionTree = allNodes(browser).find(node => (
+    typeof node.type === 'function' && node.type.name === 'SessionTree'
+  ))
+  if (sessionTree === undefined) throw new Error('grouped SessionTree was not rendered')
+  return sessionTree
+}
+
+function projectRows(tree: JsxNode): JsxNode[] {
+  return allNodes(tree).filter(node => (
+    typeof node.type === 'function'
+    && node.type.name === 'ProjectRowItem'
+    && node.props.group.workspaceId !== undefined
+  ))
+}
+
+function projectMenu(project: JsxNode, locale: 'en' | 'zh' = 'en'): JsxNode {
+  const row = hookRuntime().render(project.type as (props: Record<string, any>) => JsxNode, {
+    ...project.props,
+    t: translate(locale),
+  })
+  const menu = allNodes(row).find(node => node.type === primitiveType('Menu'))
+  if (menu === undefined) throw new Error('workspace row menu was not rendered')
+  return menu
+}
+
+function groupSection(tree: JsxNode, workspaceId: string): JsxNode {
+  const section = allNodes(tree).find(node => (
+    typeof node.props.onDrop === 'function'
+    && projectRows(node).some(project => project.props.group.workspaceId === workspaceId)
+  ))
+  if (section === undefined) throw new Error(`workspace group ${workspaceId} was not rendered`)
+  return section
+}
+
+function drop(section: JsxNode, half: 'before' | 'after'): void {
+  section.props.onDrop({
+    preventDefault: vi.fn(),
+    clientY: half === 'before' ? 10 : 30,
+    currentTarget: {
+      getBoundingClientRect: () => ({ top: 0, height: 40 }),
+    },
+  })
+}
+
+describe('workspace pinning bundle patch', () => {
+  it('persists pin toggles and prunes deleted Workspace ids', () => {
+    const store = registration.store.create()
+    expect(registration.store.persist).toBe('dsh.workspace.view.v5')
+    expect(store.getSnapshot().pinnedWorkspaceIds).toEqual([])
+
+    store.actions.toggleWorkspacePin!('alpha')
+    store.actions.toggleWorkspacePin!('deleted')
+    expect(store.getSnapshot().pinnedWorkspaceIds).toEqual(['alpha', 'deleted'])
+
+    store.actions.retainAccountKeys!(['', '__flat_session_order__', 'alpha'])
+    expect(store.getSnapshot().pinnedWorkspaceIds).toEqual(['alpha'])
+    store.actions.toggleWorkspacePin!('alpha')
+    expect(store.getSnapshot().pinnedWorkspaceIds).toEqual([])
+  })
+
+  it('renders pinned Workspaces first and exposes localized Pin and Unpin commands above Rename', () => {
+    const items = ['ordinary-a', 'pinned-a', 'ordinary-b', 'pinned-b'].map(workspace)
+    const props = browserProps(items, ['pinned-a', 'pinned-b'])
+    const treeElement = sessionTreeElement(props)
+    const tree = hookRuntime().render(
+      treeElement.type as (props: Record<string, any>) => JsxNode,
+      treeElement.props,
+    )
+    const projects = projectRows(tree)
+    expect(projects.map(project => project.props.group.workspaceId)).toEqual([
+      'pinned-a', 'pinned-b', 'ordinary-a', 'ordinary-b',
+    ])
+
+    const pinnedMenu = projectMenu(projects[0]!)
+    expect(pinnedMenu.props.items.map((item: { label: string }) => item.label)).toEqual([
+      'Unpin workspace', 'Rename', 'Delete workspace',
+    ])
+    pinnedMenu.props.onSelect('pin')
+    expect(props.actions.toggleWorkspacePin).toHaveBeenCalledWith('pinned-a')
+
+    const ordinaryMenu = projectMenu(projects[2]!, 'zh')
+    expect(ordinaryMenu.props.items.map((item: { label: string }) => item.label)).toEqual([
+      '置顶工作区', '重命名', '删除工作区',
+    ])
+  })
+
+  it('reorders inside a pin partition and rejects cross-partition drops', () => {
+    const items = ['ordinary-a', 'pinned-a', 'ordinary-b', 'pinned-b'].map(workspace)
+    const insertWorkspaceBefore = vi.fn(async () => {})
+    const treeElement = sessionTreeElement(browserProps(
+      items,
+      ['pinned-a', 'pinned-b'],
+      { insertWorkspaceBefore },
+    ))
+
+    const pinnedRuntime = hookRuntime()
+    let tree = pinnedRuntime.render(
+      treeElement.type as (props: Record<string, any>) => JsxNode,
+      treeElement.props,
+    )
+    projectRows(tree).find(project => project.props.group.workspaceId === 'pinned-a')?.props.drag.start()
+    tree = pinnedRuntime.render(
+      treeElement.type as (props: Record<string, any>) => JsxNode,
+      treeElement.props,
+    )
+    drop(groupSection(tree, 'pinned-b'), 'after')
+    expect(insertWorkspaceBefore).toHaveBeenCalledWith('pinned-a', undefined)
+
+    insertWorkspaceBefore.mockClear()
+    const crossRuntime = hookRuntime()
+    tree = crossRuntime.render(
+      treeElement.type as (props: Record<string, any>) => JsxNode,
+      treeElement.props,
+    )
+    projectRows(tree).find(project => project.props.group.workspaceId === 'pinned-b')?.props.drag.start()
+    tree = crossRuntime.render(
+      treeElement.type as (props: Record<string, any>) => JsxNode,
+      treeElement.props,
+    )
+    drop(groupSection(tree, 'ordinary-a'), 'before')
+    expect(insertWorkspaceBefore).not.toHaveBeenCalled()
+  })
+})

--- a/patches/dsh-client-ui-workspace@0.1.0-rc.7.patch
+++ b/patches/dsh-client-ui-workspace@0.1.0-rc.7.patch
@@ -1,12 +1,170 @@
 diff --git a/lib/client.js b/lib/client.js
-index 63d3f59..e2c7c9a 100644
+index ec779d5750f3810736ee05290bdd45d858cd00e0..9d600022bfb0e12f0d56fd2de5a131ce6f0eb4bf 100644
 --- a/lib/client.js
 +++ b/lib/client.js
-@@ -1849,6 +1849,7 @@ window.__ModuleLoader__.load({
- 			};
- 			return (0, react_jsx_runtime.jsxs)("div", {
- 				className: clsx(WorkspaceBrowser_module_css_default.root, !wide && WorkspaceBrowser_module_css_default.rail),
+@@ -20 +20,3 @@
+-		const FLAT_SESSION_ORDER_KEY = "__flat_session_order__";
++		const FLAT_SESSION_ORDER_KEY = "__flat_session_order__";
++		/** Stable fallback while an older persisted view snapshot has no pin field. */
++		const EMPTY_PINNED_WORKSPACE_IDS = [];
+@@ -30 +32,2 @@
+-					groupExpansion: {},
++					groupExpansion: {},
++					pinnedWorkspaceIds: [],
+@@ -47 +50,2 @@
+-						d.groupExpansion = Object.fromEntries(Object.entries(d.groupExpansion).filter(([key]) => retained.has(key)));
++						d.groupExpansion = Object.fromEntries(Object.entries(d.groupExpansion).filter(([key]) => retained.has(key)));
++						d.pinnedWorkspaceIds = (d.pinnedWorkspaceIds ?? []).filter((workspaceId) => retained.has(workspaceId));
+@@ -51 +55,5 @@
+-					syncSessionOrderAccount: (d, accountKey, order, updatedAt) => {
++					toggleWorkspacePin: (d, workspaceId) => {
++						const pinned = d.pinnedWorkspaceIds ?? [];
++						d.pinnedWorkspaceIds = pinned.includes(workspaceId) ? pinned.filter((id) => id !== workspaceId) : [...pinned, workspaceId];
++					},
++					syncSessionOrderAccount: (d, accountKey, order, updatedAt) => {
+@@ -441 +449,21 @@
+-		/**
++		/** Standard pin glyph for the Workspace menu (the shared icon set has no pin icon). */
++		function IconPinOutline16() {
++			return (0, react_jsx_runtime.jsxs)("svg", {
++				width: 16,
++				height: 16,
++				viewBox: "0 0 24 24",
++				fill: "none",
++				stroke: "currentColor",
++				strokeWidth: 2,
++				strokeLinecap: "round",
++				strokeLinejoin: "round",
++				"aria-hidden": "true",
++				children: [
++					(0, react_jsx_runtime.jsx)("path", { d: "M12 17v5" }),
++					(0, react_jsx_runtime.jsx)("path", { d: "M5 17h14" }),
++					(0, react_jsx_runtime.jsx)("path", { d: "M8 2h8" }),
++					(0, react_jsx_runtime.jsx)("path", { d: "m9 7-2.7 7.3A2 2 0 0 0 8.2 17h7.6a2 2 0 0 0 1.9-2.7L15 7" })
++				]
++			});
++		}
++		/**
+@@ -458 +486,5 @@
+-			const workspaceMenuItems = [{
++			const workspaceMenuItems = [{
++				id: "pin",
++				label: t(actions?.pinned === true ? "menu.unpinWorkspace" : "menu.pinWorkspace"),
++				icon: (0, react_jsx_runtime.jsx)(IconPinOutline16, {})
++			}, {
+@@ -506,3 +538,4 @@
+-								/* v8 ignore next -- workspaceMenuItems carries exactly these two rows today. */
+-								if (id !== "rename" && id !== "delete") return;
+-								if (id === "rename") actions.rename();
++								/* v8 ignore next -- workspaceMenuItems carries exactly these three rows today. */
++								if (id !== "pin" && id !== "rename" && id !== "delete") return;
++								if (id === "pin") actions.togglePin();
++								else if (id === "rename") actions.rename();
+@@ -1053 +1086,35 @@
+-		/**
++		/** Put pinned Workspaces first while retaining the Host order inside each partition. */
++		function partitionPinnedWorkspaces(workspaces, pinnedWorkspaceIds) {
++			const pinned = new Set(pinnedWorkspaceIds);
++			return [
++				...workspaces.filter((workspace) => pinned.has(workspace.workspaceId)),
++				...workspaces.filter((workspace) => !pinned.has(workspace.workspaceId))
++			];
++		}
++		/**
++		* Translate a same-partition display drop into one Host insert-before anchor.
++		* Opposite-partition drops are rejected so dragging never changes pin state.
++		*/
++		function workspaceDragMove(workspaces, pinnedWorkspaceIds, sourceId, targetId, half) {
++			const pinned = new Set(pinnedWorkspaceIds);
++			const sourcePinned = pinned.has(sourceId);
++			if (sourcePinned !== pinned.has(targetId)) return;
++			const partition = workspaces.filter((workspace) => pinned.has(workspace.workspaceId) === sourcePinned).map((workspace) => workspace.workspaceId);
++			const sourceIndex = partition.indexOf(sourceId);
++			const targetIndex = partition.indexOf(targetId);
++			if (sourceIndex === -1 || targetIndex === -1) return;
++			const anchor = half === "before" ? targetId : partition[targetIndex + 1];
++			if (anchor === sourceId) return;
++			const nextPartition = partition.filter((workspaceId) => workspaceId !== sourceId);
++			const insertAt = anchor === void 0 ? nextPartition.length : nextPartition.indexOf(anchor);
++			nextPartition.splice(insertAt === -1 ? nextPartition.length : insertAt, 0, sourceId);
++			if (nextPartition.every((workspaceId, index) => workspaceId === partition[index])) return;
++			const nextSamePartition = nextPartition[nextPartition.indexOf(sourceId) + 1];
++			if (nextSamePartition !== void 0) return { beforeWorkspaceId: nextSamePartition };
++			const remaining = workspaces.filter((workspace) => workspace.workspaceId !== sourceId);
++			const previousSamePartition = nextPartition[nextPartition.length - 2];
++			if (previousSamePartition === void 0) return;
++			const previousIndex = remaining.findIndex((workspace) => workspace.workspaceId === previousSamePartition);
++			return { beforeWorkspaceId: remaining[previousIndex + 1]?.workspaceId };
++		}
++		/**
+@@ -1199 +1266 @@
+-		function SessionTree({ useSessions, startSession, open, forkSession, workspaces, archivedSessionIds, onRenameRequest, onDeleteRequest, onSessionRename, onSessionArchive, insertWorkspaceBefore, insertSessionBefore, orderBy, groupExpansion, setGroupExpanded, sessionOrderByAccount, sessionUpdatedAtByAccount, syncSessionOrderAccount, setSessionOrder, t }) {
++		function SessionTree({ useSessions, startSession, open, forkSession, workspaces, archivedSessionIds, onRenameRequest, onDeleteRequest, onSessionRename, onSessionArchive, insertWorkspaceBefore, insertSessionBefore, orderBy, groupExpansion, setGroupExpanded, sessionOrderByAccount, sessionUpdatedAtByAccount, syncSessionOrderAccount, setSessionOrder, pinnedWorkspaceIds, toggleWorkspacePin, t }) {
+@@ -1200 +1267,2 @@
+-			const list = useSessions((s) => s);
++			const list = useSessions((s) => s);
++			const pinnedWorkspaceSet = (0, react.useMemo)(() => new Set(pinnedWorkspaceIds), [pinnedWorkspaceIds]);
+@@ -1257 +1325 @@
+-				return workspaces.map((workspace) => {
++				const reconciled = workspaces.map((workspace) => {
+@@ -1265 +1333,6 @@
+-			}, [sessionOrderByAccount, workspaces]);
++				return partitionPinnedWorkspaces(reconciled, pinnedWorkspaceIds);
++			}, [
++				pinnedWorkspaceIds,
++				sessionOrderByAccount,
++				workspaces
++			]);
+@@ -1306,8 +1379,3 @@
+-				const rowIndex = workspaces.findIndex((workspace) => workspace.workspaceId === over.id);
+-				if (rowIndex === -1) return;
+-				const anchor = over.half === "before" ? over.id : workspaces[rowIndex + 1]?.workspaceId;
+-				if (anchor === activeDrag.workspaceId) return;
+-				const sourceIndex = workspaces.findIndex((workspace) => workspace.workspaceId === activeDrag.workspaceId);
+-				const anchorIndex = anchor === void 0 ? workspaces.length : workspaces.findIndex((workspace) => workspace.workspaceId === anchor);
+-				if (sourceIndex !== -1 && (anchorIndex === sourceIndex || anchorIndex === sourceIndex + 1)) return;
+-				insertWorkspaceBefore(activeDrag.workspaceId, anchor).catch((reason) => {
++				const move = workspaceDragMove(workspaces, pinnedWorkspaceIds, activeDrag.workspaceId, over.id, over.half);
++				if (move === void 0) return;
++				insertWorkspaceBefore(activeDrag.workspaceId, move.beforeWorkspaceId).catch((reason) => {
+@@ -1334 +1402,2 @@
+-							const workspaceMarker = workspaceId !== void 0 && workspaceDrag?.over?.id === workspaceId ? workspaceDrag.over.half : null;
++							const samePinPartition = workspaceId !== void 0 && workspaceDrag !== null && pinnedWorkspaceSet.has(workspaceId) === pinnedWorkspaceSet.has(workspaceDrag.workspaceId);
++							const workspaceMarker = samePinPartition && workspaceDrag?.over?.id === workspaceId ? workspaceDrag.over.half : null;
+@@ -1352 +1421 @@
+-									over: {
++									over: pinnedWorkspaceSet.has(active.workspaceId) === pinnedWorkspaceSet.has(workspaceId) ? {
+@@ -1355 +1424 @@
+-									}
++									} : null
+@@ -1392 +1461,6 @@
+-											rename: () => {
++											pinned: pinnedWorkspaceIds.includes(group.workspaceId),
++											togglePin: () => {
++												/* v8 ignore next -- narrowing guard: the actions object exists only for real-workspace groups. */
++												if (group.workspaceId !== void 0) toggleWorkspacePin(group.workspaceId);
++											},
++											rename: () => {
+@@ -1655 +1729,2 @@
+-			const sessionOrderByAccount = useStore((s) => s.sessionOrderByAccount);
++			const pinnedWorkspaceIds = useStore((s) => s.pinnedWorkspaceIds ?? EMPTY_PINNED_WORKSPACE_IDS);
++			const sessionOrderByAccount = useStore((s) => s.sessionOrderByAccount);
+@@ -1850 +1925,2 @@
+-				className: clsx(WorkspaceBrowser_module_css_default.root, !wide && WorkspaceBrowser_module_css_default.rail),
++				className: clsx(WorkspaceBrowser_module_css_default.root, !wide && WorkspaceBrowser_module_css_default.rail),
 +				"data-dsh-workspace-drop-target": "",
- 				children: [
- 					(0, react_jsx_runtime.jsxs)("div", {
- 						className: WorkspaceBrowser_module_css_default.sectionHeader,
+@@ -2019 +2095,3 @@
+-							archivedSessionIds,
++							pinnedWorkspaceIds,
++							toggleWorkspacePin: actions.toggleWorkspacePin,
++							archivedSessionIds,
+@@ -2222 +2300,3 @@
+-			"menu.fork": "分叉会话",
++			"menu.pinWorkspace": "置顶工作区",
++			"menu.unpinWorkspace": "取消置顶",
++			"menu.fork": "分叉会话",
+@@ -2287 +2367,3 @@
+-			"menu.fork": "Fork session",
++			"menu.pinWorkspace": "Pin workspace",
++			"menu.unpinWorkspace": "Unpin workspace",
++			"menu.fork": "Fork session",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1776,7 +1776,7 @@ __metadata:
 
 "@deepseek-ai/dsh-client-ui-workspace@patch:@deepseek-ai/dsh-client-ui-workspace@npm%3A0.1.0-rc.7#./patches/dsh-client-ui-workspace@0.1.0-rc.7.patch::locator=deepseek-harness-desktop%40workspace%3A.":
   version: 0.1.0-rc.7
-  resolution: "@deepseek-ai/dsh-client-ui-workspace@patch:@deepseek-ai/dsh-client-ui-workspace@npm%3A0.1.0-rc.7#./patches/dsh-client-ui-workspace@0.1.0-rc.7.patch::version=0.1.0-rc.7&hash=1d300d&locator=deepseek-harness-desktop%40workspace%3A."
+  resolution: "@deepseek-ai/dsh-client-ui-workspace@patch:@deepseek-ai/dsh-client-ui-workspace@npm%3A0.1.0-rc.7#./patches/dsh-client-ui-workspace@0.1.0-rc.7.patch::version=0.1.0-rc.7&hash=13bb54&locator=deepseek-harness-desktop%40workspace%3A."
   dependencies:
     clsx: "npm:^2.0.0"
   peerDependencies:
@@ -1787,7 +1787,7 @@ __metadata:
     "@deepseek-ai/dsh-client-ui-slots": ^0.1.0-rc.7
     "@deepseek-ai/dsh-invariants": ^0.1.0-rc.7
     react: ^18.2.0
-  checksum: 10c0/a46cdf78a018eaced40da72dae10ecf9044177272e8f27bc81300c22d530bd20b98e71fb56a8e39c0dca10e1183abcfcf9b84b1274f44e0a902e21c7f335ca11
+  checksum: 10c0/3cd1f4ca044a82c2745bfe9054cb9b9aee5c4d2d7257370aacb32645aa447c51579377fa6bff134123e6b007c6be96b876261072a85e2dba945f54a7cc91f5fc
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

- add localized Pin workspace and Unpin workspace commands above Rename for real Workspace rows
- persist pinned Workspace IDs in the existing Desktop workspace-view store, prune deleted IDs, and render pinned Workspaces first while preserving Host order within each partition
- keep drag reordering within pin partitions and reject cross-partition drops so dragging never changes pin state implicitly
- extend the existing Yarn patch for the published Workspace client bundle without modifying the pinned upstream submodule
- refresh the stale README translation hash record required by the repository gate

## Test plan

- `yarn workspace dsh-plugin-desktop vitest run tests/workspace-pinning-patch.spec.ts tests/package.spec.ts`
- `yarn workspace dsh-plugin-desktop typecheck`
- `node --check dsh-plugin-desktop/node_modules/@deepseek-ai/dsh-client-ui-workspace/lib/client.js`
- `git diff --check`
- `yarn check`

Fixes #425