### PR TITLE
test(desktop): align CI profile expectations

### DIFF
--- a/dsh-plugin-desktop/tests/desktop-cli.spec.ts
+++ b/dsh-plugin-desktop/tests/desktop-cli.spec.ts
@@ -76,7 +76,7 @@ describe('packaged dsh bootstrap', () => {
       '工作 profile',
       'update',
     ])
-    expect(() => withDefaultDesktopProfile([], '../desktop')).toThrow('invalid profile name')
+    expect(() => withDefaultDesktopProfile([], '../desktop')).toThrow('invalid desktop profile name')
   })
 
   it('snapshots plugin installs launched from the built-in DSH Terminal', async () => {

--- a/dsh-plugin-desktop/tests/desktop-terminal.spec.ts
+++ b/dsh-plugin-desktop/tests/desktop-terminal.spec.ts
@@ -470,7 +470,7 @@ describe('desktop terminal environment', () => {
 
     const unsafe = macOptions(join(root, 'unsafe'), harness.spawn)
     unsafe.profileName = '../desktop'
-    expect(() => openDesktopTerminal(unsafe)).toThrow('invalid profile name')
+    expect(() => openDesktopTerminal(unsafe)).toThrow('invalid desktop profile name')
     expect(() => lstatSync(unsafe.stateDir)).toThrow()
 
     const localized = macOptions(join(root, 'localized'), harness.spawn)

--- a/dsh-plugin-desktop/tests/module-resolution.spec.ts
+++ b/dsh-plugin-desktop/tests/module-resolution.spec.ts
@@ -1,3 +1,4 @@
+import { pathToFileURL } from 'node:url'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const hooks = vi.hoisted(() => ({
@@ -53,7 +54,7 @@ describe('installProfilePackageResolver', () => {
       nextResolve,
     )).toEqual({
       shortCircuit: true,
-      url: 'file:///current/dsh-plugin-desktop/lib/index.js',
+      url: pathToFileURL('/current/dsh-plugin-desktop/lib/index.js').href,
     })
 
     expect(hooks.resolve?.(
@@ -62,7 +63,7 @@ describe('installProfilePackageResolver', () => {
       nextResolve,
     )).toEqual({
       shortCircuit: true,
-      url: 'file:///current/dsh-plugin-desktop/lib/profile.js',
+      url: pathToFileURL('/current/dsh-plugin-desktop/lib/profile.js').href,
     })
 
     expect(() => hooks.resolve?.(


### PR DESCRIPTION
## Summary
- update profile-name rejection assertions to match the current desktop validation error
- make desktop module-resolution URL expectations platform-aware on Windows

## Verification
- corepack yarn workspace dsh-plugin-desktop test tests/desktop-cli.spec.ts tests/desktop-terminal.spec.ts tests/module-resolution.spec.ts
- corepack yarn workspace dsh-plugin-desktop typecheck
- git diff --check
- corepack yarn check

## Notes
This fixes CI failures already present on master and should unblock rerunning PR #451.