### PR TITLE
fix(desktop): localize trajectory zh labels

### DIFF
--- a/dsh-plugin-desktop/tests/package.spec.ts
+++ b/dsh-plugin-desktop/tests/package.spec.ts
@@ -226,6 +226,36 @@ describe('published package surface', () => {
     }
   })
 
+  it('localizes Trajectory toolbar labels in Simplified Chinese', () => {
+    const patchPath = './patches/dsh-client-ui-trajectory@0.1.1-rc.1.patch'
+    expect(workspaceManifest.resolutions).toMatchObject({
+      '@deepseek-ai/dsh-client-ui-trajectory@npm:0.1.1-rc.1': expect.stringContaining(patchPath),
+      '@deepseek-ai/dsh-client-ui-trajectory@npm:^0.1.1-rc.1': expect.stringContaining(patchPath),
+    })
+    const patch = readFileSync(new URL(patchPath, workspaceRoot), 'utf8')
+    const installedClient = readFileSync(new URL(
+      'node_modules/@deepseek-ai/dsh-client-ui-trajectory/lib/client.js',
+      packageRoot,
+    ), 'utf8')
+    for (const marker of [
+      '"toolbar.duration": "耗时"',
+      '"toolbar.useActualDuration": "使用实际耗时"',
+      '"toolbar.useEqualWidth": "使用等宽操作"',
+      '"toolbar.turns": "轮次"',
+      '"toolbar.expandTurns": "展开轮次"',
+      '"toolbar.collapseTurns": "折叠轮次"',
+      '"toolbar.calls": "调用"',
+      '"toolbar.expandCalls": "展开调用"',
+      '"toolbar.collapseCalls": "折叠调用"',
+      '"toolbar.thinking": "思考"',
+      'children: [trajectoryLabel("toolbar.thinking")',
+      'currentTrajectoryT = t',
+    ]) {
+      expect(patch).toContain(marker)
+      expect(installedClient).toContain(marker)
+    }
+  })
+
   it('keeps Desktop boot from opening an external browser and uses Electron Node mode for explicit helpers', () => {
     const patchPath = './patches/dsh-web-app@0.1.1-rc.1.patch'
     expect(workspaceManifest.resolutions).toMatchObject({

--- a/package.json
+++ b/package.json
@@ -24,6 +24,8 @@
     "@deepseek-ai/dsh-client-ui-directory-picker-browse@npm:^0.1.1-rc.1": "patch:@deepseek-ai/dsh-client-ui-directory-picker-browse@npm%3A0.1.1-rc.1#./patches/dsh-client-ui-directory-picker-browse@0.1.1-rc.1.patch",
     "@deepseek-ai/dsh-client-ui-workspace@npm:0.1.1-rc.1": "patch:@deepseek-ai/dsh-client-ui-workspace@npm%3A0.1.1-rc.1#./patches/dsh-client-ui-workspace@0.1.1-rc.1.patch",
     "@deepseek-ai/dsh-client-ui-workspace@npm:^0.1.1-rc.1": "patch:@deepseek-ai/dsh-client-ui-workspace@npm%3A0.1.1-rc.1#./patches/dsh-client-ui-workspace@0.1.1-rc.1.patch",
+    "@deepseek-ai/dsh-client-ui-trajectory@npm:0.1.1-rc.1": "patch:@deepseek-ai/dsh-client-ui-trajectory@npm%3A0.1.1-rc.1#./patches/dsh-client-ui-trajectory@0.1.1-rc.1.patch",
+    "@deepseek-ai/dsh-client-ui-trajectory@npm:^0.1.1-rc.1": "patch:@deepseek-ai/dsh-client-ui-trajectory@npm%3A0.1.1-rc.1#./patches/dsh-client-ui-trajectory@0.1.1-rc.1.patch",
     "@deepseek-ai/dsh-client-ui-settings-models@npm:0.1.1-rc.1": "patch:@deepseek-ai/dsh-client-ui-settings-models@npm%3A0.1.1-rc.1#./patches/dsh-client-ui-settings-models@0.1.1-rc.1.patch",
     "@deepseek-ai/dsh-client-ui-settings-models@npm:^0.1.1-rc.1": "patch:@deepseek-ai/dsh-client-ui-settings-models@npm%3A0.1.1-rc.1#./patches/dsh-client-ui-settings-models@0.1.1-rc.1.patch",
     "@deepseek-ai/dsh-web-app@npm:0.1.1-rc.1": "patch:@deepseek-ai/dsh-web-app@npm%3A0.1.1-rc.1#./patches/dsh-web-app@0.1.1-rc.1.patch",

--- a/patches/dsh-client-ui-trajectory@0.1.1-rc.1.patch
+++ b/patches/dsh-client-ui-trajectory@0.1.1-rc.1.patch
@@ -1,0 +1,37 @@
+diff --git a/lib/client.js b/lib/client.js
+index 928d9f0a6d2e1f1af6b6aa627f76a6efcb9c6fdb..1a2cd164a90df92f17369e550d61078887583fd7 100644
+--- a/lib/client.js
++++ b/lib/client.js
+@@ -52,3 +52,3 @@
+-			"toolbar.duration": "Duration",
+-			"toolbar.useActualDuration": "Use actual duration",
+-			"toolbar.useEqualWidth": "Use equal-width operations",
++			"toolbar.duration": "耗时",
++			"toolbar.useActualDuration": "使用实际耗时",
++			"toolbar.useEqualWidth": "使用等宽操作",
+@@ -56,6 +56,7 @@
+-			"toolbar.turns": "Turns",
+-			"toolbar.expandTurns": "Expand turns",
+-			"toolbar.collapseTurns": "Collapse turns",
+-			"toolbar.calls": "Calls",
+-			"toolbar.expandCalls": "Expand calls",
+-			"toolbar.collapseCalls": "Collapse calls",
++			"toolbar.turns": "轮次",
++			"toolbar.expandTurns": "展开轮次",
++			"toolbar.collapseTurns": "折叠轮次",
++			"toolbar.calls": "调用",
++			"toolbar.expandCalls": "展开调用",
++			"toolbar.collapseCalls": "折叠调用",
++			"toolbar.thinking": "思考",
+@@ -78,0 +80 @@
++			"toolbar.thinking": "Thinking",
+@@ -81,0 +84,4 @@
++		let currentTrajectoryT = (key) => en[key] ?? key;
++		function trajectoryLabel(key) {
++			return currentTrajectoryT(key);
++		}
+@@ -4076 +4082 @@
+-								children: ["Thinking", (0, react_jsx_runtime.jsx)(_deepseek_ai_dsh_client_ui_primitives.IconChevronRightOutline14, {
++								children: [trajectoryLabel("toolbar.thinking"), (0, react_jsx_runtime.jsx)(_deepseek_ai_dsh_client_ui_primitives.IconChevronRightOutline14, {
+@@ -7007,0 +7014 @@
++			currentTrajectoryT = t;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1682,7 +1682,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@deepseek-ai/dsh-client-ui-trajectory@npm:^0.1.1-rc.1":
+"@deepseek-ai/dsh-client-ui-trajectory@npm:0.1.1-rc.1":
   version: 0.1.1-rc.1
   resolution: "@deepseek-ai/dsh-client-ui-trajectory@npm:0.1.1-rc.1"
   dependencies:
@@ -1698,6 +1698,25 @@ __metadata:
     "@deepseek-ai/dsh-invariants": ^0.1.1-rc.1
     "@deepseek-ai/dsh-tools": ^0.1.1-rc.1
   checksum: 10c0/0bfbd7ea5445a661cb60ec81989d94c2297f58585224820c24bffff073f01e4c40a5b66cdf2786612a98e1933ed7cb1ef1d27deb53f2a6cdb3de2e431d1d5b3d
+  languageName: node
+  linkType: hard
+
+"@deepseek-ai/dsh-client-ui-trajectory@patch:@deepseek-ai/dsh-client-ui-trajectory@npm%3A0.1.1-rc.1#./patches/dsh-client-ui-trajectory@0.1.1-rc.1.patch::locator=deepseek-harness-desktop%40workspace%3A.":
+  version: 0.1.1-rc.1
+  resolution: "@deepseek-ai/dsh-client-ui-trajectory@patch:@deepseek-ai/dsh-client-ui-trajectory@npm%3A0.1.1-rc.1#./patches/dsh-client-ui-trajectory@0.1.1-rc.1.patch::version=0.1.1-rc.1&hash=bd6858&locator=deepseek-harness-desktop%40workspace%3A."
+  dependencies:
+    "@tanstack/react-virtual": "npm:^3.14.9"
+    diff: "npm:^9.0.0"
+  peerDependencies:
+    "@deepseek-ai/cordis": ^4.0.1
+    "@deepseek-ai/dsh-agent": ^0.1.1-rc.1
+    "@deepseek-ai/dsh-client-locale": ^0.1.1-rc.1
+    "@deepseek-ai/dsh-client-runtime": ^0.1.1-rc.1
+    "@deepseek-ai/dsh-client-ui-conversation": ^0.1.1-rc.1
+    "@deepseek-ai/dsh-compaction": ^0.1.1-rc.1
+    "@deepseek-ai/dsh-invariants": ^0.1.1-rc.1
+    "@deepseek-ai/dsh-tools": ^0.1.1-rc.1
+  checksum: 10c0/3b8265f86da2aa0ff6f63e4e74552282eb1c4cfeb99576e62b842c7455f42cd43acc56d08f3071a4d15cdc2d5e1f71e23a0c60e836f9bc658185c645ab10e332
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary
- Patch @deepseek-ai/dsh-client-ui-trajectory 0.1.1-rc.1 so Simplified Chinese uses Chinese labels for the Trajectory toolbar controls reported in #441.
- Localize the rendered Thinking disclosure label through the trajectory locale namespace.
- Add a package-surface regression that checks the patch resolution, patch file, and installed client output.

Fixes #441

## Verification
- PASS: corepack yarn workspace dsh-plugin-desktop test tests/package.spec.ts -t "localizes Trajectory toolbar labels"
- PASS: corepack yarn workspace dsh-plugin-desktop typecheck
- PASS: corepack yarn install --immutable
- NOTE: corepack yarn workspace dsh-plugin-desktop test tests/package.spec.ts hit an existing Windows Electron helper timeout in "launches the browser opener helper through Electron Node mode" after the new i18n test had passed.
