### PR TITLE
fix(desktop): skip unreadable directory picker entries

### DIFF
--- a/dsh-plugin-desktop/tests/package.spec.ts
+++ b/dsh-plugin-desktop/tests/package.spec.ts
@@ -198,6 +198,27 @@ describe('published package surface', () => {
     }
   })
 
+  it('patches the browse backend to skip unreadable directory-looking entries', () => {
+    const patchPath = './patches/dsh-host-directory-picker-browse@0.1.1-rc.2.patch'
+    expect(workspaceManifest.resolutions).toMatchObject({
+      '@deepseek-ai/dsh-host-directory-picker-browse@npm:0.1.1-rc.2': expect.stringContaining(patchPath),
+      '@deepseek-ai/dsh-host-directory-picker-browse@npm:^0.1.1-rc.2': expect.stringContaining(patchPath),
+    })
+    const patch = readFileSync(new URL(patchPath, workspaceRoot), 'utf8')
+    const installedHost = readFileSync(new URL(
+      'node_modules/@deepseek-ai/dsh-host-directory-picker-browse/lib/index.js',
+      packageRoot,
+    ), 'utf8')
+    for (const marker of [
+      'Windows reparse/system directories may appear as directories but fail `stat`',
+      'let enterable = false;',
+      'if (isDirectory || isSymbolicLink) try {',
+    ]) {
+      expect(patch).toContain(marker)
+      expect(installedHost).toContain(marker)
+    }
+  })
+
   it('marks the upstream Workspace browser as the desktop folder-drop target', () => {
     const patchPath = './patches/dsh-client-ui-workspace@0.1.1-rc.2.patch'
     expect(workspaceManifest.resolutions).toMatchObject({

--- a/package.json
+++ b/package.json
@@ -22,6 +22,8 @@
     "@deepseek-ai/dsh-sandbox-windows-acl@npm:^0.1.1-rc.2": "patch:@deepseek-ai/dsh-sandbox-windows-acl@npm%3A0.1.1-rc.2#./patches/dsh-sandbox-windows-acl@0.1.1-rc.2.patch",
     "@deepseek-ai/dsh-client-ui-directory-picker-browse@npm:0.1.1-rc.2": "patch:@deepseek-ai/dsh-client-ui-directory-picker-browse@npm%3A0.1.1-rc.2#./patches/dsh-client-ui-directory-picker-browse@0.1.1-rc.2.patch",
     "@deepseek-ai/dsh-client-ui-directory-picker-browse@npm:^0.1.1-rc.2": "patch:@deepseek-ai/dsh-client-ui-directory-picker-browse@npm%3A0.1.1-rc.2#./patches/dsh-client-ui-directory-picker-browse@0.1.1-rc.2.patch",
+    "@deepseek-ai/dsh-host-directory-picker-browse@npm:0.1.1-rc.2": "patch:@deepseek-ai/dsh-host-directory-picker-browse@npm%3A0.1.1-rc.2#./patches/dsh-host-directory-picker-browse@0.1.1-rc.2.patch",
+    "@deepseek-ai/dsh-host-directory-picker-browse@npm:^0.1.1-rc.2": "patch:@deepseek-ai/dsh-host-directory-picker-browse@npm%3A0.1.1-rc.2#./patches/dsh-host-directory-picker-browse@0.1.1-rc.2.patch",
     "@deepseek-ai/dsh-client-ui-workspace@npm:0.1.1-rc.2": "patch:@deepseek-ai/dsh-client-ui-workspace@npm%3A0.1.1-rc.2#./patches/dsh-client-ui-workspace@0.1.1-rc.2.patch",
     "@deepseek-ai/dsh-client-ui-workspace@npm:^0.1.1-rc.2": "patch:@deepseek-ai/dsh-client-ui-workspace@npm%3A0.1.1-rc.2#./patches/dsh-client-ui-workspace@0.1.1-rc.2.patch",
     "@deepseek-ai/dsh-client-ui-trajectory@npm:0.1.1-rc.2": "patch:@deepseek-ai/dsh-client-ui-trajectory@npm%3A0.1.1-rc.2#./patches/dsh-client-ui-trajectory@0.1.1-rc.2.patch",

--- a/patches/dsh-host-directory-picker-browse@0.1.1-rc.2.patch
+++ b/patches/dsh-host-directory-picker-browse@0.1.1-rc.2.patch
@@ -1,0 +1,20 @@
+diff --git a/lib/index.js b/lib/index.js
+index 2b8c76e26a05022d8f24fcfff651bc8c1ee83dec..ffd9b0493d53c76debb08e45fff5579da433161a 100644
+--- a/lib/index.js
++++ b/lib/index.js
+@@ -117,11 +117,13 @@ function messageOf(error) {
+ * One listing row for a dirent, following symlinks to directories; null for
+ * non-directories and broken/cyclic links (skipped silently — the browser
+ * shows what can be entered, and a broken link cannot).
++* Windows reparse/system directories may appear as directories but fail `stat`;
++* treat those the same way so the parent listing stays usable.
+ */
+ async function directoryRow(parent, name, isDirectory, isSymbolicLink, signal) {
+ 	const path = join(parent, name);
+-	let enterable = isDirectory;
+-	if (!enterable && isSymbolicLink) try {
++	let enterable = false;
++	if (isDirectory || isSymbolicLink) try {
+ 		enterable = (await raceAbort(stat(path), signal)).isDirectory();
+ 	} catch {
+ 		/* v8 ignore next 2 -- an abort landing mid-probe needs a stalled stat; the per-candidate check in list covers the settled path. */

--- a/yarn.lock
+++ b/yarn.lock
@@ -2541,7 +2541,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@deepseek-ai/dsh-host-directory-picker-browse@npm:0.1.1-rc.2, @deepseek-ai/dsh-host-directory-picker-browse@npm:^0.1.1-rc.2":
+"@deepseek-ai/dsh-host-directory-picker-browse@npm:0.1.1-rc.2":
   version: 0.1.1-rc.2
   resolution: "@deepseek-ai/dsh-host-directory-picker-browse@npm:0.1.1-rc.2"
   dependencies:
@@ -2551,6 +2551,19 @@ __metadata:
     "@deepseek-ai/cordis": ^4.0.1
     "@deepseek-ai/dsh-invariants": ^0.1.1-rc.2
   checksum: 10c0/5c62ed480e87092585f04ecea2ef78601fa895dab0982f4e6a8ee866886f182f725afe80a873bb580c72784e1732f93aa0dba8a8bbf55a953d62657e053e9059
+  languageName: node
+  linkType: hard
+
+"@deepseek-ai/dsh-host-directory-picker-browse@patch:@deepseek-ai/dsh-host-directory-picker-browse@npm%3A0.1.1-rc.2#./patches/dsh-host-directory-picker-browse@0.1.1-rc.2.patch::locator=deepseek-harness-desktop%40workspace%3A.":
+  version: 0.1.1-rc.2
+  resolution: "@deepseek-ai/dsh-host-directory-picker-browse@patch:@deepseek-ai/dsh-host-directory-picker-browse@npm%3A0.1.1-rc.2#./patches/dsh-host-directory-picker-browse@0.1.1-rc.2.patch::version=0.1.1-rc.2&hash=c1fda8&locator=deepseek-harness-desktop%40workspace%3A."
+  dependencies:
+    "@deepseek-ai/dsh-host-directory-picker": "npm:^0.1.1-rc.2"
+    "@deepseek-ai/schemastery": "npm:^3.18.1"
+  peerDependencies:
+    "@deepseek-ai/cordis": ^4.0.1
+    "@deepseek-ai/dsh-invariants": ^0.1.1-rc.2
+  checksum: 10c0/8f8c44c1fb7e278ce77c6e839299623bb019a4ca5b57083e6e7eea4bd74a1a1fbb3288b17e1cfdb2322f6803f587d341d0139553ca86ccac5549603571decb83
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary\n- Patch the desktop-bundled directory picker browse backend so directory-looking entries that fail stat are skipped instead of surfacing as enterable rows.\n- This keeps Windows workspace browsing usable around protected/system folders such as the Start Menu case in #297.\n- Add a package-surface regression check that the patched backend is present in the published desktop workspace.\n\n## Verification\n- corepack yarn workspace dsh-plugin-desktop test tests/package.spec.ts\n- corepack yarn workspace dsh-plugin-desktop typecheck\n- corepack yarn install --immutable\n\nRefs #297