### PR TITLE
fix(desktop): restore profile overlay CI

### DIFF
--- a/dsh-plugin-desktop/scripts/verify-profile-boot.mjs
+++ b/dsh-plugin-desktop/scripts/verify-profile-boot.mjs
@@ -132,6 +132,7 @@ try {
         dshBootstrapPath: fileURLToPath(new URL('../lib/desktop-cli.js', import.meta.url)),
         installRecoveryStatePath: join(home, 'plugin-install-recovery', 'state.json'),
         generationId: 'profile-smoke-generation',
+        externalMarketInstallEnabled: prepared.market.effective === 'dsh-market',
       })
       await host.plugin(DesktopProfileService, {
         current: {

--- a/dsh-plugin-desktop/src/profile-checkpoint.ts
+++ b/dsh-plugin-desktop/src/profile-checkpoint.ts
@@ -33,6 +33,7 @@ const MANIFEST_FILENAME = 'manifest.json'
 const MARKER_FILENAME = 'restore-marker.json'
 const FILE_MODE = 0o600
 const DIRECTORY_MODE = 0o700
+const CHECK_POSIX_MODE = process.platform !== 'win32'
 const HASH_PATTERN = /^[0-9a-f]{64}$/u
 const ID_PATTERN = /^[A-Za-z0-9._:@/-]{1,256}$/u
 
@@ -193,7 +194,7 @@ function ensureDirectory(path: string): void {
   const item = lstatSync(path)
   if (!item.isDirectory() || item.isSymbolicLink()) fail(`checkpoint directory is not a real directory: ${path}`)
   // chmod is intentional: an existing directory may have inherited a wider mode.
-  if ((item.mode & 0o777) !== DIRECTORY_MODE) {
+  if (CHECK_POSIX_MODE && (item.mode & 0o777) !== DIRECTORY_MODE) {
     // The caller owns this private directory; narrowing it is safe and avoids
     // exposing a checkpoint through a permissive umask/previous installation.
     chmodSync(path, DIRECTORY_MODE)
@@ -226,7 +227,7 @@ function writeDurable(path: string, bytes: Uint8Array, mode = FILE_MODE): void {
 
 function readJson(path: string): unknown {
   const item = lstatSync(path)
-  if (!item.isFile() || item.isSymbolicLink() || (item.mode & 0o777) !== FILE_MODE) {
+  if (!item.isFile() || item.isSymbolicLink() || (CHECK_POSIX_MODE && (item.mode & 0o777) !== FILE_MODE)) {
     fail(`checkpoint file has unsafe type or mode: ${path}`)
   }
   return JSON.parse(readFileSync(path, 'utf8')) as unknown
@@ -453,7 +454,8 @@ export class DesktopProfileCheckpoint {
       const candidate = join(parent, name)
       try {
         const item = lstatSync(candidate)
-        if (!item.isDirectory() || item.isSymbolicLink() || (item.mode & 0o777) !== DIRECTORY_MODE) continue
+        if (!item.isDirectory() || item.isSymbolicLink()
+          || (CHECK_POSIX_MODE && (item.mode & 0o777) !== DIRECTORY_MODE)) continue
         renameSync(candidate, this.snapshotDirectory)
         return
       } catch (cause) {
@@ -480,7 +482,8 @@ export class DesktopProfileCheckpoint {
   private readSnapshot(requireComplete: boolean): { readonly directory: string; readonly manifest: ProfileCheckpointManifest } | undefined {
     try {
       const directoryItem = lstatSync(this.snapshotDirectory)
-      if (!directoryItem.isDirectory() || directoryItem.isSymbolicLink() || (directoryItem.mode & 0o777) !== DIRECTORY_MODE) {
+      if (!directoryItem.isDirectory() || directoryItem.isSymbolicLink()
+        || (CHECK_POSIX_MODE && (directoryItem.mode & 0o777) !== DIRECTORY_MODE)) {
         fail('latest checkpoint directory has unsafe type or mode')
       }
       const value = readJson(join(this.snapshotDirectory, MANIFEST_FILENAME))
@@ -503,7 +506,8 @@ export class DesktopProfileCheckpoint {
         const backup = filePath(this.snapshotDirectory, expected)
         if (item.present) {
           const backupItem = lstatSync(backup)
-          if (!backupItem.isFile() || backupItem.isSymbolicLink() || (backupItem.mode & 0o777) !== FILE_MODE) fail(`checkpoint backup is unsafe: ${expected}`)
+          if (!backupItem.isFile() || backupItem.isSymbolicLink()
+            || (CHECK_POSIX_MODE && (backupItem.mode & 0o777) !== FILE_MODE)) fail(`checkpoint backup is unsafe: ${expected}`)
           const bytes = readFileSync(backup)
           if (bytes.byteLength !== item.size || hash(bytes) !== item.sha256) fail(`checkpoint backup is incomplete: ${expected}`)
         } else if (existsSync(backup)) {

--- a/dsh-plugin-desktop/tests/profile-checkpoint.spec.ts
+++ b/dsh-plugin-desktop/tests/profile-checkpoint.spec.ts
@@ -101,7 +101,9 @@ describe('Desktop profile health checkpoint', () => {
       expect.stringContaining('.tmp'),
       expect.stringContaining('.staging'),
     ]))
-    expect(lstatSync(join(target.checkpoint.snapshotDirectory, 'manifest.json')).mode & 0o777).toBe(0o600)
+    if (process.platform !== 'win32') {
+      expect(lstatSync(join(target.checkpoint.snapshotDirectory, 'manifest.json')).mode & 0o777).toBe(0o600)
+    }
   })
 
   it('restores drift, removes files absent from the healthy image, and marks one failed generation', () => {

--- a/dsh-plugin-desktop/tests/profile-materializer.spec.ts
+++ b/dsh-plugin-desktop/tests/profile-materializer.spec.ts
@@ -2,6 +2,7 @@ import { EventEmitter } from 'node:events'
 import { PassThrough } from 'node:stream'
 import type { ChildProcess, SpawnOptions } from 'node:child_process'
 import { delimiter } from 'node:path'
+import { pathToFileURL } from 'node:url'
 import { describe, expect, it, vi } from 'vitest'
 import {
   materializeProfile,
@@ -63,7 +64,7 @@ describe('profile materializer', () => {
     expect(command).toBe('/Applications/DSH Desktop.app/Contents/MacOS/DSH Desktop')
     expect(args).toEqual([
       '--import',
-      'file:///private/clear-env.mjs',
+      pathToFileURL('/private/clear-env.mjs').href,
       '/private/pnpm/bin/pnpm.mjs',
       'install',
       '--frozen-lockfile',


### PR DESCRIPTION
## Summary
- pass the selected Market install capability into the profile boot smoke bootstrap
- keep checkpoint symlink/type checks on Windows while avoiding POSIX mode equality checks that Windows cannot represent
- make the profile materializer preloader URL expectation platform-aware

## Verification
- corepack yarn workspace dsh-plugin-desktop test tests/profile-checkpoint.spec.ts tests/profile-materializer.spec.ts
- corepack yarn workspace dsh-plugin-desktop test tests/pnpm.spec.ts tests/profile-checkpoint.spec.ts tests/profile-materializer.spec.ts
- corepack yarn workspace dsh-plugin-desktop build
- corepack yarn workspace dsh-plugin-desktop verify:profile
- corepack yarn workspace dsh-plugin-desktop typecheck
- git diff --check
- corepack yarn check (first run hit an unrelated one-off dsh-community-market abort timing failure; targeted rerun passed; second full run passed)

## Notes
This addresses the master push CI failure from run 32472645677 after #451 was squash-merged.