### PR TITLE
docs: add runtime upgrade troubleshooting guide (中文/English)

### DIFF
--- a/docs/README.en.md
+++ b/docs/README.en.md
@@ -13,6 +13,7 @@ Ordinary users can start with the [user guide](user-guide.en.md) and never need 
 | Document | Covers |
 | --- | --- |
 | [User guide](user-guide.en.md) | Installation, profiles, modes, terminal, plugins, and updates |
+| [Upgrading the runtime](upgrading-runtime.en.md) | Troubleshooting shell-overwrites-runtime, plugin `prepareCall` errors, and pnpm guard blocks after a manual rc/runtime upgrade |
 | [FAQ](faq.en.md) | Direct answers about platforms, bundled runtime, project status, data, plugins, and updates |
 | [Why Desktop](why-desktop.en.md) | The boundary with upstream Harness and the case for plugins |
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -13,6 +13,7 @@
 | 文档 | 你会得到什么 |
 | --- | --- |
 | [用户指南](user-guide.md) | 安装、profile、模式、终端、插件命令和更新 |
+| [升级 runtime 排障](upgrading-runtime.md) | 手动升级 runtime/rc 版本后，壳覆盖 runtime、插件报 prepareCall、pnpm 守卫拦截的排障 |
 | [常见问题](faq.md) | 支持平台、内置环境、官方边界、数据、插件和更新的直接回答 |
 | [为什么做 Desktop](why-desktop.md) | Desktop 与官方 Harness 的边界，以及为什么坚持插件化 |
 

