### PR TITLE
fix(market): surface operation failure details

### DIFF
--- a/dsh-community-market/src/client/MarketSettingsTab.tsx
+++ b/dsh-community-market/src/client/MarketSettingsTab.tsx
@@ -121,6 +121,12 @@ function isDesktopUnavailable(cause: unknown): boolean {
     && (cause as { status?: unknown }).status === 503
 }
 
+function operationErrorMessage(cause: unknown, fallback: string): string {
+  return cause instanceof Error && cause.message.trim().length > 0
+    ? cause.message
+    : fallback
+}
+
 function catalogFailureMessage(
   cause: unknown,
   source: MarketSourceView,
@@ -708,11 +714,11 @@ export function MarketSurface({ initialView = 'installable', readLocale, t, show
         setInstallationsError(t('desktopUnavailable'))
         setOperationError(t('desktopUnavailable'))
       } else {
-        setOperationError(t(requestValue.action === 'install'
+        setOperationError(operationErrorMessage(cause, t(requestValue.action === 'install'
           ? 'previewError'
           : requestValue.action === 'uninstall'
             ? 'uninstallPreviewError'
-            : requestValue.action === 'disable' ? 'disablePreviewError' : 'enablePreviewError'))
+            : requestValue.action === 'disable' ? 'disablePreviewError' : 'enablePreviewError')))
       }
     } finally {
       if (operationRequest.current === request) {
@@ -894,7 +900,7 @@ export function MarketSurface({ initialView = 'installable', readLocale, t, show
         setInstallationsError(t('desktopUnavailable'))
         setOperationError(t('desktopUnavailable'))
       } else {
-        setOperationError(t('executeError'))
+        setOperationError(operationErrorMessage(cause, t('executeError')))
       }
     } finally {
       if (operationRequest.current === request) {

--- a/dsh-community-market/tests/market-settings-tab.spec.tsx
+++ b/dsh-community-market/tests/market-settings-tab.spec.tsx
@@ -612,7 +612,7 @@ describe('MarketSettingsTab', () => {
       previewId: 'opaque-retry-install-preview',
     })
     vi.mocked(executeMarketOperation)
-      .mockRejectedValueOnce(new Error('install failed'))
+      .mockRejectedValueOnce(new Error('The package manager failed after changing the active profile, so the partial installation was rolled back.'))
       .mockResolvedValueOnce({
         action: 'install',
         receipt,
@@ -629,7 +629,9 @@ describe('MarketSettingsTab', () => {
       'opaque-retry-install-preview',
       expect.any(AbortSignal),
     ))
-    expect((await screen.findByRole('alert')).textContent).toContain(en.executeError)
+    expect((await screen.findByRole('alert')).textContent).toContain(
+      'The package manager failed after changing the active profile, so the partial installation was rolled back.',
+    )
     expect(within(screen.getByRole('dialog', { name: en.confirmInstallTitle }))
       .getByRole('button', { name: en.confirmInstall })).toBeTruthy()
 
@@ -697,7 +699,7 @@ describe('MarketSettingsTab', () => {
     fireEvent.click(screen.getByRole('button', { name: en.installable }))
     fireEvent.click(await screen.findByRole('button', { name: `${en.install}: ${item.displayName}` }))
 
-    expect(await screen.findByText(en.previewError)).toBeTruthy()
+    expect(await screen.findByText('not a standard plugin')).toBeTruthy()
     const details = screen.getByRole('link', { name: en.verificationDetails }) as HTMLAnchorElement
     expect(details.href).toBe(
       'https://github.com/anywhere-labs/deepseek-harness-desktop/blob/master/dsh-community-market/docs/install-and-uninstall.md',


### PR DESCRIPTION
## Summary\n- Show the server/client error message for market preview and execution failures instead of always falling back to the generic operation error.\n- Keep the desktop-unavailable branch intact.\n- Add a regression test for preview and execution failure text.\n\n## Verification\n- corepack yarn workspace dsh-community-market test tests/market-settings-tab.spec.tsx\n- corepack yarn workspace dsh-community-market typecheck\n\nRefs #334, #414