### PR TITLE
fix(market): accept truncated 1024Store scans

### DIFF
--- a/dsh-community-market/src/adapters/dsh-1024store.ts
+++ b/dsh-community-market/src/adapters/dsh-1024store.ts
@@ -406,8 +406,13 @@ function buildCatalogScanSnapshots(
     ? new Date(generatedAt).toISOString()
     : undefined
   const providerRevision = plainText(meta.revision, 160, '') || undefined
-  const total = providerTotal(meta, raw.packages.length) ?? items.length
-  if (total !== items.length) throw new Error('1024Store scan did not reach the provider total')
+  // The 1024Store endpoint returns only a bounded prefix of its catalog and
+  // ignores pagination parameters, so a complete scan is impossible. Accept
+  // the truncated response: report the received item count as the page total
+  // so the scan completes and the source stays browsable. The provider
+  // metadata total remains available through the browse path (buildSnapshot).
+  providerTotal(meta, raw.packages.length)
+  const total = items.length
   const fetchedAt = new Date().toISOString()
   const snapshots: CatalogSnapshot[] = []
   for (let offset = 0; offset < items.length; offset += 100) {

--- a/dsh-community-market/tests/market-runtime.spec.ts
+++ b/dsh-community-market/tests/market-runtime.spec.ts
@@ -375,7 +375,7 @@ describe('1024Store adapter', () => {
     expect(snapshot.page).toEqual({ nextCursor: '50', total: 7635 })
   })
 
-  it('fails a complete 1024Store scan when provider metadata says more items exist', async () => {
+  it('accepts a truncated 1024Store scan when provider metadata claims more items than the endpoint returns', async () => {
     const packages = Array.from({ length: 51 }, (_, index) => ({
       ...rawCatalog.packages[0]!,
       id: `anywhere-labs/plugin-${index}`,
@@ -389,10 +389,14 @@ describe('1024Store adapter', () => {
       })),
     }
 
-    await expect(dsh1024StoreAdapter.scanCatalog!(
+    const snapshots = await dsh1024StoreAdapter.scanCatalog!(
       { limit: 100 },
       { source: source(), signal: new AbortController().signal, http, media: { register: () => fixtureAssetRef } },
-    )).rejects.toThrow(/provider total/u)
+    )
+
+    expect(snapshots).toHaveLength(1)
+    expect(snapshots[0]!.items).toHaveLength(51)
+    expect(snapshots[0]!.page).toEqual({ total: 51 })
   })
 
   it('keeps the reviewed 1024Store adapter page size fixed at 50', async () => {


### PR DESCRIPTION
## Problem

The DSH 1024Store catalog endpoint (https://deepseek1024.com/api/v1/plugins) returns only a bounded prefix of its catalog (300 packages) and ignores all pagination parameters, while its meta.total claims the full catalog size (8695).

The scan path in dsh-1024store.ts (buildCatalogScanSnapshots) required providerTotal === items.length and threw '1024Store scan did not reach the provider total', so opening the 1024Store source in the plugin market always failed with a load error.

## Fix

Accept the truncated response in the scan path: keep the provider metadata sanity check (providerTotal still validates an inconsistent total), but report the received item count as the page total so the scan completes and the source stays browsable. The browse path (buildSnapshot) is unchanged and still surfaces the provider-claimed total for sorting and paging.

## Test

Updated market-runtime.spec.ts: the previous test that asserted the scan rejects a truncated response now asserts the scan accepts it and reports the received item count. All 83 tests in market-runtime.spec.ts pass.

## Notes

- The 1024Store endpoint does not support pagination (page, cursor, offset, limit, per_page, size all return the same 300-item payload), so a complete scan is not possible from the client side. Users can browse the 300 returned plugins; the provider-claimed total (8695) remains visible through the browse path.
- A follow-up could ask the 1024Store service to expose real pagination; this fix makes the source usable in the meantime.