### PR TITLE
test(desktop): cover Host-only profile Bundles

### DIFF
--- a/dsh-plugin-desktop/docs/plugin-services.i18n.yaml
+++ b/dsh-plugin-desktop/docs/plugin-services.i18n.yaml
@@ -1,5 +1,5 @@
 # Bilingual-pair consistency record: the git blob hash of each side as of the last
 # confirmed-consistent state. Both languages carry equal authority. Update both files
 # and re-record their hashes with git hash-object after editing either side.
-plugin-services.md: 806df449c7bbaaa0554ff4152bee7d752558d607
-plugin-services.zh.md: 1c180df559889f775f3e59b6aaae7b5b3907d953
+plugin-services.md: 24ff8a652a1261e57f0fb956bf4aa31bef68ee78
+plugin-services.zh.md: 06779699947a4542fab65aa8aafea8296cf2b4ca

--- a/dsh-plugin-desktop/docs/plugin-services.md
+++ b/dsh-plugin-desktop/docs/plugin-services.md
@@ -289,18 +289,33 @@ Never fall back to a guessed `web` profile after `desktopProfiles` is present. A
 
 Type-only imports are erased from JavaScript. A cross-environment package can keep `dsh-plugin-desktop` as a development dependency for compilation, or as an optional peer if it publishes declarations that expose these types; it does not need a runtime import merely to probe the services.
 
+### Host-only channel connectors
+
+A long-running channel connector that only receives remote messages and starts or resumes DSH Agents does not need a Desktop-specific adapter. Package it as an ordinary DSH Bundle with a Host Loader entry, keep its top-level `inject` list limited to ordinary DSH services, and omit `dsh.client` when it contributes no browser UI. The same package can then run under Web, headless, and Desktop Hosts.
+
+Install the Bundle from the terminal opened by DSH Desktop so the command inherits the selected profile and the launcher's `DSH_HOME`:
+
+```powershell
+dsh plugin add C:\absolute\path\to\channel-connector.tgz
+pnpm exec channel-connector setup --agent-cwd C:\absolute\path\to\workspace
+```
+
+Use an absolute `.tgz` path on Windows when distributing a local package. Restart Desktop after `dsh plugin add` so the installed Bundle enters the next Loader generation. Setup commands should store secrets through DSH credentials and place private channel state under `DSH_HOME`; they must not derive the active profile from `process.argv`, the process working directory, or a guessed `web` default.
+
+Such a connector may read `ctx.get('desktopProfiles')?.current` for diagnostics or genuinely Desktop-specific optional behavior. It does not need `desktopProfiles` merely to run Agents, and it must not require `desktopPnpm` unless it performs package mutations itself. It must also avoid `desktopRuntime`, Electron APIs, tray internals, and renderer IPC. This keeps a no-UI connector portable and lets Desktop and Web surfaces reuse the same Host-owned Sessions.
+
 ## Minimal runnable test plugin
 
-The repository includes a two-file profile-local fixture at [`tests/fixtures/desktop-host-services-smoke-plugin`](../tests/fixtures/desktop-host-services-smoke-plugin/). Its entry declares `inject = ['desktopProfiles', 'desktopPnpm']`, reads `desktopProfiles.current`, and confirms that the command and recoverable-install lifecycle methods are available. It only publishes the result as a test probe; it never executes pnpm or changes a profile.
+The repository includes two profile-local fixtures. [`tests/fixtures/desktop-host-services-smoke-plugin`](../tests/fixtures/desktop-host-services-smoke-plugin/) declares `inject = ['desktopProfiles', 'desktopPnpm']`, reads `desktopProfiles.current`, and confirms that the command and recoverable-install lifecycle methods are available. [`tests/fixtures/host-only-profile-bundle`](../tests/fixtures/host-only-profile-bundle/) is a complete DSH Bundle with only ordinary Host dependencies and an optional Desktop capability probe.
 
