### PR TITLE
fix(win): avoid update installer running false positives

### DIFF
--- a/dsh-plugin-desktop/tests/package.spec.ts
+++ b/dsh-plugin-desktop/tests/package.spec.ts
@@ -802,6 +802,10 @@ describe('published package surface', () => {
     const installedCodeSign = readFileSync(join(dirname(appBuilderManifest), 'out/codeSign/macCodeSign.js'), 'utf8')
     const installedNsisInstaller = readFileSync(join(dirname(appBuilderManifest), 'templates/nsis/installer.nsi'), 'utf8')
     const installedNsisPortable = readFileSync(join(dirname(appBuilderManifest), 'templates/nsis/portable.nsi'), 'utf8')
+    const installedNsisSingleInstance = readFileSync(
+      join(dirname(appBuilderManifest), 'templates/nsis/include/allowOnlyOneInstallerInstance.nsh'),
+      'utf8',
+    )
 
     expect(workspaceManifest.resolutions).toMatchObject({
       'app-builder-lib@npm:26.15.7': patchResolution,
@@ -811,11 +815,14 @@ describe('published package surface', () => {
     expect(patch).toContain('importCerts(keychainFile, certPaths, cscPasswords, keychainPassword)')
     expect(patch).toContain('"-k", keychainPassword, keychainFile')
     expect(patch).toContain('ManifestLongPathAware true')
+    expect(patch).toContain("[System.IO.Path]::GetFileName($$_.Path) -ieq '${_FILE}'")
     expect(manifest.build?.toolsets?.nsis).toBe('1.2.1')
     expect(installedCodeSign).toContain('importCerts(keychainFile, certPaths, cscPasswords, keychainPassword)')
     expect(installedCodeSign).toContain('"-k", keychainPassword, keychainFile')
     expect(installedNsisInstaller).toContain('ManifestLongPathAware true')
     expect(installedNsisPortable).toContain('ManifestLongPathAware true')
+    expect(installedNsisSingleInstance).toContain("[System.IO.Path]::GetFileName($$_.Path) -ieq '${_FILE}'")
+    expect(installedNsisSingleInstance).not.toContain("$$_.Path.StartsWith('$INSTDIR', 'CurrentCultureIgnoreCase')}).Count")
   })
 
   it('starts restricted Windows shells with a hidden console show state', () => {

--- a/patches/app-builder-lib@26.15.7.patch
+++ b/patches/app-builder-lib@26.15.7.patch
@@ -28,6 +28,25 @@ index 2f5d5cf1240c5219217498f1f1a0530deab435a6..821e1d1c9b97dce3fd8e847132508384
 +++ b/templates/nsis/installer.nsi
 @@ -28,0 +29 @@
 +ManifestLongPathAware true
+diff --git a/templates/nsis/include/allowOnlyOneInstallerInstance.nsh b/templates/nsis/include/allowOnlyOneInstallerInstance.nsh
+index b32bafafac67d1e2ba6d867fb97865f67766a17e..77b621c83ccbd51392f292c989fbb249c76aa243 100644
+--- a/templates/nsis/include/allowOnlyOneInstallerInstance.nsh
++++ b/templates/nsis/include/allowOnlyOneInstallerInstance.nsh
+@@ -64,6 +64,6 @@
+ !macro FIND_PROCESS _FILE _RETURN
+   ${if} $IsPowerShellAvailable == 0
+-    nsExec::Exec `"$PowerShellPath" -C "if ((Get-CimInstance -ClassName Win32_Process | ? {$$_.Path -and $$_.Path.StartsWith('$INSTDIR', 'CurrentCultureIgnoreCase')}).Count -gt 0) { exit 0 } else { exit 1 }"`
++    nsExec::Exec `"$PowerShellPath" -C "if ((Get-CimInstance -ClassName Win32_Process | ? {$$_.Path -and [System.IO.Path]::GetFileName($$_.Path) -ieq '${_FILE}'}).Count -gt 0) { exit 0 } else { exit 1 }"`
+     Pop ${_RETURN}
+   ${else}
+     !ifdef INSTALL_MODE_PER_ALL_USERS
+@@ -93,5 +93,5 @@
+   ${if} $IsPowerShellAvailable == 0
+-    nsExec::Exec `"$PowerShellPath" -C "Get-CimInstance -ClassName Win32_Process | ? {$$_.Path -and $$_.Path.StartsWith('$INSTDIR', 'CurrentCultureIgnoreCase')} | % { Stop-Process -Id $$_.ProcessId $0 }"`
++    nsExec::Exec `"$PowerShellPath" -C "Get-CimInstance -ClassName Win32_Process | ? {$$_.Path -and [System.IO.Path]::GetFileName($$_.Path) -ieq '${_FILE}'} | % { Stop-Process -Id $$_.ProcessId $0 }"`
+   ${else}
+     !ifdef INSTALL_MODE_PER_ALL_USERS
+       nsExec::Exec `taskkill /IM "${_FILE}" /FI "PID ne $pid"`
 diff --git a/templates/nsis/portable.nsi b/templates/nsis/portable.nsi
 index 8d2992afbe79af270a0d08c38203166d3afc03f1..bd8dc7fd2bc01a4ec9ade821bbd5d7bd37265caf 100644
 --- a/templates/nsis/portable.nsi

--- a/yarn.lock
+++ b/yarn.lock
@@ -6982,7 +6982,7 @@ __metadata:
 
 "app-builder-lib@patch:app-builder-lib@npm%3A26.15.7#./patches/app-builder-lib@26.15.7.patch::locator=deepseek-harness-desktop%40workspace%3A.":
   version: 26.15.7
-  resolution: "app-builder-lib@patch:app-builder-lib@npm%3A26.15.7#./patches/app-builder-lib@26.15.7.patch::version=26.15.7&hash=f9c097&locator=deepseek-harness-desktop%40workspace%3A."
+  resolution: "app-builder-lib@patch:app-builder-lib@npm%3A26.15.7#./patches/app-builder-lib@26.15.7.patch::version=26.15.7&hash=1a3632&locator=deepseek-harness-desktop%40workspace%3A."
   dependencies:
     "@electron/asar": "npm:3.4.1"
     "@electron/fuses": "npm:^1.8.0"
@@ -7028,7 +7028,7 @@ __metadata:
   peerDependencies:
     dmg-builder: 26.15.7
     electron-builder-squirrel-windows: 26.15.7
-  checksum: 10c0/5a1a3c283ee655741cac7bccbf2e94d6c48d36a8b96b640b84691e85d7e6a2cbf667cf42cc5c33bdb2b384eae834cac333fc84f4f37c604a0e2693b76faf1bfb
+  checksum: 10c0/a2ef8f0f99244cd66e441054230261ef55c5429f09afda857afe279d262f07f053ef31659afffba5e20361521c5f4ad49c8a617e708c30ff660754705f084cd8
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary
- Patch the app-builder-lib NSIS single-instance PowerShell path so it only matches the target app executable name instead of any process running under `$INSTDIR`.
- Keep the fallback behavior aligned with the existing `tasklist /FI "IMAGENAME eq ..."` check.
- Add package-surface coverage that verifies the installed patched NSIS template contains the filename-based predicate and no longer contains the broad `$INSTDIR` prefix-count marker.

## Bug
Refs #469

The reported Windows update path from 2.0.1 to 2.0.2 can show the “DSH Desktop is still running” prompt even when no visible DSH process remains. The old PowerShell predicate matched every `Win32_Process` whose path started with the install directory, which can produce false positives when updater/installer-related processes are launched from that directory.

## Verification
- `corepack yarn workspace dsh-plugin-desktop test tests/package.spec.ts` failed before the fix with the added regression assertion.
- `corepack yarn install`
- `git diff --check`
- `corepack yarn workspace dsh-plugin-desktop test tests/package.spec.ts`
- `corepack yarn install --immutable`
- `corepack yarn workspace dsh-plugin-desktop test tests/package-win.spec.ts tests/verify-win-installer.spec.ts`
- `corepack yarn workspace dsh-plugin-desktop typecheck`