### PR TITLE
docs: add external sandbox integration guidance

### DIFF
--- a/docs/plugin-development.en.md
+++ b/docs/plugin-development.en.md
@@ -78,7 +78,7 @@ export function apply(ctx: Context, config: { profile?: string }): void {
     return
   }
 
-  ctx.inject(['desktopPnpm'], (desktopPnpm) => {
+  ctx.inject(['desktopProfiles', 'desktopPnpm'], (desktopPnpm) => {
     mountManager(ctx, {
       profile: profiles.current.name,
       profileDir: profiles.current.dir,
@@ -89,6 +89,16 @@ export function apply(ctx: Context, config: { profile?: string }): void {
 ```
 
 The ordinary DSH fallback remains the plugin's authoritative implementation. Do not infer the Desktop profile from `process.argv`, `ctx.baseUrl`, settings, or `$DSH_HOME`; in Desktop, use `desktopProfiles.current`.
+
+## Isolated development-sandbox mirrors
+
+An external development-sandbox plugin can use this cross-environment pattern to test a local plugin checkout without changing the active Desktop profile. Its target is an isolated DSH Web mirror, not a second Electron process.
+
+When `desktopProfiles` is available, retain both `desktopProfiles` and `desktopPnpm` in the nested `ctx.inject()` dependency set. Build a `host-web` mirror from the immutable `desktopProfiles.current.dir` for that Host generation; do not assume `profiles/web`, and do not retain the profile or runner after either Desktop service leaves the generation.
+
+A user-requested build may use the low-level `desktopPnpm.run(['--dir', absolutePluginDir, 'run', 'build'], signal)` because it builds a local checkout and does not mutate the active profile. Give it a deadline, read both output streams, retain the returned handle, and on disposal call `cancel()` and await `done`. A nonzero exit, signal termination, or rejected `done` must stop the mirror from launching.
+
+A reference implementation is [`dsh-dev-sandbox`](https://github.com/zp-home/dsh-dev-sandbox).
 
 ## `run()`, `runPlugin()`, and `installPlugin()`
 

--- a/docs/plugin-development.en.md
+++ b/docs/plugin-development.en.md
@@ -78,10 +78,10 @@ export function apply(ctx: Context, config: { profile?: string }): void {
     return
   }
 
-  ctx.inject(['desktopProfiles', 'desktopPnpm'], (desktopPnpm) => {
+  ctx.inject(['desktopProfiles', 'desktopPnpm'], (desktopProfiles, desktopPnpm) => {
     mountManager(ctx, {
-      profile: profiles.current.name,
-      profileDir: profiles.current.dir,
+      profile: desktopProfiles.current.name,
+      profileDir: desktopProfiles.current.dir,
       runPlugin: (args, cwd, signal) => desktopPnpm.runPlugin(args, cwd, signal),
     })
   })
@@ -99,6 +99,30 @@ When `desktopProfiles` is available, retain both `desktopProfiles` and `desktopP
 A user-requested build may use the low-level `desktopPnpm.run(['--dir', absolutePluginDir, 'run', 'build'], signal)` because it builds a local checkout and does not mutate the active profile. Give it a deadline, read both output streams, retain the returned handle, and on disposal call `cancel()` and await `done`. A nonzero exit, signal termination, or rejected `done` must stop the mirror from launching.
 
 A reference implementation is [`dsh-dev-sandbox`](https://github.com/zp-home/dsh-dev-sandbox).
+
+## Desktop Settings entry for a sandbox
+
+The sandbox client belongs in the official Settings navigation, rather than a custom sidebar node or an overlay. Register a `settings.section` occupant with a stable id. In the current Settings ordering, `order: 25` places `sandbox` immediately after the built-in Agent Presets section (`order: 20`).
+
+```tsx
+import type { ClientContext } from '@deepseek-ai/dsh-client-runtime/client'
+import type {} from '@deepseek-ai/dsh-client-ui-settings/client'
+import { SandboxSettingsSection } from './SandboxSettingsSection'
+
+export const inject = ['slots', 'locale']
+
+export function apply(ctx: ClientContext): void {
+  ctx.slots.inject('settings.section', () => ctx.slots.register({
+    name: 'settings.section',
+    id: 'sandbox',
+    order: 25,
+    locale: 'dsh-dev-sandbox',
+    label: () => ctx.locale.bind('dsh-dev-sandbox')('entry.label'),
+  }, SandboxSettingsSection))
+}
+```
+
+The section component should render the sandbox workbench in the Settings content pane. It must dispose any mounted DOM or request work when its Client fiber is disposed; do not retain a Settings DOM node, overlay state, or Desktop Host service across generations.
 
 ## `run()`, `runPlugin()`, and `installPlugin()`
 

--- a/docs/plugin-development.md
+++ b/docs/plugin-development.md
@@ -78,10 +78,10 @@ export function apply(ctx: Context, config: { profile?: string }): void {
     return
   }
 
-  ctx.inject(['desktopProfiles', 'desktopPnpm'], (desktopPnpm) => {
+  ctx.inject(['desktopProfiles', 'desktopPnpm'], (desktopProfiles, desktopPnpm) => {
     mountManager(ctx, {
-      profile: profiles.current.name,
-      profileDir: profiles.current.dir,
+      profile: desktopProfiles.current.name,
+      profileDir: desktopProfiles.current.dir,
       runPlugin: (args, cwd, signal) => desktopPnpm.runPlugin(args, cwd, signal),
     })
   })
@@ -99,6 +99,30 @@ export function apply(ctx: Context, config: { profile?: string }): void {
 由用户明确请求的构建可以使用低层 `desktopPnpm.run(['--dir', absolutePluginDir, 'run', 'build'], signal)`，因为它构建的是本地检出，不会修改活动 profile。必须提供 deadline，读取两个输出流，保留返回的 handle，并在 dispose 时调用 `cancel()` 后等待 `done`。非零退出码、信号终止或被拒绝的 `done` 都必须阻止镜像继续启动。
 
 参考实现见 [`dsh-dev-sandbox`](https://github.com/zp-home/dsh-dev-sandbox)。
+
+## 沙盒的 Desktop 设置入口
+
+沙盒 Client 应进入官方的设置导航，而不是创建自定义的侧边栏节点或 overlay。为 `settings.section` 注册一个稳定的 id。当前设置导航中，`order: 25` 会把 `sandbox` 放在内置“Agent 预设”（`order: 20`）之后。
+
+```tsx
+import type { ClientContext } from '@deepseek-ai/dsh-client-runtime/client'
+import type {} from '@deepseek-ai/dsh-client-ui-settings/client'
+import { SandboxSettingsSection } from './SandboxSettingsSection'
+
+export const inject = ['slots', 'locale']
+
+export function apply(ctx: ClientContext): void {
+  ctx.slots.inject('settings.section', () => ctx.slots.register({
+    name: 'settings.section',
+    id: 'sandbox',
+    order: 25,
+    locale: 'dsh-dev-sandbox',
+    label: () => ctx.locale.bind('dsh-dev-sandbox')('entry.label'),
+  }, SandboxSettingsSection))
+}
+```
+
+section 组件应在设置内容区渲染沙盒工作台。它必须在 Client fiber dispose 时清理已挂载的 DOM 与请求；不要跨 generation 保留设置 DOM 节点、overlay 状态或 Desktop Host service。
 
 ## `run()`、`runPlugin()` 和 `installPlugin()` 的区别
 

--- a/docs/plugin-development.md
+++ b/docs/plugin-development.md
@@ -78,7 +78,7 @@ export function apply(ctx: Context, config: { profile?: string }): void {
     return
   }
 
-  ctx.inject(['desktopPnpm'], (desktopPnpm) => {
+  ctx.inject(['desktopProfiles', 'desktopPnpm'], (desktopPnpm) => {
     mountManager(ctx, {
       profile: profiles.current.name,
       profileDir: profiles.current.dir,
@@ -89,6 +89,16 @@ export function apply(ctx: Context, config: { profile?: string }): void {
 ```
 
 普通 DSH 的 fallback 仍然是插件自己的权威实现。不要从 `process.argv`、`ctx.baseUrl`、settings 或 `$DSH_HOME` 推断 Desktop profile；在 Desktop 中以 `desktopProfiles.current` 为准。
+
+## 隔离开发沙盒镜像
+
+外部开发沙盒插件可以使用这种跨环境模式，在不修改活动 Desktop profile 的情况下测试本地插件检出。它的目标是隔离的 DSH Web 镜像，而不是第二个 Electron 进程。
+
+当存在 `desktopProfiles` 时，嵌套的 `ctx.inject()` 依赖集合应同时保留 `desktopProfiles` 和 `desktopPnpm`。`host-web` 镜像应以当前 Host generation 中不可变的 `desktopProfiles.current.dir` 为来源；不要假设为 `profiles/web`，也不要在任一 Desktop service 离开该 generation 后保留 profile 或 runner。
+
+由用户明确请求的构建可以使用低层 `desktopPnpm.run(['--dir', absolutePluginDir, 'run', 'build'], signal)`，因为它构建的是本地检出，不会修改活动 profile。必须提供 deadline，读取两个输出流，保留返回的 handle，并在 dispose 时调用 `cancel()` 后等待 `done`。非零退出码、信号终止或被拒绝的 `done` 都必须阻止镜像继续启动。
+
+参考实现见 [`dsh-dev-sandbox`](https://github.com/zp-home/dsh-dev-sandbox)。
 
 ## `run()`、`runPlugin()` 和 `installPlugin()` 的区别
 


### PR DESCRIPTION
## Summary / 摘要

Document the lifecycle-safe pattern for an external plugin that creates an isolated DSH Web development mirror:

- require both public Desktop services in the nested injection so the adapter unloads with either service;
- mirror `desktopProfiles.current.dir` rather than guessing `profiles/web`;
- use `desktopPnpm.run()` only for explicit local checkout builds, with a deadline, output draining, cancellation, and awaited completion; and
- distinguish a Web mirror from an Electron application test.

The reference implementation is `zp-home/dsh-dev-sandbox` on `feat/desktop-aware-sandbox`; its Desktop adapter has been typechecked, tested, built, and verified in a clean local mirror.

## Related Issues / 关联 Issue

Closes #427

## Type / 类型

- [x] Documentation / 文档

## Platforms / 影响平台

- [x] Not platform-specific / 与平台无关

## Verification / 验证

- [x] `git diff --check`
- [ ] `corepack yarn check:layout` (not run; documentation-only change)
- [ ] `corepack yarn typecheck` (not run; documentation-only change)
- [ ] `corepack yarn test` (not run; documentation-only change)
- [ ] `corepack yarn check` (not run; documentation-only change)
- [ ] Platform package smoke / 平台打包或启动冒烟 (not applicable)
- [ ] Manual test / 人工测试 (not applicable)

## Release Notes / 发布说明

Developer-facing documentation only. External plugin authors can follow the public Desktop service boundary when building isolated Web mirrors.