-The complete Profile Loader smoke copies that package into a temporary profile's `node_modules`, loads it as a normal bare-package Loader entry, and fails unless the probe reports the active profile and both package-manager methods. Run it with:
+The complete Profile Loader smoke installs the Host-only fixture through the temporary profile's `dsh.profile.bundles` layer stack, loads the Desktop-only fixture as a normal bare-package Loader entry, and fails unless both activate with the expected core and Desktop services. Neither fixture executes pnpm or changes a live profile. Run the smoke with:
 
 ```sh
 yarn workspace dsh-plugin-desktop build
 yarn workspace dsh-plugin-desktop verify:profile
 ```
 
-This fixture is under `tests/`, is absent from the npm `files` list and Electron build files, and never enters a production archive.
+Both fixtures are under `tests/`, are absent from the npm `files` list and Electron build files, and never enter a production archive.
 
 ## Failure and teardown checklist
 

--- a/dsh-plugin-desktop/docs/plugin-services.zh.md
+++ b/dsh-plugin-desktop/docs/plugin-services.zh.md
@@ -288,18 +288,33 @@ export function apply(ctx: Context, config: { profile?: string }): void {
 
 Type-only import 会从 JavaScript 中消除。跨环境 package 可以把 `dsh-plugin-desktop` 作为编译所需 dev dependency；若发布的 declaration 会暴露这些类型，也可以将其声明为 optional peer。仅为了探测 service，不需要 runtime import。
 
+### 仅 Host 的通道连接器
+
+如果一个常驻通道连接器只负责接收远程消息并创建或恢复 DSH Agent，它不需要 Desktop 专用 adapter。把它打包成带 Host Loader entry 的普通 DSH Bundle，顶层 `inject` 只声明普通 DSH service；没有浏览器界面时不要声明 `dsh.client`。同一个 package 就能在 Web、headless 与 Desktop Host 中运行。
+
+请从 DSH Desktop 打开的终端安装 Bundle，这样命令会继承当前选中的 profile 与 launcher 的 `DSH_HOME`：
+
+```powershell
+dsh plugin add C:\absolute\path\to\channel-connector.tgz
+pnpm exec channel-connector setup --agent-cwd C:\absolute\path\to\workspace
+```
+
+在 Windows 上分发本地 package 时应使用绝对 `.tgz` 路径。执行 `dsh plugin add` 后重启 Desktop，让已安装 Bundle 进入下一次 Loader generation。Setup 命令应通过 DSH credentials 保存秘密，并把私有通道状态放在 `DSH_HOME` 下；不能从 `process.argv`、进程工作目录或猜测的 `web` 默认值推断当前 profile。
+
+这类连接器可以读取 `ctx.get('desktopProfiles')?.current`，用于诊断或确实属于 Desktop 的可选行为。仅仅运行 Agent 不需要 `desktopProfiles`；除非插件自身会修改 package，否则也不能要求 `desktopPnpm`。同时不得依赖 `desktopRuntime`、Electron API、托盘内部对象或 renderer IPC。这样，无页面连接器可以保持跨环境兼容，并让 Desktop 与 Web 界面复用 Host 拥有的 Session。
+
 ## 最小可运行测试插件
 
-仓库在 [`tests/fixtures/desktop-host-services-smoke-plugin`](../tests/fixtures/desktop-host-services-smoke-plugin/) 中提供了一个只有两个文件的 profile-local fixture。它的 entry 声明 `inject = ['desktopProfiles', 'desktopPnpm']`，读取 `desktopProfiles.current`，并确认 command 与可恢复安装生命周期方法可用。它只把结果发布为测试 probe，绝不会执行 pnpm 或修改 profile。
+仓库提供了两个 profile-local fixture。[`tests/fixtures/desktop-host-services-smoke-plugin`](../tests/fixtures/desktop-host-services-smoke-plugin/) 声明 `inject = ['desktopProfiles', 'desktopPnpm']`，读取 `desktopProfiles.current`，并确认 command 与可恢复安装生命周期方法可用。[`tests/fixtures/host-only-profile-bundle`](../tests/fixtures/host-only-profile-bundle/) 是完整的 DSH Bundle，只依赖普通 Host service，并可选探测 Desktop capability。
 
-完整 Profile Loader smoke 会把该 package 复制到临时 profile 的 `node_modules`，以普通 bare-package Loader entry 加载，并在 probe 没有返回激活 profile 或两个 package-manager 方法时失败。运行命令：
+完整 Profile Loader smoke 会通过临时 profile 的 `dsh.profile.bundles` layer stack 安装仅 Host fixture，把 Desktop-only fixture 作为普通 bare-package Loader entry 加载；如果两者没有使用预期的核心与 Desktop service 激活，测试就会失败。两个 fixture 都不会执行 pnpm 或修改真实 profile。运行命令：
 
 ```sh
 yarn workspace dsh-plugin-desktop build
 yarn workspace dsh-plugin-desktop verify:profile
 ```
 
-该 fixture 位于 `tests/`，不在 npm `files` 列表或 Electron build files 中，因此不会进入生产 archive。
+两个 fixture 都位于 `tests/`，不在 npm `files` 列表或 Electron build files 中，因此不会进入生产 archive。
 
 ## Failure 与 teardown checklist
 

--- a/dsh-plugin-desktop/scripts/verify-profile-boot.mjs
+++ b/dsh-plugin-desktop/scripts/verify-profile-boot.mjs
@@ -13,12 +13,14 @@ import {
 import { DESKTOP_SETTINGS_NAMESPACE } from '../lib/index.js'
 import { installDesktopPnpmRuntime } from '../lib/desktop-runtime-environment.js'
 import { installProfilePackageResolver } from '../lib/module-resolution.js'
-import { prepareDesktopProfile } from '../lib/profile.js'
+import { ensureDesktopProfile, prepareDesktopProfile } from '../lib/profile.js'
 import { DesktopProfileService } from '../lib/profile-service.js'
 
 const BIN_NAME = 'dsh-plugin-desktop-profile-smoke'
 const HOST_SERVICE_PLUGIN_NAME = 'dsh-desktop-host-services-smoke-plugin'
 const HOST_SERVICE_PROBE_KEY = 'desktopHostServiceProbe'
+const HOST_ONLY_BUNDLE_NAME = 'dsh-host-only-profile-smoke-bundle'
+const HOST_ONLY_PROBE_KEY = 'hostOnlyProfileProbe'
 const home = mkdtempSync(join(tmpdir(), 'dsh-desktop-profile-'))
 let ctx
 let releasePackageResolver
@@ -35,7 +37,23 @@ try {
     '  default: minimal',
     '',
   ].join('\n'))
+  const profileDir = ensureDesktopProfile(home)
+  const hostOnlyBundleDir = join(profileDir, 'node_modules', HOST_ONLY_BUNDLE_NAME)
+  mkdirSync(join(profileDir, 'node_modules'), { recursive: true })
+  cpSync(
+    fileURLToPath(new URL('../tests/fixtures/host-only-profile-bundle/', import.meta.url)),
+    hostOnlyBundleDir,
+    { recursive: true, force: false, errorOnExist: true },
+  )
+  const profileManifestPath = join(profileDir, 'package.json')
+  const profileManifest = JSON.parse(readFileSync(profileManifestPath, 'utf8'))
+  profileManifest.dependencies[HOST_ONLY_BUNDLE_NAME] = '0.0.0'
+  profileManifest.dsh.profile.bundles.push(HOST_ONLY_BUNDLE_NAME)
+  writeFileSync(profileManifestPath, `${JSON.stringify(profileManifest, undefined, 2)}\n`)
   const prepared = prepareDesktopProfile('1', home, 'win32')
+  if (!prepared.profile.layers.some(layer => layer.packageName === HOST_ONLY_BUNDLE_NAME)) {
+    throw new Error('profile-installed Host-only Bundle is missing from the prepared layer stack')
+  }
   const hostServicePluginDir = join(
     prepared.profile.dir,
     'node_modules',
@@ -193,6 +211,17 @@ try {
     || hostServiceProbe.pnpm.rollbackPluginInstall !== 'function') {
     throw new Error(
       `profile-local Host service plugin produced an unexpected probe: ${JSON.stringify(hostServiceProbe)}`,
+    )
+  }
+  const hostOnlyProbe = ctx.get(HOST_ONLY_PROBE_KEY)
+  const hostOnlyRequiredServices = Object.values(hostOnlyProbe?.requiredServices ?? {})
+  if (hostOnlyProbe?.desktopProfile?.name !== 'desktop'
+    || hostOnlyProbe.desktopProfile.dir !== prepared.profile.dir
+    || hostOnlyProbe.hasDesktopPnpm !== true
+    || hostOnlyRequiredServices.length !== 7
+    || hostOnlyRequiredServices.some(available => available !== true)) {
+    throw new Error(
+      `profile-installed Host-only Bundle produced an unexpected probe: ${JSON.stringify(hostOnlyProbe)}`,
     )
   }
 

--- a/dsh-plugin-desktop/tests/fixtures/host-only-profile-bundle/cordis.patch.yml
+++ b/dsh-plugin-desktop/tests/fixtures/host-only-profile-bundle/cordis.patch.yml
@@ -1,0 +1,3 @@
+- insert:
+    - id: host-only-profile-smoke
+      name: dsh-host-only-profile-smoke-bundle

--- a/dsh-plugin-desktop/tests/fixtures/host-only-profile-bundle/index.js
+++ b/dsh-plugin-desktop/tests/fixtures/host-only-profile-bundle/index.js
@@ -1,0 +1,29 @@
+/** Profile-installed Host-only Bundle used by the complete Loader smoke. */
+
+export const name = 'host-only-profile-smoke-plugin'
+
+// These are ordinary DSH Host services. Desktop capabilities remain optional
+// so the same Bundle can load in Web, headless, and Desktop profiles.
+export const inject = [
+  'credentials',
+  'agents',
+  'agentDefaultModel',
+  'agentPresets',
+  'permissionPresets',
+  'approval',
+  'systemPrompt',
+]
+
+/** Publish the services and optional Desktop identity observed at activation. */
+export function apply(ctx) {
+  const current = ctx.get('desktopProfiles')?.current
+  ctx.provide('hostOnlyProfileProbe', Object.freeze({
+    requiredServices: Object.freeze(Object.fromEntries(
+      inject.map(service => [service, ctx.get(service) !== undefined]),
+    )),
+    desktopProfile: current === undefined
+      ? undefined
+      : Object.freeze({ name: current.name, dir: current.dir }),
+    hasDesktopPnpm: ctx.get('desktopPnpm') !== undefined,
+  }))
+}

--- a/dsh-plugin-desktop/tests/fixtures/host-only-profile-bundle/package.json
+++ b/dsh-plugin-desktop/tests/fixtures/host-only-profile-bundle/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "dsh-host-only-profile-smoke-bundle",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "exports": "./index.js",
+  "dsh": {
+    "bundle": {
+      "patch": "./cordis.patch.yml"
+    }
+  }
+}


### PR DESCRIPTION
## 中文

### 变更摘要

- 增加一个完整的、通过 Profile 安装的 Host-only Bundle fixture，不包含 Client UI。
- 在完整 Desktop Profile smoke 中覆盖真实 `dsh.profile.bundles` layer 路径。
- 验证普通 Agent、credential、preset service，以及 Desktop capability 的可选探测。
- 中英文同步记录跨环境、无页面通道连接器的接入方式。

Closes #463

### 设计与兼容性

Fixture 模拟远程通道连接器：顶层 `inject` 只包含普通 DSH Host service，`desktopProfiles` 与 `desktopPnpm` 仅通过能力探测读取。因此它不会把 Desktop 变成 runtime dependency，并保持与 Web、headless Host 兼容。

Smoke 会把 fixture 复制到临时 Profile，将它声明为直接 dependency 与 `dsh.profile.bundles` layer，组合当前 Desktop Profile，再断言 layer 发现和 Host 激活均成功。它不会对真实 Profile 执行 package operation。

### 安全边界

- 不访问 Electron、`desktopRuntime`、托盘、renderer IPC 或 launcher 私有 API。
- Fixture 不包含 credential、通道状态、用户标识或配对产物。
- Fixture 不发起网络请求，也不执行 package mutation。
- Setup 指南要求通过 DSH credentials 保存秘密，并把私有状态放在 `DSH_HOME` 下。

### 验证

本地环境：Windows、Node 22.19.0、Yarn 4.18.0、Desktop 2.0.2、固定 DSH `0.1.1-rc.2`。

已通过：

- `corepack yarn install --immutable`
- `corepack yarn build`
- `corepack yarn typecheck`
- `corepack yarn check:layout`
- `corepack yarn check:bilingual-docs`
- `corepack yarn workspace dsh-plugin-desktop verify:closure`
- `corepack yarn workspace dsh-plugin-desktop verify:cli`
- `corepack yarn workspace dsh-plugin-desktop verify:loader`
- `corepack yarn workspace dsh-plugin-desktop verify:profile`
- `corepack yarn workspace dsh-plugin-desktop verify:licenses`
- `git diff --check`

`corepack yarn check` 运行到 Desktop suite 时共有 740 项通过、11 项跳过、9 项失败。9 项均为与本次改动无关的现有 Windows 环境断言：7 项要求当前账户不具备的符号链接权限，1 项构造仅适用于 POSIX 的 file URL，1 项写死 POSIX 路径分隔符。本次修改的 Profile smoke 已独立通过，也在同一次总门禁中先于这些失败完成。

另将真实 `@local/dsh-weixin@0.2.0` tarball 安装到隔离 Desktop Profile。Desktop 正常渲染工作区并输出预期的“未配对”启动日志，证明 Host entry 与 required DSH service 已加载，且未读取现有 credential；随后 `pnpm exec dsh-weixin status` 成功完成。

### 截图

不适用：本 PR 只修改文档和 headless 验证，不包含 UI 变更。

---

## English

### Summary

- Add a complete profile-installed Host-only Bundle fixture with no Client UI.
- Exercise the real `dsh.profile.bundles` layer path in the complete Desktop Profile smoke.
- Verify ordinary Agent, credential, and preset services plus optional Desktop capability discovery.
- Document the cross-environment, no-UI channel connector pattern in English and Chinese.

Closes #463

### Design and compatibility

The fixture follows the same shape as a remote channel connector: its top-level `inject` contains only ordinary DSH Host services, while `desktopProfiles` and `desktopPnpm` are capability-detected. It therefore does not make Desktop a runtime dependency and remains compatible with Web and headless Hosts.

The smoke copies the fixture into a temporary profile, declares it as a direct dependency and `dsh.profile.bundles` layer, composes the current Desktop profile, and asserts both layer discovery and Host activation. It performs no package operation against a real profile.

### Security boundary

- No Electron, `desktopRuntime`, tray, renderer IPC, or launcher-private API access.
- No credentials, channel state, identifiers, or pairing artifacts in the fixture.
- No network calls or package mutations from the fixture.
- Setup guidance stores secrets through DSH credentials and private state under `DSH_HOME`.

### Verification

Local environment: Windows, Node 22.19.0, Yarn 4.18.0, Desktop 2.0.2, and pinned DSH `0.1.1-rc.2`.

Passed:

- `corepack yarn install --immutable`
- `corepack yarn build`
- `corepack yarn typecheck`
- `corepack yarn check:layout`
- `corepack yarn check:bilingual-docs`
- `corepack yarn workspace dsh-plugin-desktop verify:closure`
- `corepack yarn workspace dsh-plugin-desktop verify:cli`
- `corepack yarn workspace dsh-plugin-desktop verify:loader`
- `corepack yarn workspace dsh-plugin-desktop verify:profile`
- `corepack yarn workspace dsh-plugin-desktop verify:licenses`
- `git diff --check`

`corepack yarn check` reached the Desktop suite with 740 passed and 11 skipped tests. Nine unrelated existing Windows-environment assertions failed: seven require symlink privileges unavailable to the current account, one constructs a POSIX-only file URL, and one matches a POSIX path separator. The changed Profile smoke passed independently and inside the same run before those failures.

A real `@local/dsh-weixin@0.2.0` tarball was also installed into an isolated Desktop profile. Desktop rendered its workspace and logged the expected unpaired startup warning, proving that the Host entry and required DSH services loaded without reading an existing credential. `pnpm exec dsh-weixin status` then completed successfully from that profile.

### Screenshots

Not applicable: this PR changes documentation and headless verification only; there is no UI change.