--- a/docs/upgrading-runtime.en.md
+++ b/docs/upgrading-runtime.en.md
@@ -1,0 +1,82 @@
+# Upgrading the DSH runtime — troubleshooting guide
+
+[中文](upgrading-runtime.md)
+
+This page is for users who **already run DSH Desktop or the local Web client and upgrade the `@deepseek-ai/dsh` runtime themselves** (for example switching to a pre-release like `0.1.1-rc.2`). If you only use the Desktop's built-in updater and have never touched `~/.dsh` manually, you can skip this page.
+
+> Note: this is a community-maintained troubleshooting note, not official documentation. The [`dsh-upgrade-toolkit`](https://github.com/TOBYCAI/dsh-upgrade-toolkit) mentioned here is an independent open-source tool maintained by a community author, with no affiliation or endorsement from this project. It codifies the reliable fixes for the problems below into reusable scripts.
+
+## Why things break
+
+DSH has **two independent version tracks**: the "shared install (runtime)" and the "Desktop shell (App)".
+
+- **runtime** = `@deepseek-ai/dsh` inside `~/.dsh/runtime`. It decides actual harness behavior, the adapter API, and plugin compatibility.
+- **shell** = the `DeepSeek Harness.app` (Electron package). On launch it uses `healProfilesModuleFallback` to symlink the `@deepseek-ai/*` packages under `~/.dsh/profiles` to the runtime.
+
+The trap: **a shell update can silently overwrite the runtime**, and **a runtime upgrade (especially rc pre-releases) changes the adapter API**, breaking older plugins or an older shell. Typical symptoms are tracked in community Issues #448 and #457.
+
+## Three common failure modes
+
+### 1. Shell update overwrites / desyncs the runtime
+
+Symptoms: after upgrading the runtime, restarting Desktop shows the old `dsh --version` again; or Desktop and the Web client resolve to different runtimes.
+
+Root cause: the shell's heal mechanism symlinks profile packages to the runtime **bundled inside the shell**, not the shared runtime you pinned.
+
+Fix: make the shared runtime the authority so shell and profile symlinks both resolve to it. See [`pin-runtime.sh`](https://github.com/TOBYCAI/dsh-upgrade-toolkit/blob/main/bin/pin-runtime.sh):
+
+```bash
+# Pin the shared runtime as authority (shell/profile symlinks → runtime);
+# re-run after any shell update.
+bash pin-runtime.sh
+```
+
+### 2. After upgrading to an rc version, a plugin throws `prepareCall is not a function`
+
+Symptoms: the Web client fails to start with `registration.adapter.prepareCall is not a function`.
+
+Root cause: `0.1.1-rc.2` introduced a **breaking adapter API change** — every LLM adapter must now implement `prepareCall(provider, model, signal)`. Some third-party plugins (e.g. `@liustack/modlens` <= 3.23.0) have not adapted and crash on load. **This is a general rc risk, not limited to one plugin.**
+
+Temporary fix: patch the plugin with a `prepareCall` implementation and freeze it via `pnpm patch`, then remove it once upstream ships a fix. The patch and full steps are in [`patches/modlens-prepareCall.md`](https://github.com/TOBYCAI/dsh-upgrade-toolkit/blob/main/patches/modlens-prepareCall.md).
+
+> For which plugins/versions break on which DSH version, see the [toolkit's compatibility matrix](https://github.com/TOBYCAI/dsh-upgrade-toolkit#compatibility-matrix-plugin--version-vs-dsh-version).
+
+### 3. Updating a plugin via the plugin manager is blocked by a "safe-delete guard"
+
+Symptoms: running the Web client inside a terminal that has a safe-delete guard (e.g. WorkBuddy) and updating a plugin through plugin-manager fails with:
+
+```
+ERROR [safe-delete][SAFE_DELETE_BULK_CONFIRM_REQUIRED] {"count":123,"threshold":50,...}
+```
+
+Root cause: the host terminal injects `CODEBUDDY_SAFE_DELETE_*` environment variables. When pnpm cleans up its temp directory at the end of an install (123 files), it exceeds the bulk-delete threshold, and the non-interactive call cannot confirm, so it aborts.
+
+Fix: unload those guard variables before launching the Web client (see the [`web` subcommand of `dsh-manage.sh`](https://github.com/TOBYCAI/dsh-upgrade-toolkit/blob/main/bin/dsh-manage.sh)):
+
+```bash
+env -u CODEBUDDY_SAFE_DELETE_BULK_GUARD \
+    -u CODEBUDDY_SAFE_DELETE_BULK_STATE_DIR \
+    -u CODEBUDDY_SESSION_ID \
+    -u CODEBUDDY_TOOL_CALL_ID \
+    dsh web
+```
+
+## All-in-one tool
+
+[`dsh-upgrade-toolkit`](https://github.com/TOBYCAI/dsh-upgrade-toolkit) bundles the fixes for all three problems into a reusable CLI:
+
+| Command | Purpose |
+| --- | --- |
+| `pin-runtime.sh` | Pin the runtime as authority; shell updates can't overwrite it |
+| `dsh-manage.sh update` | Upgrade runtime (pnpm + registry precheck + re-pin) |
+| `dsh-manage.sh shell` | Upgrade the Desktop shell (GitHub Releases + backup + replace) |
+| `dsh-manage.sh web` | Launch the Web client with the safe-delete guard unloaded |
+| `verify-heal.mjs` | Verify key packages still resolve to the runtime after heal |
+
+> The tool is **complementary, not competitive**: it does not modify Desktop source; it only manages the version relationship between runtime and shell on the user's side. If you only use the Desktop's built-in updater, the manual steps in the first three sections are enough.
+
+## Related links
+
+- Community Issue [#448](https://github.com/anywhere-labs/deepseek-harness-desktop/issues/448) (rc.1 adaptation request)
+- Community Issue [#457](https://github.com/anywhere-labs/deepseek-harness-desktop/issues/457) (Desktop/Web version desync)
+- [dsh-upgrade-toolkit](https://github.com/TOBYCAI/dsh-upgrade-toolkit)

--- a/docs/upgrading-runtime.md
+++ b/docs/upgrading-runtime.md
@@ -1,0 +1,81 @@
+# 升级 DSH 运行时（runtime）排障指南
+
+[English](upgrading-runtime.en.md)
+
+本页面向**已经在使用 DSH Desktop 或本地 Web 端、并自行升级 `@deepseek-ai/dsh` runtime（例如切到 `0.1.1-rc.2` 等预发布版本）** 的用户。如果你只是用桌面端自带的更新按钮、没有手动动过 `~/.dsh`，可以跳过本页。
+
+> 说明：本页是社区维护的排障笔记，不是官方文档。文中提到的 [`dsh-upgrade-toolkit`](https://github.com/TOBYCAI/dsh-upgrade-toolkit) 是一个独立的开源工具，由社区作者维护，与本项目不存在隶属或背书关系。它把下面几类问题的可靠解法固化成了可复用脚本。
+
+## 为什么会踩坑
+
+DSH 的"共享安装（runtime）"和"桌面壳（Desktop App）"是**两套独立的版本**：
+
+- **runtime** = `~/.dsh/runtime` 里的 `@deepseek-ai/dsh`，决定实际的 harness 行为、adapter API、插件兼容性。
+- **壳** = `DeepSeek Harness.app`（Electron 包），启动时通过 `healProfilesModuleFallback` 把 `~/.dsh/profiles` 下的 `@deepseek-ai/*` 软链接指向 runtime。
+
+问题出在：**壳更新可能静默覆盖 runtime**，而 **runtime 升级（尤其是 rc 预发布版本）会改变 adapter API**，导致旧插件或旧壳崩溃。典型现象见 [常见问题](faq.md) 与社区 Issue #448、#457。
+
+## 三类高频问题
+
+### 1. 壳更新后 runtime 被覆盖 / 版本错位
+
+现象：明明升级过 runtime，重启桌面端后 `dsh --version` 又变回旧版；或桌面端和 Web 端读取的 runtime 不一致。
+
+根因：壳的 heal 机制把 profiles 的包软链接指向壳**自带**的 runtime，而不是你钉死的共享 runtime。
+
+解法：把共享 runtime 设为权威，让壳和 profiles 的软链接都解析到它。参考 [`pin-runtime.sh`](https://github.com/TOBYCAI/dsh-upgrade-toolkit/blob/main/bin/pin-runtime.sh)：
+
+```bash
+# 钉死 runtime 为权威（壳/Profile 软链 → runtime），壳更新后重跑即可
+bash pin-runtime.sh
+```
+
+### 2. 升级到 rc 版本后，第三方插件报 `prepareCall is not a function`
+
+现象：Web 端启动报 `registration.adapter.prepareCall is not a function`。
+
+根因：`0.1.1-rc.2` 对 **adapter API 做了破坏性变更**——每个 LLM adapter 必须实现 `prepareCall(provider, model, signal)`。部分第三方插件（如 `@liustack/modlens` ≤ 3.23.0）尚未适配，会在加载时崩溃。**这是 rc 版本的普遍风险，不只是某一个插件。**
+
+临时解法：给插件打 `prepareCall` 补丁并用 `pnpm patch` 固化，等上游发版后移除。补丁示例与完整步骤见 [`patches/modlens-prepareCall.md`](https://github.com/TOBYCAI/dsh-upgrade-toolkit/blob/main/patches/modlens-prepareCall.md)。
+
+> 兼容性细节（哪些插件/版本不适配哪个 DSH 版本）见 [toolkit 的兼容性矩阵](https://github.com/TOBYCAI/dsh-upgrade-toolkit#兼容性矩阵插件--版本-vs-dsh-版本)。
+
+### 3. 用插件管理器更新插件时，pnpm 被"安全删除守卫"拦截
+
+现象：在 WorkBuddy 等带安全删除守卫的终端里启动 Web 端，用 plugin-manager 更新插件报：
+
+```
+ERROR [safe-delete][SAFE_DELETE_BULK_CONFIRM_REQUIRED] {"count":123,"threshold":50,...}
+```
+
+根因：宿主终端注入了 `CODEBUDDY_SAFE_DELETE_*` 环境变量，pnpm 在 install 收尾清理临时目录（含 123 个文件）时超过批量删除阈值，非交互式调用无法确认而中断。
+
+解法：启动 Web 端前卸载这些守卫变量（见 [`dsh-manage.sh` 的 `web` 子命令](https://github.com/TOBYCAI/dsh-upgrade-toolkit/blob/main/bin/dsh-manage.sh)）：
+
+```bash
+env -u CODEBUDDY_SAFE_DELETE_BULK_GUARD \
+    -u CODEBUDDY_SAFE_DELETE_BULK_STATE_DIR \
+    -u CODEBUDDY_SESSION_ID \
+    -u CODEBUDDY_TOOL_CALL_ID \
+    dsh web
+```
+
+## 一站式工具
+
+[`dsh-upgrade-toolkit`](https://github.com/TOBYCAI/dsh-upgrade-toolkit) 把上述三类问题的解法整合成一个可复用的命令行工具：
+
+| 命令 | 作用 |
+| --- | --- |
+| `pin-runtime.sh` | 钉死 runtime 权威，壳更新不再覆盖 |
+| `dsh-manage.sh update` | runtime 升级（pnpm + registry 预检 + 重钉） |
+| `dsh-manage.sh shell` | 桌面壳升级（GitHub Releases + 备份 + 替换） |
+| `dsh-manage.sh web` | 启动 Web 端并卸载安全删除守卫 |
+| `verify-heal.mjs` | 校验 heal 后关键包仍解析到 runtime |
+
+> 该工具是**互补而非竞争**：它不修改 Desktop 源码，只在用户侧管理 runtime 与壳的版本关系。如果你只想用桌面端自带的更新，本页前三节的手工步骤也足够。
+
+## 相关链接
+
+- 社区 Issue [#448](https://github.com/anywhere-labs/deepseek-harness-desktop/issues/448)（rc.1 适配请求）
+- 社区 Issue [#457](https://github.com/anywhere-labs/deepseek-harness-desktop/issues/457)（桌面端与 Web 端版本错位）
+- [dsh-upgrade-toolkit](https://github.com/TOBYCAI/dsh-upgrade-toolkit)


### PR DESCRIPTION
## Summary / 摘要

为**手动升级 `@deepseek-ai/dsh` runtime / rc 版本**的用户新增一份排障指南（中英双语）：

- 壳更新静默覆盖 / 错位共享 runtime（`pin-runtime.sh` 思路）；
- rc.2 破坏性 adapter API 变更导致第三方插件报 `prepareCall is not a function`；
- 在带安全删除守卫的终端里用插件管理器更新插件时 pnpm 被 `SAFE_DELETE_BULK_CONFIRM_REQUIRED` 拦截。

三类问题均已在社区 Issue #448、#457 中出现。文中链接到一个**独立维护、与本项目无隶属/背书关系**的互补工具 [`dsh-setup-manager`](https://github.com/TOBYCAI/dsh-setup-manager)（一站式安装 / 升级 / 维护 DSH；原名 `dsh-upgrade-toolkit`，已于 2026-08-26 更名），它把这些解法固化成了可复用脚本；本页也给出纯手工步骤，用户不装工具也能排障。

新增文件：
- `docs/upgrading-runtime.md`
- `docs/upgrading-runtime.en.md`
- 在 `docs/README.md` 与 `docs/README.en.md` 的用户文档表格中登记。

## Related Issues / 关联 Issue

参考 #448、#457（未直接 Closes，因为本 PR 是文档，不是代码修复）。

## Type / 类型

- [x] Documentation / 文档

## Platforms / 影响平台

- [x] Not platform-specific / 与平台无关

## Verification / 验证

- [x] `git diff --check`（无尾随空白/冲突标记）
- [ ] `corepack yarn check:layout` (not run; documentation-only change)
- [ ] `corepack yarn typecheck` (not run; documentation-only change)
- [ ] `corepack yarn test` (not run; documentation-only change)
- [ ] `corepack yarn check` (not run; documentation-only change)
- [ ] Platform package smoke / 平台打包或启动冒烟 (not applicable)
- [ ] Manual test / 人工测试 (not applicable)

## Release Notes / 发布说明

开发者/用户文档增补，无代码或行为变化。手动升级 runtime 的用户可在文档索引的"用户文档"中找到《升级 runtime 排障》。
