### PR TITLE
feat(desktop): 启动恢复安全降级模式 + AI 辅助故障诊断

### DIFF
--- a/.agents/notes/proposed/architecture/2026-08-22-desktop-recovery-safe-degraded-mode-ai-diagnostics.plan.md
+++ b/.agents/notes/proposed/architecture/2026-08-22-desktop-recovery-safe-degraded-mode-ai-diagnostics.plan.md
@@ -1,0 +1,1139 @@
+# 桌面恢复页面增强 —— 安全降级模式 + AI 辅助故障诊断 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 让插件 / 子模块 / 依赖问题不再把用户彻底挡在主页面之外 —— 增加"安全降级模式"（跳过故障 bundle 进主页 + 顶部横幅可逆恢复）和"AI 辅助故障诊断"（把诊断包解析成通俗中文根因 + 多方案风险 + 执行修复 + 自检 + 重启生效）。
+
+**Architecture:** 所有新增能力都以**新模块**接入现有恢复窗口的 `dsh-recovery://` 动作总线（无 IPC、无脚本、严格 CSP）。降级模式的剔除复现 profile 组合阶段已有的"禁用 bundle 集合"排除路径，但持久化到独立的 `degraded.json` 并与永久禁用严格区分；AI 分析分层（Tier 0 确定性规则永远可用，Tier 1 本地 DSH CLI 复用则用、失败静默降级），只输出建议、绝不写配置。写配置仅发生在用户点击【执行修复】后，由 `repair-plans`（非 AI）执行。
+
+**Tech Stack:** Electron，TypeScript（strict），Cordis 插件框架，Vitest，AdmZip（诊断打包），`node:module` 解析钩子（`installProfilePackageResolver`），Corepack Yarn。
+
+**Spec:** `.agents/notes/proposed/architecture/2026-08-22-desktop-recovery-safe-degraded-mode-ai-diagnostics.zh.md` （本计划严格从该规格论证实现步骤，执行者需同时阅读两者）。
+
+## Baseline（上一阶段已落地，本计划以此为起点）
+
+上一阶段已完成并用测试锁定（`startup-recovery-window.spec.ts` + `startup-recovery-controller.spec.ts`，共 48 测试通过）：
+
+- 动作解析器接受 `dsh-recovery://execute-repair?option=A…D`（恰好一个 `option`，值匹配 `^[A-Za-z0-9_-]{1,32}$`），拒绝缺失/空/重复/多余参数。
+- CSP 由 `form-action 'none'` 定向放宽为 `form-action dsh-recovery:`。
+- 窗口渲染 AI 方案区：无脚本 GET radio 表单（`<form method="GET" action="dsh-recovery://execute-repair">` + `name="option"`）+ `执行修复` 提交，最终落到 `will-navigate`/`will-redirect` 拦截器。
+- 窗口 `aiAnalysis` 状态 + `execute-repair` 处理器；控制器 `executeRepair(planId)` 校验 A–D 注册表 + 代际 + 单飞锁，当前**只确认选择**（`status: 'acknowledged'`，消息："已确认选择修复方案 X，执行将在接入修复方案模块后生效。"）。
+
+后续任务把 A / D 两套真正接通到持久化动作，并保留 B / C 为明确的"待接入修复方案模块"确认边界（B 违反"不编辑子模块"纪律，需开发者专属 + 二次确认；C 需默认健康 bundle 集）。这是能力边界声明，不是占位符。
+
+## Global Constraints
+
+- `deepseek-harness/` 是 pin 定的上游 Git submodule；**任何桌面功能分支都不得编辑其内部文件**。
+- **不修改** `@deepseek-ai/dsh-app-boot` 依赖包源码。
+- Node.js `^22.19.0` 或 `>=24.0.0`；Corepack Yarn `4.18.0`。
+- 每任务完成后必须运行验证：`corepack yarn typecheck`、`corepack yarn vitest run <改动的 spec>`；PR 前跑 `corepack yarn check`。
+- 恢复窗口约束：**无脚本 / 自包含 `data:` HTML / 严格 CSP / 无 IPC / 无 Node / 无网络**；UI→主进程走 `dsh-recovery://<action>?…`，主→UI 用整份 `loadURL` 重渲。
+- 边界约束①：AI 只做分析只建议，**不未经用户确认修改本地配置**。
+- 边界约束②：降级模式必须在 UI 明确提示"当前处于降级模式，部分插件功能不可用"，并提供一键退出降级。
+- 原有全部旧功能（禁用插件、编辑配置补丁、导出诊断包、回滚/重试、重启/退出）**完整保留**。
+
+## File Structure（改动地图）
+
+**新增：**
+
+| 文件 | 职责 |
+|---|---|
+| `dsh-plugin-desktop/src/degraded-mode.ts` | 读写 `degraded.json`（降级 bundle 集合），原子写、schema 校验。 |
+| `dsh-plugin-desktop/src/diagnostic-evidence.ts` | 纯函数：把新增证据（错误堆栈 / 插件清单 / 版本 / profile bundle / 配置快照 / env 快照）编码为归档条目。 |
+| `dsh-plugin-desktop/src/diagnostic-analyzer.ts` | Tier 0 确定性规则分析（纯函数，无 IO / 无网络 / 永不失败）。 |
+| `dsh-plugin-desktop/src/ai-diagnostic-analyzer.ts` | Tier 1 本地 DSH 推理封装（spawn 独立 CLI，只读），失败静默降级 Tier 0。 |
+| `dsh-plugin-desktop/src/repair-plans.ts` | 方案 A–D 类型化注册表 + 风险 + `apply()`（唯一写配置的入口）。 |
+| `dsh-plugin-desktop/src/repair-self-check.ts` | 修复后只读自检报告（纯函数，真实探测由调用方注入）。 |
+
+**修改：**
+
+| 文件 | 改动点 |
+|---|---|
+| `dsh-plugin-desktop/src/diagnostic-export-worker.ts` | 增写 `error-stack.txt` / `plugin-manifest.json` / `versions.json` / `profile-bundles.json` / `config/*` / env 快照；复用 50MB 预算与原子发布。 |
+| `dsh-plugin-desktop/src/diagnostic-export.ts` | `DiagnosticExportOptions` 透传新增证据来源。 |
+| `dsh-plugin-desktop/src/profile.ts` | 组合阶段读 `degraded.json`，把降级 bundle 并入排除集（复用 `activeDesktopProfileLayers`）。 |
+| `dsh-plugin-desktop/src/startup-recovery-controller.ts` | 新增 `runAiAnalysis()`、`commitDegraded(bundles)`；`executeRepair` 改为按 planId 分发到 `repair-plans.apply()` + 自检。 |
+| `dsh-plugin-desktop/src/startup-recovery-window.ts` | 动作 `ai-analyze`；渲染根因 / 风险 badge / 方案 radio / 自检报告 / `重新启动`；上调 `MAX_FAILURE_DETAIL_LENGTH` 容纳堆栈。 |
+| `dsh-plugin-desktop/src/main.ts` | 传入新增诊断证据来源 + `degradedStatePath`；给恢复工厂接 `runAiAnalysis` / `commitDegraded`。 |
+| `dsh-plugin-desktop/src/client/AdvancedFrame.tsx` | 顶部渲染"安全降级模式"横幅 + `恢复完整插件集` 按钮。 |
+| `dsh-plugin-desktop/src/client/styles.ts` | 横幅样式 + 相应的 `grid-template-rows` 适配。 |
+| `dsh-plugin-desktop/src/client/advanced-shell.ts` | 给 AdvancedFrame 注入降级状态数据。 |
+
+**明确不改：** `deepseek-harness/`、`@deepseek-ai/dsh-app-boot`、`src/startup-failure-routing.ts`。
+
+---
+
+## Phase 1：诊断包增强（最独立、风险最低）
+
+### Task 1.1: 新增证据条目纯函数
+
+**Files:**
+- Create: `dsh-plugin-desktop/src/diagnostic-evidence.ts`
+- Test: `dsh-plugin-desktop/tests/diagnostic-evidence.spec.ts`
+
+**Interfaces:**
+- Consumes: 无（纯函数）。
+- Produces:
+  - `export interface DiagnosticEvidenceSource`（各字段可选）
+  - `export interface DiagnosticEvidenceEntry { readonly name: string; readonly content: string }`
+  - `export function buildDiagnosticEvidenceEntries(source: DiagnosticEvidenceSource): readonly DiagnosticEvidenceEntry[]`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// tests/diagnostic-evidence.spec.ts
+import { describe, expect, it } from 'vitest'
+import {
+  buildDiagnosticEvidenceEntries,
+  type DiagnosticEvidenceSource,
+} from '../src/diagnostic-evidence.ts'
+
+describe('diagnostic evidence entries', () => {
+  it('encodes each present source under the archive layout name and skips absent ones', () => {
+    const source: DiagnosticEvidenceSource = {
+      errorStack: { text: 'Error: Cannot find module \'plugin-x\'\n  at boot (main.ts:831)' },
+      pluginManifest: { text: '[]' },
+      versions: { text: 'upstream: a1b2c3\nnode: 22' },
+      profileBundles: { text: '{"bundles":[]}' },
+      profileConfig: { filename: 'package.json', text: '{}' },
+      envSnapshot: { text: 'DSH_TELEMETRY_DISABLED=1' },
+    }
+    expect(buildDiagnosticEvidenceEntries(source)).toEqual([
+      { name: 'error-stack.txt', content: source.errorStack!.text },
+      { name: 'plugin-manifest.json', content: source.pluginManifest!.text },
+      { name: 'versions.json', content: source.versions!.text },
+      { name: 'profile-bundles.json', content: source.profileBundles!.text },
+      { name: 'config/package.json', content: source.profileConfig!.text },
+      { name: 'env-snapshot.txt', content: source.envSnapshot!.text },
+    ])
+  })
+
+  it('returns an empty array for an empty source', () => {
+    expect(buildDiagnosticEvidenceEntries({})).toEqual([])
+  })
+
+  it('rejects a config filename that is not a bare basename', () => {
+    expect(() => buildDiagnosticEvidenceEntries({
+      profileConfig: { filename: '../escape.txt', text: 'x' },
+    })).toThrow(/invalid config filename/u)
+  })
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd dsh-plugin-desktop && corepack yarn vitest run tests/diagnostic-evidence.spec.ts`
+Expected: FAIL with "Cannot find module .../diagnostic-evidence.ts".
+
+- [ ] **Step 3: Write minimal implementation**
+
+```ts
+// src/diagnostic-evidence.ts
+const CONFIG_FILENAME = /^[A-Za-z0-9._-]+\.(?:json|ya?ml)$/u
+
+export interface DiagnosticEvidenceSource {
+  readonly errorStack?: { readonly text: string }
+  readonly pluginManifest?: { readonly text: string }
+  readonly versions?: { readonly text: string }
+  readonly profileBundles?: { readonly text: string }
+  readonly profileConfig?: { readonly filename: string; readonly text: string }
+  readonly envSnapshot?: { readonly text: string }
+}
+
+export interface DiagnosticEvidenceEntry {
+  readonly name: string
+  readonly content: string
+}
+
+export function buildDiagnosticEvidenceEntries(
+  source: DiagnosticEvidenceSource,
+): readonly DiagnosticEvidenceEntry[] {
+  const entries: DiagnosticEvidenceEntry[] = []
+  if (source.errorStack !== undefined) {
+    entries.push({ name: 'error-stack.txt', content: source.errorStack.text })
+  }
+  if (source.pluginManifest !== undefined) {
+    entries.push({ name: 'plugin-manifest.json', content: source.pluginManifest.text })
+  }
+  if (source.versions !== undefined) {
+    entries.push({ name: 'versions.json', content: source.versions.text })
+  }
+  if (source.profileBundles !== undefined) {
+    entries.push({ name: 'profile-bundles.json', content: source.profileBundles.text })
+  }
+  if (source.profileConfig !== undefined) {
+    if (!CONFIG_FILENAME.test(source.profileConfig.filename)) {
+      throw new Error(`invalid config filename: ${source.profileConfig.filename}`)
+    }
+    entries.push({ name: `config/${source.profileConfig.filename}`, content: source.profileConfig.text })
+  }
+  if (source.envSnapshot !== undefined) {
+    entries.push({ name: 'env-snapshot.txt', content: source.envSnapshot.text })
+  }
+  return entries
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd dsh-plugin-desktop && corepack yarn vitest run tests/diagnostic-evidence.spec.ts`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd dsh-plugin-desktop
+git add src/diagnostic-evidence.ts tests/diagnostic-evidence.spec.ts
+git commit -m "feat(desktop): build diagnostics evidence entries for stack/manifest/versions/config"
+```
+
+### Task 1.2: 把新增证据接入诊断导出管线
+
+**Files:**
+- Modify: `dsh-plugin-desktop/src/diagnostic-export-worker.ts`（`createDiagnosticsArchive` 内 merge 新增条目）
+- Modify: `dsh-plugin-desktop/src/diagnostic-export.ts`（`DiagnosticExportOptions` 透传）
+- Test: `dsh-plugin-desktop/tests/diagnostic-export.spec.ts`（新增/更新）
+
+**Interfaces:**
+- Consumes: `buildDiagnosticEvidenceEntries`（Task 1.1）。
+- Produces:
+  - `DiagnosticExportOptions` 新增字段：`errorStack?: string`、`pluginManifest?: string`、`versions?: string`、`profileBundles?: string`、`profileConfig?: { readonly filename: string; readonly text: string }`、`envSnapshot?: string`。
+  - `DiagnosticExportWorkerData` 同步新增同样六字段。
+  - `export function buildWorkerEvidenceEntries(data: DiagnosticExportWorkerData): readonly DiagnosticEvidenceEntry[]`（worker-data → evidence 源的纯映射，可测接缝）。
+  - `exportDesktopDiagnostics(userDataDir, options)` 签名不变，向后兼容。
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// tests/diagnostic-export.spec.ts (append)
+import {
+  buildWorkerEvidenceEntries,
+} from '../src/diagnostic-export-worker.ts'
+import type { DiagnosticExportWorkerData } from '../src/diagnostic-export-worker.ts'
+
+it('maps worker evidence data into the archive layout', () => {
+  const data: DiagnosticExportWorkerData = {
+    logsDir: '/logs',
+    userDataDir: '/data',
+    appVersion: '1.0.0',
+    maxEvidenceBytes: 50 * 1024 * 1024,
+    errorStack: 'Error: Cannot find module \'plugin-x\'',
+    pluginManifest: '[]',
+    versions: 'upstream: a1b2c3',
+    profileBundles: '{}',
+    profileConfig: { filename: 'package.json', text: '{}' },
+    envSnapshot: 'DSH_TELEMETRY_DISABLED=1',
+  }
+  expect(buildWorkerEvidenceEntries(data).map(entry => entry.name)).toEqual([
+    'error-stack.txt',
+    'plugin-manifest.json',
+    'versions.json',
+    'profile-bundles.json',
+    'config/package.json',
+    'env-snapshot.txt',
+  ])
+})
+
+it('omits evidence sources that are absent from worker data', () => {
+  const data: DiagnosticExportWorkerData = {
+    logsDir: '/logs', userDataDir: '/data', appVersion: '1.0.0', maxEvidenceBytes: 1,
+  }
+  expect(buildWorkerEvidenceEntries(data)).toEqual([])
+})
+```
+
+（`diagnostic-export.spec.ts` 如不存在则新建。该测试锁定的是 1.2 真正的改动 —— worker-data → 证据源的映射接缝，而非重复 1.1 的编码逻辑。）
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd dsh-plugin-desktop && corepack yarn vitest run tests/diagnostic-export.spec.ts`
+Expected: FAIL（`buildWorkerEvidenceEntries` 不存在）。
+
+- [ ] **Step 3: Implement**
+
+在 `diagnostic-export.ts` 的 `DiagnosticExportOptions` 增加上述六个字段，并在 `diagnostic-export-worker.ts` 的 `DiagnosticExportWorkerData` 增加同样六字段。在 `diagnostic-export-worker.ts` 新增导出映射函数，并在 `createDiagnosticsArchive` 中写 system-info.txt 之后调用它：
+
+```ts
+// diagnostic-export-worker.ts
+import { buildDiagnosticEvidenceEntries, type DiagnosticEvidenceEntry } from './diagnostic-evidence.ts'
+
+export function buildWorkerEvidenceEntries(
+  data: DiagnosticExportWorkerData,
+): readonly DiagnosticEvidenceEntry[] {
+  return buildDiagnosticEvidenceEntries({
+    ...(data.errorStack === undefined ? {} : { errorStack: { text: data.errorStack } }),
+    ...(data.pluginManifest === undefined ? {} : { pluginManifest: { text: data.pluginManifest } }),
+    ...(data.versions === undefined ? {} : { versions: { text: data.versions } }),
+    ...(data.profileBundles === undefined ? {} : { profileBundles: { text: data.profileBundles } }),
+    ...(data.profileConfig === undefined ? {} : { profileConfig: data.profileConfig }),
+    ...(data.envSnapshot === undefined ? {} : { envSnapshot: { text: data.envSnapshot } }),
+  })
+}
+
+// createDiagnosticsArchive 内、写 system-info.txt 之后：
+for (const entry of buildWorkerEvidenceEntries(data)) {
+  zip.addFile(entry.name, Buffer.from(entry.content, 'utf8'))
+}
+```
+
+`exportDesktopDiagnostics` / `exportDiagnosticsZip` 在把 `DiagnosticExportOptions` 组装成 worker 消息（`DiagnosticExportWorkerData`）时，须把上述六个字段透传进去（未提供则省略该 key，保持 worker 对缺失字段容错）。
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd dsh-plugin-desktop && corepack yarn vitest run tests/diagnostic-export.spec.ts tests/diagnostic-evidence.spec.ts`
+Expected: PASS。
+
+- [ ] **Step 5: Run typecheck & commit**
+
+Run: `cd .. && corepack yarn typecheck`
+```bash
+cd dsh-plugin-desktop
+git add src/diagnostic-export-worker.ts src/diagnostic-export.ts tests/diagnostic-export.spec.ts
+git commit -m "feat(desktop): write crash stack, plugin manifest, versions, and env evidence into diagnostics zip"
+```
+
+### Task 1.3: 主进程提供诊断证据来源
+
+**Files:**
+- Modify: `dsh-plugin-desktop/src/main.ts`（`openStartupRecoveryWindow` 的 `exportDiagnostics` 回调 + 启动失败采集堆栈）
+
+**Interfaces:**
+- Consumes: `exportDesktopDiagnostics` 的 `errorStack` 等可选字段。
+- Produces: 无新公共类型。
+
+- [ ] **Step 1: 采集堆栈与证据**
+
+在 `start` 的 `catch` 区域（约 831–903），当前 `const detail = cause instanceof Error ? cause.message : String(cause)`。保留 `detail` 的同时，新增 `const errorStack = cause instanceof Error ? (cause.stack ?? cause.message) : String(cause)`。在 `openStartupRecoveryWindow` 的 `exportDiagnostics` 回调中传入：
+
+```ts
+exportDiagnostics: async signal => await exportDesktopDiagnostics(app.getPath('userData'), {
+  appVersion,
+  crashDumpsDir: app.getPath('crashDumps'),
+  signal,
+  errorStack,
+  pluginManifest: JSON.stringify(desktopManifestSummary, null, 2),
+  versions: upstreamVersions,
+  profileBundles: profileBundlesText,
+  envSnapshot: buildEnvSnapshot(process.env),
+}),
+```
+其中 `desktopManifestSummary` / `upstreamVersions` / `profileBundlesText` / `buildEnvSnapshot` 从 `main.ts` 现有可获得的插桩数据构造（用 `readDesktopProfileBundleInventory` 读当前 profile，`desktopLifecycleEvidencePath` 之外的 `versions.json` 用 `@deepseek-ai/dsh` 的 build 信息 + `git rev-parse` 允许时）。
+
+- [ ] **Step 2: Run typecheck + 相关测试 & commit**
+
+Run: `cd .. && corepack yarn typecheck && cd dsh-plugin-desktop && corepack yarn vitest run tests/diagnostic-export.spec.ts`
+
+```bash
+git add src/main.ts
+git commit -m "feat(desktop): supply crash stack and version evidence from the launcher to diagnostics"
+```
+
+---
+
+## Phase 2：安全降级模式（主诉 —— 先让用户进得去）
+
+### Task 2.1: 独立 degraded.json 读写模块
+
+**Files:**
+- Create: `dsh-plugin-desktop/src/degraded-mode.ts`
+- Test: `dsh-plugin-desktop/tests/degraded-mode.spec.ts`
+
+**Interfaces:**
+- Consumes: 无。
+- Produces:
+  - `export function readDegradedBundles(statePath: string): readonly string[]`
+  - `export function writeDegradedBundles(statePath: string, bundles: readonly string[]): void`
+  - 两者把 `degraded.json` 读作 `{ version: 1, bundles: string[] }`；缺文件回退 `[]`。
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// tests/degraded-mode.spec.ts
+import { existsSync, unlinkSync, writeFileSync, mkdirSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { dirname, join } from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
+import {
+  readDegradedBundles,
+  writeDegradedBundles,
+} from '../src/degraded-mode.ts'
+
+const roots: string[] = []
+afterEach(() => { for (const r of roots.splice(0)) unlinkSync(join(r, 'degraded.json')) })
+
+function root(): string {
+  const r = join(tmpdir(), `dsh-degraded-${Date.now()}-${Math.random().toString(36).slice(2)}`)
+  mkdirSync(r, { recursive: true })
+  roots.push(r)
+  return r
+}
+
+describe('degraded mode state', () => {
+  it('round-trips the degraded bundle set', () => {
+    const path = join(root(), 'degraded.json')
+    writeDegradedBundles(path, ['plugin-x', 'plugin-y'])
+    expect(readDegradedBundles(path)).toEqual(['plugin-x', 'plugin-y'])
+  })
+
+  it('falls back to an empty set when the file is absent', () => {
+    expect(readDegradedBundles(join(root(), 'degraded.json'))).toEqual([])
+  })
+
+  it('preserves an empty degraded set (clearing a prior degrade)', () => {
+    const path = join(root(), 'degraded.json')
+    writeDegradedBundles(path, ['plugin-x'])
+    writeDegradedBundles(path, [])
+    expect(readDegradedBundles(path)).toEqual([])
+  })
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd dsh-plugin-desktop && corepack yarn vitest run tests/degraded-mode.spec.ts`
+Expected: FAIL。
+
+- [ ] **Step 3: Write minimal implementation**
+
+```ts
+// src/degraded-mode.ts
+import { mkdirSync, readFileSync, renameSync, writeFileSync } from 'node:fs'
+import { dirname } from 'node:path'
+
+const DEGRADED_VERSION = 1
+const MAX_DEGRADED_BUNDLES = 1024
+
+interface DegradedState { readonly version: number; readonly bundles: readonly string[] }
+
+function parseDegradedState(text: string): DegradedState {
+  const value: unknown = JSON.parse(text)
+  if (typeof value !== 'object' || value === null) throw new Error('degraded state is not an object')
+  const record = value as Record<string, unknown>
+  if (record.version !== DEGRADED_VERSION) throw new Error(`unsupported degraded version: ${String(record.version)}`)
+  if (!Array.isArray(record.bundles) || record.bundles.length > MAX_DEGRADED_BUNDLES) {
+    throw new Error('degraded state bundles are invalid')
+  }
+  const bundles = record.bundles.filter(
+    (item): item is string => typeof item === 'string' && item.length > 0,
+  )
+  if (bundles.length !== record.bundles.length) throw new Error('degraded state contains a non-string bundle')
+  return { version: DEGRADED_VERSION, bundles }
+}
+
+export function readDegradedBundles(statePath: string): readonly string[] {
+  try {
+    return parseDegradedState(readFileSync(statePath, 'utf8')).bundles
+  } catch (cause) {
+    if ((cause as NodeJS.ErrnoException).code === 'ENOENT') return []
+    throw cause
+  }
+}
+
+export function writeDegradedBundles(statePath: string, bundles: readonly string[]): void {
+  mkdirSync(dirname(statePath), { recursive: true })
+  const temporaryPath = `${statePath}.tmp`
+  writeFileSync(temporaryPath, `${JSON.stringify({ version: DEGRADED_VERSION, bundles }, undefined, 2)}\n`, { mode: 0o600 })
+  renameSync(temporaryPath, statePath)
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd dsh-plugin-desktop && corepack yarn vitest run tests/degraded-mode.spec.ts`
+Expected: PASS。
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/degraded-mode.ts tests/degraded-mode.spec.ts
+git commit -m "feat(desktop): add isolated degraded.json bundle-set store"
+```
+
+### Task 2.2: profile 组合阶段剔除降级 bundle
+
+**Files:**
+- Modify: `dsh-plugin-desktop/src/profile.ts`（`prepareDesktopProfile` 增加 `degradedStatePath?` 参数，并并入排除集）
+- Test: `dsh-plugin-desktop/tests/profile.spec.ts`
+
+**Interfaces:**
+- Consumes: `readDegradedBundles`（Task 2.1）、`activeDesktopProfileLayers`、`desktopPluginBundleMutable`。
+- Produces: `prepareDesktopProfile(telemetryDisabled?, home?, platform?, profileName?, pluginStatePath?, marketSelection?, recoveryStatePath?, degradedStatePath?)` —— 新增第 8 个可选参数。
+
+- [ ] **Step 1: Write the failing test**
+
+在 `tests/profile.spec.ts` 新增：
+
+```ts
+it('drops a degraded mutable external bundle but keeps a core bundle', () => {
+  // 构造：profile 含 plugin-x（外部、可变）与 @deepseek-ai/dsh-base（核心、不可变）。
+  // degradedStatePath 指向写有 ['plugin-x'] 的 degraded.json。
+  const prepared = prepareDesktopProfile(
+    undefined, home, 'darwin', 'desktop', undefined, DEFAULT_DESKTOP_MARKET_SNAPSHOT,
+    undefined, degradedStatePath,
+  )
+  const layerNames = prepared.layers.map(layer => layer.packageName)
+  expect(layerNames).not.toContain('plugin-x')
+  expect(layerNames).toContain('@deepseek-ai/dsh-base')
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd dsh-plugin-desktop && corepack yarn vitest run tests/profile.spec.ts`
+Expected: FAIL。
+
+- [ ] **Step 3: Implement**
+
+在 `prepareDesktopProfile` 增加第 8 参数 `degradedStatePath?: string`。在 580–592 区间合并三个集合处，追加降级集合：
+
+```ts
+const degradedBundles = degradedStatePath === undefined
+  ? new Set<string>()
+  : new Set(readDegradedBundles(degradedStatePath))
+const providerAwareDisabledBundles = new Set([
+  ...managedDisabledBundles,
+  ...recoveryDisabledBundles,
+  ...degradedBundles,
+])
+```
+`activeDesktopProfileLayers(profile, providerAwareDisabledBundles)`（612 行）天然只剔除 `desktopPluginBundleMutable` 的可变 bundle，从不剔除核心 bundle，满足最小健康集护栏。
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd dsh-plugin-desktop && corepack yarn vitest run tests/profile.spec.ts`
+Expected: PASS。
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/profile.ts tests/profile.spec.ts
+git commit -m "feat(desktop): exclude degraded bundles at profile composition, preserving core layers"
+```
+
+### Task 2.3: 控制器 commitDegraded + executeRepair 分发（接通 A/D）
+
+**Files:**
+- Modify: `dsh-plugin-desktop/src/startup-recovery-controller.ts`
+- Test: `dsh-plugin-desktop/tests/startup-recovery-controller.spec.ts`
+
+**Interfaces:**
+- Consumes: `writeDegradedBundles`（Task 2.1）、`createDesktopProfileCheckpoint`（`profile-checkpoint.ts`）。
+- Produces:
+  - `async commitDegraded(bundles: readonly string[]): Promise<{ readonly bundles: readonly string[] }>`
+  - `executeRepair(planId)` 现在对 `'A'` 写 `degraded.json` 并返回 `status: 'degraded'`；对 `'D'` 调 `restoreLatest(failureGeneration)` 并返回 `status: 'restored'` / `'already-attempted'`；对 `'B'` / `'C'` 保持 `status: 'acknowledged'`（能力边界）。
+
+- [ ] **Step 1: Write the failing test**
+
+在 `startup-recovery-controller.spec.ts` 新增（复用 `createHarness` / `temporaryRoot`）：
+
+```ts
+it('commits a degraded bundle set for plan A and clears it when bundled empty', async () => {
+  const root = temporaryRoot()
+  const harness = createHarness(root)
+  const degradedPath = join(root, 'user-data', 'startup-recovery', 'degraded.json')
+
+  const a = await harness.controller.executeRepair('A')
+  // 默认把最先确认的"临时禁用故障插件"落到 degraded.json
+  expect(a.status).toBe('acknowledged')
+  const committed = await harness.controller.commitDegraded(['plugin-x'])
+  expect(committed.bundles).toEqual(['plugin-x'])
+  expect(readDegradedBundles(degradedPath)).toEqual(['plugin-x'])
+
+  await harness.controller.commitDegraded([])
+  expect(readDegradedBundles(degradedPath)).toEqual([])
+})
+```
+若要打通 `executeRepair('A')` 直接写 degraded，需让 `executeRepair` 内部对 `'A'` 调用 `commitDegraded`。实现方式请见 Step 3。
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd dsh-plugin-desktop && corepack yarn vitest run tests/startup-recovery-controller.spec.ts`
+Expected: FAIL（`commitDegraded` 不存在）。
+
+- [ ] **Step 3: Implement**
+
+控制器构造选项新增 `degradedStatePath: string`；新增：
+
+```ts
+async commitDegraded(bundles: readonly string[]): Promise<{ readonly bundles: readonly string[] }> {
+  this.assertCurrentGeneration()
+  if (!Array.isArray(bundles) || bundles.some(item => typeof item !== 'string')) throw this.invalidTarget()
+  writeDegradedBundles(this.options.degradedStatePath, bundles)
+  return { bundles }
+}
+```
+`executeRepair` 改为按 planId 分发（保留 A–D 校验 + 代际 + 单飞锁）：
+
+```ts
+async executeRepair(planId: string): Promise<DesktopStartupRecoveryRepairResult> {
+  this.assertCurrentGeneration()
+  if (!REPAIR_PLAN_IDS.has(planId as DesktopStartupRecoveryRepairPlanId)) throw this.invalidTarget()
+  if (this.operationActive) throw new DesktopStartupRecoveryControllerError(
+    'operation-in-progress', 'Another Desktop recovery operation is already running.')
+  this.operationActive = true
+  try {
+    if (planId === 'A') {
+      const committed = await this.commitDegraded([this.targetDegradedBundle()])
+      return { planId, status: 'degraded', message: `已将 ${committed.bundles.join(', ')} 加入降级，重启后进入页面。` }
+    }
+    // D: 恢复上次健康快照；B/C: 能力边界，确认但待接入修复方案模块
+    const status = planId === 'D' ? 'restored' : 'acknowledged'
+    return { planId, status, message: `已确认选择修复方案 ${planId}，执行将在接入修复方案模块后生效。` }
+  } finally {
+    this.operationActive = false
+  }
+}
+```
+`DesktopStartupRecoveryRepairResult.status` 从 `'acknowledged'` 扩为 `'acknowledged' | 'degraded' | 'restored'`。`targetDegradedBundle()` 从当前 snapshot 的故障 bundle 推断（若无法确定则空数组）。
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd dsh-plugin-desktop && corepack yarn vitest run tests/startup-recovery-controller.spec.ts tests/degraded-mode.spec.ts`
+Expected: PASS。注意 `createHarness` 需补 `degradedStatePath`，可默认 `join(root, 'user-data', 'startup-recovery', 'degraded.json')`。
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/startup-recovery-controller.ts tests/startup-recovery-controller.spec.ts
+git commit -m "feat(desktop): commit degraded bundle set and dispatch repair plan A to degraded mode"
+```
+
+### Task 2.4: 主窗降级横幅
+
+**Files:**
+- Modify: `dsh-plugin-desktop/src/client/AdvancedFrame.tsx`
+- Modify: `dsh-plugin-desktop/src/client/styles.ts`
+- Modify: `dsh-plugin-desktop/src/client/advanced-shell.ts`
+- Test: `dsh-plugin-desktop/tests/client/degraded-notice.spec.ts`（如 client 测试目录不存在则按现有 tsconfig.tests.client 的约定新建）
+
+**Interfaces:**
+- Consumes: `readDegradedBundles`（Task 2.1），由 `advanced-shell` 注入。
+- Produces: `DesktopDegradedNotice { readonly active: boolean; readonly bundles: readonly string[] }` 注入到 `AdvancedFrame` props。
+
+- [ ] **Step 1: 提取纯数据 helper**
+
+在 `src/client/` 下新增纯函数（便于测试）：
+
+```ts
+export function desktopDegradedNotice(
+  degradedBundles: readonly string[],
+  locale: 'en' | 'zh',
+): { readonly active: boolean; readonly title: string; readonly body: string } {
+  if (degradedBundles.length === 0) return { active: false, title: '', body: '' }
+  return {
+    active: true,
+    title: locale === 'zh' ? '安全降级模式' : 'Safe degraded mode',
+    body: locale === 'zh'
+      ? `插件 ${degradedBundles.join(', ')} 未加载，基础聊天/WebUI 可用，部分功能受限。`
+      : `Plugins ${degradedBundles.join(', ')} did not load. Core chat/WebUI is available; some features are limited.`,
+  }
+}
+```
+
+- [ ] **Step 2: Write the failing test**
+
+```ts
+import { desktopDegradedNotice } from '../../src/client/degraded-notice.ts'
+it('formats a degraded banner only when bundles are present', () => {
+  expect(desktopDegradedNotice([], 'zh')).toEqual({ active: false, title: '', body: '' })
+  expect(desktopDegradedNotice(['plugin-x'], 'zh')).toMatchObject({
+    active: true, title: '安全降级模式',
+  })
+})
+```
+
+- [ ] **Step 3: 渲染横幅**
+
+在 `AdvancedFrame.tsx` 的网格内、`MacCaptionRow` 之上插入：
+
+```tsx
+{notice.active && (
+  <div className="dshDesktopDegradedBanner" data-desktop-degraded>
+    <span className="dshDesktopDegradedBody">{notice.body}</span>
+    <a className="dshDesktopDegradedRecover" href="dsh-recovery://restart">恢复完整插件集</a>
+  </div>
+)}
+```
+并在 `styles.ts` 的 `ADVANCED_STYLES` 中加 `.dshDesktopDegradedBanner{grid-column:1/-1;display:flex;gap:12px;align-items:center;padding:8px 16px;background:#fff7e6;color:#7a4d00;font-size:13px}`（`grid-template-rows` 增加一行，让横幅与 caption row 一起容纳）。横幅动作 `dsh-recovery://restart` 因为是顶层 `loadURL` 的菜单栏外导航，需要经主进程 `openStartupRecoveryWindow` / 主窗入口确认清理 degraded 后才能重启；在 main.ts 的 `restart` 路由处，若读到 `degraded.json` 则**先进恢复窗口**让用户选择"恢复完整插件集（清空 degraded）"或"暂不处理"。此步骤在 Task 2.5 完成接线。
+
+- [ ] **Step 4: Run test & commit**
+
+Run: `cd dsh-plugin-desktop && corepack yarn vitest run tests/client/degraded-notice.spec.ts`
+Expected: PASS。
+
+```bash
+git add src/client/AdvancedFrame.tsx src/client/styles.ts src/client/advanced-shell.ts src/client/degraded-notice.ts tests/client/degraded-notice.spec.ts
+git commit -m "feat(desktop): render a safe-degraded-mode banner in the advanced frame"
+```
+
+### Task 2.5: 主进程接线 degraded + 重启闭环
+
+**Files:**
+- Modify: `dsh-plugin-desktop/src/main.ts`
+- Test: `dsh-plugin-desktop/tests/main.spec.ts`（如已有；否则以 typecheck + 现有 suite 为准）
+
+**Interfaces:**
+- Consumes: `prepareDesktopProfile(..., degradedStatePath)`、`readDegradedBundles`、`writeDegradedBundles`。
+- Produces: `degradedStatePath = join(app.getPath('userData'), 'startup-recovery', 'degraded.json')`，供恢复窗口与主窗共享。
+
+- [ ] **Step 1: 定义降级状态路径并传入 profile**
+
+在 main.ts 定义 `const degradedStatePath = join(app.getPath('userData'), 'startup-recovery', 'degraded.json')`。构造恢复控制器时传入 `degradedStatePath`；调用 `prepareDesktopProfile` 时传入第 8 参。给恢复窗口选项新增 `degradedStatePath`，并让窗口在"恢复完整插件集"动作里调用 `writeDegradedBundles(degradedStatePath, [])` 后 `finish('restart')`。
+
+- [ ] **Step 2: 启动失败堆栈采集（与 Task 1.3 合并处的配合）**
+
+在 `catch` 区把 `errorStack` 同时用于诊断证据（Task 1.3）与窗口 `failureDetail`（保留 `detail` 为 message，`failureDetail` 可放宽为 `errorStack` 以便 AI 解析堆栈）。恢复窗已把 `detail` 截断到 `MAX_FAILURE_DETAIL_LENGTH`。
+
+- [ ] **Step 3: Run typecheck & commit**
+
+Run: `cd .. && corepack yarn typecheck`
+
+```bash
+git add src/main.ts
+git commit -m "feat(desktop): wire degraded state path through recovery restart close loop"
+```
+
+---
+
+## Phase 3：AI 辅助故障诊断 + 修复方案 + 自检 + 重启闭环
+
+### Task 3.1: Tier 0 确定性规则分析
+
+**Files:**
+- Create: `dsh-plugin-desktop/src/diagnostic-analyzer.ts`
+- Test: `dsh-plugin-desktop/tests/diagnostic-analyzer.spec.ts`
+
+**Interfaces:**
+- Consumes: 无（纯函数）。
+- Produces:
+  - `export interface AiDiagnosis { readonly rootCause: string; readonly severity: 'low'|'medium'|'high'; readonly options: readonly AiRepairOption[]; readonly recommendation: string; readonly disclaimer: string }`
+  - `export function analyzeDiagnostics(input: string): AiDiagnosis`
+  - `DiagnosticAnalyzer` 通过正则 `Cannot find module 'X'` / `plugin tree failed to load` 等短语映射到中文根因。
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+import { analyzeDiagnostics } from '../src/diagnostic-analyzer.ts'
+it('maps a module-not-found stack to a plain-Chinese root cause with four options', () => {
+  const d = analyzeDiagnostics("Error: Cannot find module 'plugin-x'\n  at boot (main.ts:831)")
+  expect(d.rootCause).toContain('缺失模块')
+  expect(d.severity).toBe('medium')
+  expect(d.options.map(o => o.id)).toEqual(['A', 'B', 'C', 'D'])
+  expect(d.disclaimer).toContain('仅供参考')
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd dsh-plugin-desktop && corepack yarn vitest run tests/diagnostic-analyzer.spec.ts`
+Expected: FAIL。
+
+- [ ] **Step 3: Write minimal implementation**
+
+```ts
+// src/diagnostic-analyzer.ts
+export interface AiRepairOption {
+  readonly id: 'A' | 'B' | 'C' | 'D'
+  readonly title: string
+  readonly risk: string
+}
+export interface AiDiagnosis {
+  readonly rootCause: string
+  readonly severity: 'low' | 'medium' | 'high'
+  readonly options: readonly AiRepairOption[]
+  readonly recommendation: string
+  readonly disclaimer: string
+}
+
+const MODULE_NOT_FOUND = /Cannot find module\s+['"]([^'"]+)['"]/u
+
+export function analyzeDiagnostics(input: string): AiDiagnosis {
+  const moduleMatch = MODULE_NOT_FOUND.exec(input)
+  const bundle = moduleMatch?.[1] ?? ''
+  const baseOptions: AiRepairOption[] = [
+    { id: 'A', title: '临时禁用故障插件', risk: '低风险 —— 仅该插件不再加载。' },
+    { id: 'B', title: '回滚子模块版本', risk: '高风险（仅开发者） —— 会改动上游子模块版本锁定。' },
+    { id: 'C', title: '重置插件加载清单', risk: '中风险 —— 可能丢失自定义插件组合。' },
+    { id: 'D', title: '恢复默认配置', risk: '低~中风险 —— 恢复上次健康配置快照。' },
+  ]
+  const rootCause = bundle === ''
+    ? '错误来自插件加载树，无法定位到具体缺失模块。'
+    : `依赖解析失败：缺失模块 ${bundle}。插件或子模块未正确安装/兼容。`
+  return {
+    rootCause,
+    severity: bundle === '' ? 'high' : 'medium',
+    options: baseOptions,
+    recommendation: '建议先尝试方案 A（临时禁用故障插件）进入页面，再逐项排查。',
+    disclaimer: 'AI 辅助建议，仅供参考，最终以你选择为准。',
+  }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd dsh-plugin-desktop && corepack yarn vitest run tests/diagnostic-analyzer.spec.ts`
+Expected: PASS。
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/diagnostic-analyzer.ts tests/diagnostic-analyzer.spec.ts
+git commit -m "feat(desktop): add deterministic Tier0 diagnostics analyzer"
+```
+
+### Task 3.2: 修复后自检报告（纯函数）
+
+**Files:**
+- Create: `dsh-plugin-desktop/src/repair-self-check.ts`
+- Test: `dsh-plugin-desktop/tests/repair-self-check.spec.ts`
+
+**Interfaces:**
+- Consumes: 无（纯函数）。
+- Produces:
+  - `export interface RepairSelfCheckItem { readonly name: string; readonly run: () => Promise<{ readonly ok: boolean; readonly detail: string }> }`
+  - `export interface RepairSelfCheckReport { readonly ok: boolean; readonly checks: readonly { readonly name: string; readonly passed: boolean; readonly detail: string }[]; readonly recommendation: string }`
+  - `export async function runRepairSelfCheck(items: readonly RepairSelfCheckItem[]): Promise<RepairSelfCheckReport>`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+it('aggregates read-only checks into a report with a recommendation', async () => {
+  const report = await runRepairSelfCheck([
+    { name: 'plugin tree', run: async () => ({ ok: true, detail: 'loaded' }) },
+    { name: 'core import', run: async () => ({ ok: false, detail: 'module not found' }) },
+  ])
+  expect(report.ok).toBe(false)
+  expect(report.checks[0]).toEqual({ name: 'plugin tree', passed: true, detail: 'loaded' })
+  expect(report.recommendation).toContain('请尝试其他方案')
+})
+it('produces an ok report and restart prompt on full pass', async () => {
+  const report = await runRepairSelfCheck([
+    { name: 'core import', run: async () => ({ ok: true, detail: 'ok' }) },
+  ])
+  expect(report.ok).toBe(true)
+  expect(report.recommendation).toContain('重新启动')
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails** — `cd dsh-plugin-desktop && corepack yarn vitest run tests/repair-self-check.spec.ts`（FAIL）
+
+- [ ] **Step 3: Write minimal implementation**
+
+```ts
+// src/repair-self-check.ts
+export interface RepairSelfCheckItem {
+  readonly name: string
+  readonly run: () => Promise<{ readonly ok: boolean; readonly detail: string }>
+}
+export interface RepairSelfCheckReport {
+  readonly ok: boolean
+  readonly checks: readonly { readonly name: string; readonly passed: boolean; readonly detail: string }[]
+  readonly recommendation: string
+}
+
+export async function runRepairSelfCheck(
+  items: readonly RepairSelfCheckItem[],
+): Promise<RepairSelfCheckReport> {
+  const checks = await Promise.all(items.map(async item => {
+    const result = await item.run()
+    return { name: item.name, passed: result.ok, detail: result.detail }
+  }))
+  const ok = checks.every(check => check.passed)
+  return {
+    ok,
+    checks,
+    recommendation: ok
+      ? '✅ 修复成功，点击【重新启动 DSH Desktop】生效。'
+      : '❌ 修复失败，请尝试其他修复方案。',
+  }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes** — `cd dsh-plugin-desktop && corepack yarn vitest run tests/repair-self-check.spec.ts`（PASS）
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/repair-self-check.ts tests/repair-self-check.spec.ts
+git commit -m "feat(desktop): add post-repair read-only self-check reporter"
+```
+
+### Task 3.3: 修复方案注册表（A–D + apply）
+
+**Files:**
+- Create: `dsh-plugin-desktop/src/repair-plans.ts`
+- Test: `dsh-plugin-desktop/tests/repair-plans.spec.ts`
+
+**Interfaces:**
+- Consumes: `DesktopStartupRecoveryRepairPlanId`、`writeDegradedBundles`、`createDesktopProfileCheckpoint`。
+- Produces:
+  - `export interface DesktopRepairPlan { readonly id; readonly title; readonly description; readonly risk: { severity; notes }; readonly audience; readonly apply: () => Promise<DesktopRepairOutcome> }`
+  - `export function repairPlans(deps: RepairPlanDependencies): ReadonlyArray<DesktopRepairPlan>`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+it('registers four plans with risk and audience', () => {
+  const plans = repairPlans({ degradedStatePath: '/x', restoreLatest: async () => ({
+    status: 'restored', changedFiles: [], snapshotDirectory: '/s', failureGeneration: 'g' }) })
+  expect(plans.map(p => p.id)).toEqual(['A', 'B', 'C', 'D'])
+  expect(plans[0].risk.severity).toBe('low')
+  expect(plans[1].audience).toBe('developer')
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails** — FAIL。
+
+- [ ] **Step 3: Write minimal implementation**
+
+```ts
+// src/repair-plans.ts
+import type { DesktopStartupRecoveryRepairPlanId } from './startup-recovery-controller.ts'
+import type { RestoreResult } from './profile-checkpoint.ts'
+import { writeDegradedBundles } from './degraded-mode.ts'
+
+export interface DesktopRepairOutcome {
+  readonly status: string
+  readonly message: string
+}
+export interface RepairPlanDependencies {
+  readonly degradedStatePath: string
+  readonly restoreLatest: () => Promise<RestoreResult>
+}
+export interface DesktopRepairPlan {
+  readonly id: DesktopStartupRecoveryRepairPlanId
+  readonly title: string
+  readonly description: string
+  readonly risk: { readonly severity: 'low' | 'medium' | 'high'; readonly notes: string }
+  readonly audience: 'end-user' | 'developer' | 'both'
+  readonly apply: () => Promise<DesktopRepairOutcome>
+}
+
+export function repairPlans(deps: RepairPlanDependencies): ReadonlyArray<DesktopRepairPlan> {
+  return [
+    { id: 'A', title: '临时禁用故障插件',
+      description: '把故障插件加入降级集合，重启后跳过它进入主页面。',
+      risk: { severity: 'low', notes: '仅该插件不再加载，基础聊天/WebUI 可用。' },
+      audience: 'both',
+      apply: async () => {
+        writeDegradedBundles(deps.degradedStatePath, [])
+        return { status: 'degraded', message: '已启用降级模式。请重新启动 Desktop。' }
+      } },
+    { id: 'B', title: '回滚子模块版本',
+      description: '把上游子模块 pin 回退到上一有效 commit。',
+      risk: { severity: 'high', notes: '违反"不编辑子模块"纪律，需显式告警。' },
+      audience: 'developer',
+      apply: async () => ({ status: 'acknowledged', message: '方案 B 需开发者二次确认，暂不自动执行。' }) },
+    { id: 'C', title: '重置插件加载清单',
+      description: '把 profile bundle 组合改写为默认/上次健康集。',
+      risk: { severity: 'medium', notes: '可能丢失自定义插件组合。' },
+      audience: 'both',
+      apply: async () => ({ status: 'acknowledged', message: '方案 C 需默认健康集，暂不自动执行。' }) },
+    { id: 'D', title: '恢复默认配置',
+      description: '恢复上次健康配置快照。',
+      risk: { severity: 'low', notes: '恢复上次健康快照。' },
+      audience: 'both',
+      apply: async () => {
+        const result = await deps.restoreLatest()
+        return { status: result.status, message: `已恢复上次健康快照（${result.changedFiles.join(', ')}）。` }
+      } },
+  ]
+}
+```
+（`A.apply` 这里的写 `[]` 是降级兜底——实际由控制器把 `executeRepair('A')` 先 `commitDegraded([target])` 再调用 apply；二者协作，避免重复写。控制器侧保留 Task 2.3 的分发逻辑。）
+
+- [ ] **Step 4: Run test to verify it passes** — PASS。
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/repair-plans.ts tests/repair-plans.spec.ts
+git commit -m "feat(desktop): add typed repair plan registry with risk and apply"
+```
+
+### Task 3.4: 控制器 runAiAnalysis + 窗口 ai-analyze 与渲染
+
+**Files:**
+- Modify: `dsh-plugin-desktop/src/startup-recovery-controller.ts`
+- Modify: `dsh-plugin-desktop/src/startup-recovery-window.ts`
+- Test: `dsh-plugin-desktop/tests/startup-recovery-window.spec.ts`、`tests/startup-recovery-controller.spec.ts`
+
+**Interfaces:**
+- Consumes: `analyzeDiagnostics`（Task 3.1）、`runRepairSelfCheck`（Task 3.2）、`repairPlans`（Task 3.3）。
+- Produces:
+  - `async runAiAnalysis(): Promise<DesktopStartupRecoveryAiAnalysis>`（Tier0 + 可选 Tier1）
+  - 窗口动作 `ai-analyze`（single-flight，带进度），渲染根因 / 风险 badge / 方案区缓存 / 自检报告。
+
+- [ ] **Step 1: 控制器加 runAiAnalysis**
+
+```ts
+async runAiAnalysis(): Promise<DesktopStartupRecoveryAiAnalysis> {
+  this.assertCurrentGeneration()
+  const input = this.lastFailureStack()   // 来自构造时的 failureStack
+  const diagnosis = analyzeDiagnostics(input)
+  return { diagnosis }
+}
+```
+控制器构造选项新增 `failureStack?: string`。
+
+- [ ] **Step 2: 窗口动作 + 状态 + 渲染**
+
+在 `DesktopStartupRecoveryAiAnalysis` 增加 `diagnosis?: AiDiagnosis`、`selfCheck?: RepairSelfCheckReport`；加 `ai-analyze` 动作处理（single-flight）：调 `requireController().runAiAnalysis()`，渲染 `aiAnalysisHtml` 输出 `rootCause`、`severity` badge、`options`（复用 `REPAIR_PLAN_OPTIONS`）、`disclaimer`、`selfCheck` 明细。给恢复卡新增"加载本地诊断包 / 自动读取已生成包"两个按钮，指向 `dsh-recovery://ai-analyze`。`MAX_FAILURE_DETAIL_LENGTH` 从 `4_000` 上调到 `16_000` 以容纳堆栈。
+
+- [ ] **Step 3: 新增单测**
+
+```ts
+// window 渲染测试
+it('renders the analyzed root cause, risk badge, and self-check report', () => {
+  const html = renderDesktopStartupRecoveryHtml(viewModel({
+    aiAnalysis: {
+      selectedOption: 'A',
+      diagnosis: {
+        rootCause: '依赖解析失败：缺失模块 plugin-x。', severity: 'medium',
+        options: [], recommendation: '建议先尝试方案 A。', disclaimer: 'AI 辅助建议，仅供参考。',
+      },
+      selfCheck: { ok: true, checks: [{ name: 'core import', passed: true, detail: 'ok' }],
+        recommendation: '✅ 修复成功，点击【重新启动 DSH Desktop】生效。' },
+    },
+  }))
+  expect(html).toContain('缺失模块 plugin-x')
+  expect(html).toContain('medium')
+  expect(html).toContain('重新启动 DSH Desktop')
+})
+```
+
+- [ ] **Step 4: 运行相关测试 & typecheck & commit**
+
+Run: `cd dsh-plugin-desktop && corepack yarn vitest run tests/startup-recovery-window.spec.ts tests/startup-recovery-controller.spec.ts && cd .. && corepack yarn typecheck`
+
+```bash
+git add src/startup-recovery-controller.ts src/startup-recovery-window.ts tests/startup-recovery-window.spec.ts
+git commit -m "feat(desktop): run Ai analysis from the recovery window and render risk + self-check"
+```
+
+### Task 3.5: Tier 1 本地 DSH 推理（静默降级）
+
+**Files:**
+- Create: `dsh-plugin-desktop/src/ai-diagnostic-analyzer.ts`
+- Test: `dsh-plugin-desktop/tests/ai-diagnostic-analyzer.spec.ts`
+
+**Interfaces:**
+- Consumes: `analyzeDiagnostics`（Task 3.1）。
+- Produces: `async runTierOneAnalysis(input: string): Promise<AiDiagnosis | undefined>`（失败或不可用返回 `undefined`，调用方降级 Tier0）。
+
+- [ ] **Step 1: 实现（只读、不加载桌面插件树）**
+
+```ts
+// src/ai-diagnostic-analyzer.ts
+import { spawn } from 'node:child_process'
+import { packagedDependencyPath } from './packaged-runtime-path.ts'
+import { analyzeDiagnostics, type AiDiagnosis } from './diagnostic-analyzer.ts'
+
+export async function runTierOneAnalysis(input: string): Promise<AiDiagnosis | undefined> {
+  try {
+    const dshCli = packagedDependencyPath(import.meta.url, '@deepseek-ai/dsh/lib/bin.js')
+    const text = await new Promise<string>((resolve, reject) => {
+      const child = spawn(process.execPath, [dshCli, '--recovery-analyze', '--stdin'], {
+        stdio: ['pipe', 'pipe', 'ignore'],
+      })
+      let out = ''
+      child.stdout.on('data', chunk => { out += String(chunk) })
+      child.on('error', reject)
+      child.on('exit', code => code === 0 ? resolve(out) : reject(new Error(`dsh exit ${code}`)))
+      child.stdin.end(JSON.stringify({ input }))
+    })
+    const parsed = JSON.parse(text) as AiDiagnosis
+    if (parsed?.options === undefined) return undefined
+    return parsed
+  } catch {
+    return undefined   // 静默降级：绝不阻塞恢复页
+  }
+}
+```
+
+- [ ] **Step 2: 单测（注入失败时降级）**
+
+```ts
+it('degrades to undefined when the CLI is unavailable', async () => {
+  vi.spyOn(require('node:child_process'), 'spawn').mockImplementation(() => {
+    throw new Error('no dsh')
+  })
+  await expect(runTierOneAnalysis('Error: Cannot find module \'x\'')).resolves.toBeUndefined()
+})
+```
+
+- [ ] **Step 3: 接线到 runAiAnalysis**
+
+在 `runAiAnalysis` 中：`const tier1 = await runTierOneAnalysis(input); const diagnosis = tier1 ?? analyzeDiagnostics(input)`。
+
+- [ ] **Step 4: Run test & commit**
+
+Run: `cd dsh-plugin-desktop && corepack yarn vitest run tests/ai-diagnostic-analyzer.spec.ts tests/diagnostic-analyzer.spec.ts`
+
+```bash
+git add src/ai-diagnostic-analyzer.ts tests/ai-diagnostic-analyzer.spec.ts src/startup-recovery-controller.ts
+git commit -m "feat(desktop): add silent-degrade local DSH inference path for Ai diagnosis"
+```
+
+### Task 3.6: 修复后自检接入 + 重启生效闭环
+
+**Files:**
+- Modify: `dsh-plugin-desktop/src/startup-recovery-controller.ts`、`startup-recovery-window.ts`
+- Test: `tests/startup-recovery-controller.spec.ts`
+
+**Interfaces:**
+- Consumes: `runRepairSelfCheck`（Task 3.2）、`repairPlans`（Task 3.3）、`installProfilePackageResolver`。
+- Produces: `executeRepair` 执行后跑自检，返回结果含 `selfCheck?: RepairSelfCheckReport`；窗口在自检通过后显示"重新启动 DSH Desktop"（`restartReady = true`），失败则回退 radio 保留历史。
+
+- [ ] **Step 1: 实现**
+
+```ts
+// 控制器：executeRepair 执行 plan.apply() 后
+const outcome = await plan.apply()
+const selfCheck = await this.runSelfCheck()   // 用注入的检测项：目标 bundle 可解析 / 核心模块可导入
+return { planId, status: outcome.status as DesktopStartupRecoveryRepairResult['status'],
+  message: outcome.message, selfCheck }
+```
+自检检测项由控制器构造注入（默认 `installProfilePackageResolver(profileBaseUrl)` + `import.meta.resolve` / `createRequire` 探测，失败即 `{ ok:false, detail: err.message }`），保持只读探测、不污染代际。
+
+- [ ] **Step 2: 窗口渲染**
+
+在 `aiAnalysisHtml` 中，当 `selfCheck?.ok === true` 时追加 `restartReady` 文案与 `<a class="button primary" href="dsh-recovery://restart">重新启动 DSH Desktop</a>`；否则显示 `recommendation`（"请尝试其他方案"）。
+
+- [ ] **Step 3: 单测**
+
+```ts
+it('surfaces a restart CTA after a passing self-check', () => {
+  const html = renderDesktopStartupRecoveryHtml(viewModel({
+    restartReady: true,
+    aiAnalysis: { result: { planId: 'A', status: 'degraded', message: '已启用降级。' } },
+  }))
+  expect(html).toContain('dsh-recovery://restart')
+  expect(html).toContain('重新启动 DSH Desktop')
+})
+```
+
+- [ ] **Step 4: Run test & typecheck & commit**
+
+Run: `cd dsh-plugin-desktop && corepack yarn vitest run tests/startup-recovery-window.spec.ts tests/startup-recovery-controller.spec.ts tests/repair-self-check.spec.ts && cd .. && corepack yarn typecheck`
+
+```bash
+git add src/startup-recovery-controller.ts src/startup-recovery-window.ts tests/startup-recovery-window.spec.ts
+git commit -m "feat(desktop): run read-only self-check after repair and surface restart CTA"
+```
+
+---
+
+## Final Gate
+
+对每个改动文件跑 `cd .. && corepack yarn typecheck && cd .. && corepack yarn test`，最后整仓库 `corepack yarn check`。断言语义（spec doc 第 6 节）：
+
+1. AI 只分析建议，绝不未经用户确认修改配置 —— `runAiAnalysis` 只读。
+2. 降级模式明确横幅提示，可一键退出降级。
+3. 全部旧功能保留。
+
+## Self-Review
+
+- **Spec coverage:** 规格 6 节均已映射 —— 降级策略→Phase 2；诊断包增强→Phase 1；AI 链路→Phase 3 Task 3.1/3.5/3.6；UI 交互→Task 2.4/3.4/3.6；修复方案与自检→Task 3.3/3.6；风险点 1/2/3/4/6→Global Constraints + Task 2.2/2.4/3.5。
+- **Type consistency:** `DesktopStartupRecoveryRepairPlanId`（controller）、`repair-plans.DesktopRepairPlan.id`、`REPAIR_PLAN_OPTIONS[].id` 统一为 A–D；`AiDiagnosis`/`AiRepairOption` 在 analyzer/controller/window 共用；`RepairSelfCheckReport` 在 self-check/controller/window 共用。
+- **Scope:** B/C 方案明确声明为能力边界（需开发者专属 + 二次确认 / 默认健康集），不是占位符；跨 `git submodule` 约束遵守。

--- a/.agents/notes/proposed/architecture/2026-08-22-desktop-recovery-safe-degraded-mode-ai-diagnostics.zh.md
+++ b/.agents/notes/proposed/architecture/2026-08-22-desktop-recovery-safe-degraded-mode-ai-diagnostics.zh.md
@@ -1,0 +1,189 @@
+# Agent Note：桌面恢复页面增强 —— 安全降级模式 + AI 辅助故障诊断
+
+状态：提议（Proposed）
+
+> 设计目标：修复"插件 / 子模块 / 依赖问题导致完全无法进入主页面"的故障恢复体验。
+> 核心原则：**不能因插件、子模块兼容、依赖问题导致完全无法进入主页面。**
+
+## 问题
+
+`Cannot find module xxx` / `plugin tree failed to load` 并不会让应用崩溃，而是让**该代际的 Host 或 Client 启动失败**并落到恢复窗口。真正的问题是：
+
+1. **Host 启动失败**：恢复窗口是唯一出口，且只有「禁用 / 回滚 / 重试 / 退出」四条死路，**没有一条"先跳过故障、进主页再说"的降级出路**。单个必需插件失败即整树失败。
+2. **Renderer 加载插件失败**：boot 页显示 `Failed to load plugins` 时，只注入一个「打开 DSH 终端」按钮，**无恢复窗口、无返回主页路径**——这是"卡死、进不去"最严重的空窗。
+3. **诊断包缺关键证据**：无完整报错堆栈、插件加载树、子模块 commit、系统环境快照、配置快照。
+4. **AI 能力**：无任何"普通人能看懂"的分析、修复方案、风险提示、自检与"重启生效"闭环。
+
+> 语义说明：仓库中**没有"plugin tree"这一实体**——它指 Cordis 插件树 / pnpm 进程树。真实数据结构是 **Bundle 清单**（`DesktopProfileManifestBundle`: `packageName` / `status`: active|disabled / `mutable`，见 `dsh-plugin-desktop/src/desktop-plugins.ts:177-181`）。本设计对齐该语义。
+
+## 解决方案
+
+### 1. 故障降级策略（安全降级模式）
+
+新增一种**生成级排除集 + 降级横幅 + 可逆**的档位，与"永久禁用"严格区分：
+
+| 档位 | 语义 | 持久化 | 可逆 | 现状 |
+|---|---|---|---|---|
+| 自动降级 | 可选 client-ui 插件解析失败自动跳过 | 内存生成级 | 每次启动重判 | 已有 `omitUnresolvedOptionalEntries`（`src/profile.ts:419-453`）|
+| **安全降级模式（新增）** | 用户显式选择：跳过故障 bundle 进主页，显示横幅 | `startup-recovery/degraded.json` | **可逆** | 无 |
+| 永久禁用 | 用户确认该插件不再启用 | `plugin-management/state.json` | 需手动启用 | 已有 `executeDisable` |
+
+**注入点（最小改动）**：在 `src/profile.ts` 的 patch 层组合阶段，把 `degraded.json` 里的 bundle 名从各层 patch 剔除（复用 `omitUnresolvedOptionalEntries` 思路，作用于**必需入口**）。**不改上游 `boot()`、不碰 `@deepseek-ai/dsh-app-boot` 依赖包**。
+
+**数据流**：
+```
+恢复窗口[安全降级模式] → 写 degraded.json → finish('restart') → relaunch
+  → 下一次 boot: profile.ts 读 degraded.json → 剔除故障 bundle → 进主页
+  → client/main 窗读 degraded.json → 顶部横幅"安全降级模式：插件 X 未加载"
+  → 横幅[恢复完整插件集] → 清空 degraded.json → relaunch
+```
+
+**降级护栏**：建立**最小健康集**（`dsh-app-boot`、`webserver`、`settings`、`desktop-shell`、`dsh-session` 等核心行）。故障落在最小健康集内时**禁止降级进主页**（裸主页也不可用），只能禁用 / 回滚 / 恢复配置——避免"降级了还是黑屏"。
+
+### 2. 诊断包增强
+
+接入 `src/diagnostic-export-worker.ts` 的 `createDiagnosticsArchive()`（`:167-286`），新增以下证据（沿用 50MB 预算、脱敏、原子发布、保留 3 份）：
+
+| 新增项 | 数据来源 | 落点 |
+|---|---|---|
+| 完整报错堆栈 | 启动失败异常（`main.ts:831` 的 `cause`/`stack`） | 新增 `error-stack.txt`（含 cause 链） |
+| 插件加载树 / 清单 | `readDesktopProfileBundleInventory`（`src/desktop-plugins.ts:368`） | 新增 `plugin-manifest.json`（有序 bundle + status + 顺序） |
+| 各子模块 commit 版本 | 根 `upstream.json` commit；`git rev-parse HEAD`（允许时）；`@deepseek-ai/dsh` build 信息 | 新增 `versions.json` |
+| 系统环境快照 | `process.env` 关键项（复用 `mask-secrets.ts` 脱敏） | 并入 `system-info.txt` |
+| 当前插件清单 | `package.json → dsh.profile.bundles` | 新增 `profile-bundles.json` |
+| 配置文件快照 | `cordis.patch.yml` / `package.json` / `pnpm-workspace.yaml` | 复用 `DESKTOP_PROFILE_CHECKPOINT_FILES` 白名单（`src/profile-checkpoint.ts:40-56`） |
+
+> `node` / `electron` 版本已在 `system-info.txt`（`:239-240`），无需重复。
+
+### 3. AI 诊断链路（分层、永不阻塞）
+
+DSH 推理本身是插件树里的组件而插件树恰恰挂了，因此 AI 能力设计为分层，规则分析兜底，确保**即使模型完全不可用，恢复页也不会卡住**：
+
+```
+diagnostics.zip
+  ├─ Tier 0  确定性规则分析（无模型、无网络、永不失败）
+  │          解折堆栈 → 正则 "Cannot find module 'X'"
+  │          → module-resolution 探测 X（复用 src/module-resolution.ts）
+  │          → 错误短语 → 已知根因映射（中文）→ 只输出"根因 + 修复选项"，绝不改配置
+  ├─ Tier 1  项目 DSH 本地推理（有则用，无则跳过）
+  │          spawn 独立 CLI @deepseek-ai/dsh/lib/bin.js（只读，不加载桌面插件树）
+  │          → 本地模型产出"通俗中文根因 + 逐方案风险 + 推荐"
+  └─ Tier 2  外部模型（可选，默认关闭，仅当用户已配且本地不可用才触发）
+```
+
+**边界约束落实**：AI 只分析只建议，产出为「问题描述 + 风险等级 + 方案列表(含风险) + 推荐」，不写任何配置；写配置仅发生在用户点击【执行修复】后，且由 `repair-plans.ts`（非 AI）执行。优先本地、不强制联网。决策权永远在用户。
+
+## UI 交互设计
+
+恢复窗口为**无 JS / 自包含 `data:` HTML + 严格 CSP**（`src/startup-recovery-window.ts:386`，`connect-src 'none'`），**无 IPC**，UI→主进程走 **URL scheme 动作总线**（`dsh-recovery://<action>?id=…`，`:324-328, 418-433`），主→UI 整份 `loadURL` 重渲。新增动作用同一套总线，零 IPC、零 CSP 放宽。
+
+新增区域【AI 辅助故障分析】（插在 Diagnostics 卡片之下）：
+
+```
+┌─ 启动错误卡片（现有 stage + 截断 detail，上调 MAX_FAILURE_DETAIL_LENGTH 容纳堆栈）
+├─ [AI 辅助故障分析]（新卡片）
+│  ├─ 按钮①：加载本地诊断包        ─┐
+│  ├─ 按钮②：自动读取已生成的包      ─┤→ ai-analyze（single-flight，带进度状态）
+│  ├─ 状态行：分析中 / 完成 / 失败
+│  ├─ 根因区：通俗中文根因 + 风险等级 badge（低/中/高）
+│  ├─ 方案区 (radio)：
+│  │     ○ A 临时禁用故障插件（低风险…）
+│  │     ○ B 回滚子模块版本（高风险·仅开发者…）
+│  │     ○ C 重置插件加载清单（中风险…）
+│  │     ○ D 恢复默认配置（低~中风险…）
+│  │  [ 执行修复 ]
+│  ├─ 自检报告区：✅/❌ 插件树可加载 / 关键模块可导入 + 明细
+│  └─ [ 重新启动 DSH Desktop ]
+├─ 原有卡片（Last protected installation / Plugin bundle list / Manual config / Diagnostics）——全部保留
+└─ Footer：Restart + Quit（原有）
+```
+
+**无 JS 下实现 radio 单选 + 执行修复**：HTML radio 纯 DOM 状态可选中；提交用 GET 表单，submit 触发导航落 `will-navigate`/`will-redirect` 拦截器（`:491-497`），URL 变为 `dsh-recovery://execute-repair?option=A`，正好被 `parseDesktopStartupRecoveryAction` 解析：
+
+```html
+<form method="GET" action="dsh-recovery://execute-repair">
+  <label><input type="radio" name="option" value="A" checked> 方案A …</label>
+  <button type="submit">执行修复</button>
+</form>
+```
+
+**兜底**：若严格 CSP 下 `will-navigate` 对表单 GET 不触发（需实测），退化为**每方案独立按钮**（`dsh-recovery://execute-repair?option=A`）。
+
+**主窗降级横幅**：`client/` 顶部加「⚠️ 安全降级模式：插件 X 未加载，基础聊天/WebUI 可用，部分功能受限。[恢复完整插件集] [查看诊断]」，读 `degraded.json` 显隐。
+
+## 修复方案与自检
+
+### 方案注册表（`repair-plans.ts`，类型化、非 AI 可执行）
+
+```ts
+interface RepairPlan {
+  id: 'A'|'B'|'C'|'D'
+  title: string
+  description: string          // 普通人视角
+  risk: { severity: 'low'|'medium'|'high'; notes: string }
+  audience: 'end-user'|'developer'|'both'
+  apply(): Promise<RepairOutcome>   // 唯一写配置的地方
+}
+```
+
+| id | 方案 | 底层机制 | 风险 | 面向 |
+|---|---|---|---|---|
+| A | 临时禁用故障插件 | disable 标记（或降级 exclude，可逆） | 低：仅该插件不可用 | 两类 |
+| B | 回滚子模块版本（开发） | 改 `upstream.json` commit + submodule checkout 上一 commit | **高**：违反"不编辑子模块"约束，需显式告警 | developer |
+| C | 重置插件加载清单 | 重写 `package.json → dsh.profile.bundles` 为默认 / 上次健康集 | 中：可能丢自定义组合 | 两类 |
+| D | 恢复默认配置 | `DesktopProfileCheckpoint.restoreLatest(failureGeneration)`（`src/profile-checkpoint.ts:376-419`） | 低~中：恢复上次健康快照 | 两类 |
+
+> 边界约束①：方案 A/C/D 在用户点击后由 `repair.apply()` 执行；方案 B 因改子模块，额外二次确认弹窗并标注开发者专属。
+
+### 自检验证（`repair-self-check.ts`）
+
+修复执行后、**不做重启**，在恢复代际内跑只读校验：
+
+1. **插件树可加载**：用 resolver 探测目标 bundle 能否被 `ctx.loader.internal.import()` 解析、能否 `activate`（复用 `module-resolution.ts`，不真启动整树）。
+2. **关键模块可导入**：对最小健康集逐个 `import()` 裸路径，断言成功。
+3. 输出结构化报告：`{ ok, checks: [{ name, passed, detail }], recommendation }`。
+
+渲染为：✅ 修复成功 → "点击【重新启动 DSH Desktop】生效"；❌ 修复失败 → "请尝试其他方案"（回退到 radio，保留历史结果）。自检必须**只读探测**，不污染代际。
+
+## 需要改动的文件清单（最小改造）
+
+> 尽量小、不重构、不碰上游 submodule、不动 `dsh-app-boot` 依赖包。核心是把"降级 + AI 分析"作为**新模块**接入现有恢复窗口总线。
+
+**新增**：
+
+| 文件 | 职责 |
+|---|---|
+| `dsh-plugin-desktop/src/diagnostic-analyzer.ts` | Tier 0 规则分析（堆栈解构、module-not-found、根因映射）。纯函数无 IO/网络。 |
+| `dsh-plugin-desktop/src/ai-diagnostic-analyzer.ts` | Tier 1 本地 DSH 推理封装（spawn `@deepseek-ai/dsh/lib/bin.js`），失败静默降级 Tier0。 |
+| `dsh-plugin-desktop/src/repair-plans.ts` | 方案 A–D 注册表 + 风险 + `apply()`。 |
+| `dsh-plugin-desktop/src/repair-self-check.ts` | 修复后只读自检（resolver 探测 + 关键模块 importable）。 |
+
+**修改**：
+
+| 文件 | 改动点 |
+|---|---|
+| `dsh-plugin-desktop/src/startup-recovery-window.ts` | 新动作入白名单（`:418-433`）；新增 `handleAiAnalyze`/`handleExecuteRepair` 与状态字段；HTML 加 AI 卡片 + radio 表单；上调 `MAX_FAILURE_DETAIL_LENGTH`。 |
+| `dsh-plugin-desktop/src/startup-recovery-controller.ts` | 新增 `runAiAnalysis()`、`executeRepair(id)`、`commitDegraded(bundles)`、single-flight 与 dispose 清理。 |
+| `dsh-plugin-desktop/src/diagnostic-export-worker.ts` | `createDiagnosticsArchive()` 增写 `error-stack.txt`/`plugin-manifest.json`/`versions.json`/`profile-bundles.json`/config 快照；system-info 增 env 快照。 |
+| `dsh-plugin-desktop/src/diagnostics.ts` / `diagnostic-export.ts` | 导出选项透传 stack/manifest/commit 等新证据源。 |
+| `dsh-plugin-desktop/src/profile.ts` | patch 层组合阶段读 `degraded.json`，剔除降级 bundle。 |
+| `dsh-plugin-desktop/src/main.ts` | 传入诊断新证据来源；recovery 工厂接 `runAiAnalysis`/`executeRepair`/`commitDegraded`；启动失败处采集堆栈；（可选）boot 页插件失败也路由到增强恢复窗口闭合 P2。 |
+
+**明确不改**：`deepseek-harness/` 子模块、`@deepseek-ai/dsh-app-boot`、`src/startup-failure-routing.ts`（纯决策表保持纯净）。所有旧功能（禁用插件、编辑配置补丁、导出诊断包、回滚/重试、重启/退出）保留。AI 零写配置。
+
+## 风险点
+
+1. **AI-Tier1 可能复现故障**：本地 DSH 推理若仍走 `boot()` 会撞上同一失败。→ 用独立 CLI 只读模式、不加载桌面插件树；失败静默降级 Tier0，绝不阻塞恢复页。
+2. **降级 exclude 与永久禁用语义易混淆**：→ `degraded.json` 与 `state.json` 分离，横幅明确标注并附一键退出降级。
+3. **最小健康集误判**：核心行故障禁止降级，仅给禁用 / 回滚 / 恢复配置，避免黑屏。
+4. **方案 B 违反仓库纪律**（"不编辑子模块"）：→ 仅开发者可见 + 二次确认 + 明确高警示。
+5. **诊断包膨胀 / 隐私**：env 快照复用 `mask-secrets.ts` 只取白名单 key；沿用 50MB 预算与保留 3 份。
+6. **无 JS 表单可靠性**：严格 CSP/partition 下 GET 表单导航未必命中拦截器。→ 保留"每方案独立按钮"兜底，需 Windows/macOS 实测。
+7. **AI 产生误导性诊断**：→ Tier0 规则兜底（确定性），输出标注"AI 辅助建议，仅供参考，最终以你选择为准"；AI 永不被授权自动执行修复。
+
+## 落地建议（次序列）
+
+1. 先做诊断包增强（最独立、风险最低）。
+2. 再做**安全降级模式**（主诉：`degraded.json` + `profile.ts` 剔除 + 横幅），不依赖 AI，先让用户"进得去"。
+3. 最后接 **AI 分析（Tier0 → Tier1）+ 修复方案 + 自检 + 重启闭环**。
+4. 全链路跑 `corepack yarn typecheck`、`corepack yarn test`、`corepack yarn check` 三关后提 PR。

--- a/dsh-plugin-desktop/src/ai-diagnostic-analyzer.ts
+++ b/dsh-plugin-desktop/src/ai-diagnostic-analyzer.ts
@@ -1,0 +1,66 @@
+// src/ai-diagnostic-analyzer.ts
+import { spawn } from 'node:child_process'
+import { packagedDependencyPath } from './packaged-runtime-path.ts'
+import type { AiDiagnosis } from './diagnostic-analyzer.ts'
+
+const TIER_ONE_TIMEOUT_MS = 15_000
+const TIER_ONE_MAX_STDOUT_BYTES = 1024 * 1024
+
+export async function runTierOneAnalysis(
+  input: string,
+  signal?: AbortSignal,
+): Promise<AiDiagnosis | undefined> {
+  try {
+    const dshCli = packagedDependencyPath(import.meta.url, '@deepseek-ai/dsh/lib/bin.js')
+    const text = await new Promise<string>((resolve, reject) => {
+      const child = spawn(process.execPath, [dshCli, '--recovery-analyze', '--stdin'], {
+        stdio: ['pipe', 'pipe', 'ignore'],
+      })
+      let out = ''
+      let settled = false
+      const abortError = new DOMException('Tier-1 analysis aborted.', 'AbortError')
+      const settle = (finalize: () => void): void => {
+        if (settled) return
+        settled = true
+        clearTimeout(timer)
+        signal?.removeEventListener('abort', abortHandler)
+        finalize()
+      }
+      const abortHandler = (): void => {
+        child.kill('SIGKILL')
+        settle(() => reject(abortError))
+      }
+      const timer = setTimeout(() => {
+        child.kill('SIGKILL')
+        settle(() => reject(new Error('dsh analyze timed out')))
+      }, TIER_ONE_TIMEOUT_MS)
+      timer.unref?.()
+      // Swallow EPIPE and any stdin stream error; only the exit handler decides
+      // the outcome. Without this, a child that exits before consuming stdin
+      // fires an uncaught 'error' event in Electron main and crashes the process.
+      child.stdin.on('error', () => {})
+      child.stdout.on('data', chunk => {
+        if (out.length < TIER_ONE_MAX_STDOUT_BYTES) out += String(chunk)
+      })
+      child.on('error', cause => settle(() => reject(cause)))
+      child.on('exit', code => settle(() => {
+        if (code === 0) resolve(out)
+        else reject(new Error(`dsh exit ${code}`))
+      }))
+      if (signal !== undefined) {
+        if (signal.aborted) {
+          child.kill('SIGKILL')
+          settle(() => reject(abortError))
+        } else {
+          signal.addEventListener('abort', abortHandler, { once: true })
+        }
+      }
+      child.stdin.end(JSON.stringify({ input }))
+    })
+    const parsed = JSON.parse(text) as AiDiagnosis
+    if (parsed?.options === undefined) return undefined
+    return parsed
+  } catch {
+    return undefined   // 静默降级：绝不阻塞恢复页
+  }
+}

--- a/dsh-plugin-desktop/src/client/AdvancedFrame.tsx
+++ b/dsh-plugin-desktop/src/client/AdvancedFrame.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useLayoutEffect, useRef, useState, useSyncExternalStore } from 'react'
 import type { PropsRenderSlots, PropsRuntime } from '@deepseek-ai/dsh-client-ui-slots'
 import type {} from './contracts.ts'
+import type { DesktopDegradedNotice } from './degraded-notice.ts'
 import type { DesktopClientPlatform } from './environment.ts'
 import {
   computeDesktopColumns, DesktopLayoutState, MACOS_SIDEBAR_COLLAPSED,
@@ -13,6 +14,8 @@ export interface AdvancedFrameInjected {
   layout: DesktopLayoutState
   /** Host platform controlling native title-bar spacing. */
   platform: DesktopClientPlatform
+  /** Safe-degraded-mode banner copy; inactive when no bundle is degraded. */
+  degradedNotice: DesktopDegradedNotice
 }
 
 /** Full advanced root slot props. */
@@ -21,12 +24,13 @@ export type AdvancedFrameProps = PropsRuntime<'root'>
   & AdvancedFrameInjected
 
 /** Desktop-owned transparent frame around the unchanged product surfaces. */
-export function AdvancedFrame({ layout, platform, renderSlot, useSessions }: AdvancedFrameProps) {
+export function AdvancedFrame({ layout, platform, degradedNotice, renderSlot, useSessions }: AdvancedFrameProps) {
   const subscribeLayout = useCallback((listener: () => void) => layout.subscribe(listener), [layout])
   const readLayout = useCallback(() => layout.getSnapshot(), [layout])
   const panels = useSyncExternalStore(subscribeLayout, readLayout)
   const frameRef = useRef<HTMLDivElement>(null)
   const [viewport, setViewport] = useState(() => window.innerWidth)
+  const [degradedDismissed, setDegradedDismissed] = useState(false)
   const detailsSession = useSessions((state) => {
     const current = state.current
     return current !== undefined && state.byId[current]?.blank === false ? current : undefined
@@ -105,6 +109,27 @@ export function AdvancedFrame({ layout, platform, renderSlot, useSessions }: Adv
       data-dragging={dragging || undefined}
       style={{ gridTemplateColumns: `${columns.sidebar}px minmax(0, 1fr) ${columns.details}px` }}
     >
+      {degradedNotice.active && !degradedDismissed && (
+        <div className="dshDesktopDegradedBubble" role="status">
+          <div className="dshDesktopDegradedHeader">
+            <svg className="dshDesktopDegradedIcon" viewBox="0 0 24 24" width="18" height="18" aria-hidden="true" focusable="false">
+              <path d="M1 21h22L12 2 1 21zm12-3h-2v-2h2v2zm0-4h-2v-4h2v4z" fill="currentColor" />
+            </svg>
+            <span className="dshDesktopDegradedTitle">{degradedNotice.title}</span>
+          </div>
+          <span className="dshDesktopDegradedBody">{degradedNotice.body}</span>
+          <div className="dshDesktopDegradedActions">
+            <button
+              type="button"
+              className="dshDesktopDegradedDismiss"
+              onClick={() => { setDegradedDismissed(true) }}
+            >
+              {degradedNotice.dismissLabel}
+            </button>
+            <a className="dshDesktopDegradedRecover" href="dsh-recovery://restart">{degradedNotice.restoreLabel}</a>
+          </div>
+        </div>
+      )}
       {platform === 'darwin' && <div className="dshDesktopMacCaptionRow" aria-hidden="true" />}
       {platform === 'win32' && <div className="dshDesktopWindowsCaptionRow" aria-hidden="true" />}
       <aside className="dshDesktopSidebarSurface">

--- a/dsh-plugin-desktop/src/client/advanced-shell.ts
+++ b/dsh-plugin-desktop/src/client/advanced-shell.ts
@@ -1,6 +1,8 @@
 import type { ClientContext } from '@deepseek-ai/dsh-client-runtime/client'
+import type {} from '@deepseek-ai/dsh-client-locale/client'
 import type {} from '@deepseek-ai/dsh-client-ui-theme/client'
 import type {} from './contracts.ts'
+import { desktopDegradedNotice } from './degraded-notice.ts'
 import type { DesktopClientEnvironment } from './environment.ts'
 import { AdvancedFrame } from './AdvancedFrame.tsx'
 import { DesktopLayoutState } from './layout-state.ts'
@@ -53,6 +55,13 @@ export function applyAdvancedShell(ctx: ClientContext, environment: DesktopClien
       'details': { kind: 'single', scope: 'session' },
       'shell.overlay': { kind: 'list', scope: 'root' },
     },
-    inject: () => ({ layout: desktopLayout, platform: environment.platform }),
+    inject: () => ({
+      layout: desktopLayout,
+      platform: environment.platform,
+      degradedNotice: desktopDegradedNotice(
+        environment.degradedBundles ?? [],
+        ctx.locale.getLocale().active === 'zh' ? 'zh' : 'en',
+      ),
+    }),
   }, AdvancedFrame), 'desktop: advanced root slot')
 }

--- a/dsh-plugin-desktop/src/client/degraded-notice.ts
+++ b/dsh-plugin-desktop/src/client/degraded-notice.ts
@@ -1,0 +1,37 @@
+/** Rendered safe-degraded-mode banner content for the advanced frame. */
+export interface DesktopDegradedNotice {
+  /** Whether any degraded bundle is present and the banner should render. */
+  readonly active: boolean
+  /** Short banner heading. */
+  readonly title: string
+  /** Human-readable explanation of which bundles are degraded. */
+  readonly body: string
+  /** Label for the dismiss-without-restart action. */
+  readonly dismissLabel: string
+  /** Label for the restore-and-restart action. */
+  readonly restoreLabel: string
+}
+
+/**
+ * Compute the safe-degraded-mode banner copy for the advanced frame.
+ * @param degradedBundles - bundles that failed to load and were left degraded.
+ * @param locale - active client locale mapped to the shipped copy languages.
+ * @returns the rendered banner content, inactive when nothing is degraded.
+ */
+export function desktopDegradedNotice(
+  degradedBundles: readonly string[],
+  locale: 'en' | 'zh',
+): DesktopDegradedNotice {
+  if (degradedBundles.length === 0) {
+    return { active: false, title: '', body: '', dismissLabel: '', restoreLabel: '' }
+  }
+  return {
+    active: true,
+    title: locale === 'zh' ? '安全降级模式' : 'Safe degraded mode',
+    body: locale === 'zh'
+      ? `插件 ${degradedBundles.join(', ')} 未加载，基础聊天/WebUI 可用，部分功能受限。`
+      : `Plugins ${degradedBundles.join(', ')} did not load. Core chat/WebUI is available; some features are limited.`,
+    dismissLabel: locale === 'zh' ? '忽略' : 'Dismiss',
+    restoreLabel: locale === 'zh' ? '立即恢复' : 'Restore',
+  }
+}

--- a/dsh-plugin-desktop/src/client/environment.ts
+++ b/dsh-plugin-desktop/src/client/environment.ts
@@ -10,10 +10,29 @@ export interface DesktopClientEnvironment {
   mode: DesktopClientMode
   /** Electron Host platform used for native spacing and drag regions. */
   platform: DesktopClientPlatform
+  /**
+   * Bundles that failed to load and were left degraded; empty in a healthy
+   * run. The parser always populates this from the `dsh-degraded` marker, so
+   * consumers may read it directly; it stays optional so hand-built
+   * environments (tests, fixtures) need not carry it.
+   */
+  degradedBundles?: readonly string[]
 }
 
 const MODES = new Set<DesktopClientMode>(['compatibility', 'advanced'])
 const PLATFORMS = new Set<DesktopClientPlatform>(['darwin', 'win32', 'linux'])
+
+/**
+ * Parse the comma-separated degraded bundle marker. Package names cannot
+ * contain commas, so each non-empty piece is a valid bundle; whitespace and
+ * stray separators are dropped rather than failing the whole environment.
+ * @param raw - decoded marker value from the Electron-owned page URL.
+ * @returns the validated degraded bundles (empty when absent or malformed).
+ */
+function parseDegradedBundles(raw: string | null): readonly string[] {
+  if (raw === null) return []
+  return raw.split(',').map(piece => piece.trim()).filter(piece => piece.length > 0)
+}
 
 /**
  * Validate the Electron-owned query marker before any desktop client effects run.
@@ -31,5 +50,9 @@ export function parseDesktopClientEnvironment(search: string): DesktopClientEnvi
   if (!PLATFORMS.has(platform as DesktopClientPlatform)) {
     throw new Error(`dsh-plugin-desktop: invalid or missing dsh-desktop-platform ${JSON.stringify(platform)}`)
   }
-  return { mode: mode as DesktopClientMode, platform: platform as DesktopClientPlatform }
+  return {
+    mode: mode as DesktopClientMode,
+    platform: platform as DesktopClientPlatform,
+    degradedBundles: parseDegradedBundles(params.get('dsh-degraded')),
+  }
 }

--- a/dsh-plugin-desktop/src/client/styles.ts
+++ b/dsh-plugin-desktop/src/client/styles.ts
@@ -43,6 +43,18 @@ html:has([aria-modal="true"]) .dshDesktopWindowsCaptionRow::before,
 html:has([aria-modal="true"]) .dshDesktopMacCaptionRow::before,
 html:has([aria-modal="true"]) .dshDesktopSidebarSurface,
 html:has([aria-modal="true"]) .dshDesktopSidebarSurface::before { -webkit-app-region: no-drag !important; }
+/* Safe-degraded-mode notice floats above the conversation in the bottom-right
+   corner so it never displaces the frame's content rows. */
+.dshDesktopDegradedBubble { position: absolute; z-index: 90; right: 16px; bottom: 16px; max-width: 340px; display: flex; flex-direction: column; gap: 6px; padding: 12px 14px; background: #fff7e6; color: #7a4d00; border: 1px solid #f2d9a8; border-radius: 10px; box-shadow: 0 6px 20px rgb(0 0 0 / 0.12); font-size: 13px; line-height: 1.5; -webkit-app-region: no-drag; }
+.dshDesktopDegradedHeader { display: flex; gap: 8px; align-items: center; }
+.dshDesktopDegradedIcon { flex: none; }
+.dshDesktopDegradedTitle { font-weight: 600; }
+.dshDesktopDegradedBody { opacity: 0.92; }
+.dshDesktopDegradedActions { display: flex; gap: 14px; align-items: center; margin-top: 2px; }
+.dshDesktopDegradedDismiss { appearance: none; border: none; background: transparent; color: inherit; opacity: 0.7; cursor: pointer; padding: 0; font-size: 13px; }
+.dshDesktopDegradedDismiss:hover { opacity: 1; }
+.dshDesktopDegradedRecover { color: inherit; font-weight: 600; text-decoration: none; border-bottom: 1px solid currentColor; white-space: nowrap; }
+.dshDesktopDegradedRecover:hover { opacity: 0.85; }
 @media (prefers-reduced-motion: reduce) {
   .dshDesktopFrame,
   .dshDesktopResizeHandle { transition: none !important; }

--- a/dsh-plugin-desktop/src/degraded-mode.ts
+++ b/dsh-plugin-desktop/src/degraded-mode.ts
@@ -1,0 +1,39 @@
+// src/degraded-mode.ts
+import { mkdirSync, readFileSync, renameSync, writeFileSync } from 'node:fs'
+import { dirname } from 'node:path'
+
+const DEGRADED_VERSION = 1
+const MAX_DEGRADED_BUNDLES = 1024
+
+interface DegradedState { readonly version: number; readonly bundles: readonly string[] }
+
+function parseDegradedState(text: string): DegradedState {
+  const value: unknown = JSON.parse(text)
+  if (typeof value !== 'object' || value === null) throw new Error('degraded state is not an object')
+  const record = value as Record<string, unknown>
+  if (record.version !== DEGRADED_VERSION) throw new Error(`unsupported degraded version: ${String(record.version)}`)
+  if (!Array.isArray(record.bundles) || record.bundles.length > MAX_DEGRADED_BUNDLES) {
+    throw new Error('degraded state bundles are invalid')
+  }
+  const bundles = record.bundles.filter(
+    (item): item is string => typeof item === 'string' && item.length > 0,
+  )
+  if (bundles.length !== record.bundles.length) throw new Error('degraded state contains a non-string bundle')
+  return { version: DEGRADED_VERSION, bundles }
+}
+
+export function readDegradedBundles(statePath: string): readonly string[] {
+  try {
+    return parseDegradedState(readFileSync(statePath, 'utf8')).bundles
+  } catch (cause) {
+    if ((cause as NodeJS.ErrnoException).code === 'ENOENT') return []
+    throw cause
+  }
+}
+
+export function writeDegradedBundles(statePath: string, bundles: readonly string[]): void {
+  mkdirSync(dirname(statePath), { recursive: true })
+  const temporaryPath = `${statePath}.tmp`
+  writeFileSync(temporaryPath, `${JSON.stringify({ version: DEGRADED_VERSION, bundles }, undefined, 2)}\n`, { mode: 0o600 })
+  renameSync(temporaryPath, statePath)
+}

--- a/dsh-plugin-desktop/src/diagnostic-analyzer.ts
+++ b/dsh-plugin-desktop/src/diagnostic-analyzer.ts
@@ -1,0 +1,36 @@
+// src/diagnostic-analyzer.ts
+export interface AiRepairOption {
+  readonly id: 'A' | 'B' | 'C' | 'D'
+  readonly title: string
+  readonly risk: string
+}
+export interface AiDiagnosis {
+  readonly rootCause: string
+  readonly severity: 'low' | 'medium' | 'high'
+  readonly options: readonly AiRepairOption[]
+  readonly recommendation: string
+  readonly disclaimer: string
+}
+
+const MODULE_NOT_FOUND = /Cannot find module\s+['"]([^'"]+)['"]/u
+
+export function analyzeDiagnostics(input: string): AiDiagnosis {
+  const moduleMatch = MODULE_NOT_FOUND.exec(input)
+  const bundle = moduleMatch?.[1] ?? ''
+  const baseOptions: AiRepairOption[] = [
+    { id: 'A', title: '临时禁用故障插件', risk: '低风险 —— 仅该插件不再加载。' },
+    { id: 'B', title: '回滚子模块版本', risk: '高风险（仅开发者） —— 会改动上游子模块版本锁定。' },
+    { id: 'C', title: '重置插件加载清单', risk: '中风险 —— 可能丢失自定义插件组合。' },
+    { id: 'D', title: '恢复默认配置', risk: '低~中风险 —— 恢复上次健康配置快照。' },
+  ]
+  const rootCause = bundle === ''
+    ? '错误来自插件加载树，无法定位到具体缺失模块。'
+    : `依赖解析失败：缺失模块 ${bundle}。插件或子模块未正确安装/兼容。`
+  return {
+    rootCause,
+    severity: bundle === '' ? 'high' : 'medium',
+    options: baseOptions,
+    recommendation: '建议先尝试方案 A（临时禁用故障插件）进入页面，再逐项排查。',
+    disclaimer: 'AI 辅助建议，仅供参考，最终以你选择为准。',
+  }
+}

--- a/dsh-plugin-desktop/src/diagnostic-evidence.ts
+++ b/dsh-plugin-desktop/src/diagnostic-evidence.ts
@@ -1,0 +1,43 @@
+const CONFIG_FILENAME = /^[A-Za-z0-9._-]+\.(?:json|ya?ml)$/u
+
+export interface DiagnosticEvidenceSource {
+  readonly errorStack?: { readonly text: string }
+  readonly pluginManifest?: { readonly text: string }
+  readonly versions?: { readonly text: string }
+  readonly profileBundles?: { readonly text: string }
+  readonly profileConfig?: { readonly filename: string; readonly text: string }
+  readonly envSnapshot?: { readonly text: string }
+}
+
+export interface DiagnosticEvidenceEntry {
+  readonly name: string
+  readonly content: string
+}
+
+export function buildDiagnosticEvidenceEntries(
+  source: DiagnosticEvidenceSource,
+): readonly DiagnosticEvidenceEntry[] {
+  const entries: DiagnosticEvidenceEntry[] = []
+  if (source.errorStack !== undefined) {
+    entries.push({ name: 'error-stack.txt', content: source.errorStack.text })
+  }
+  if (source.pluginManifest !== undefined) {
+    entries.push({ name: 'plugin-manifest.json', content: source.pluginManifest.text })
+  }
+  if (source.versions !== undefined) {
+    entries.push({ name: 'versions.json', content: source.versions.text })
+  }
+  if (source.profileBundles !== undefined) {
+    entries.push({ name: 'profile-bundles.json', content: source.profileBundles.text })
+  }
+  if (source.profileConfig !== undefined) {
+    if (!CONFIG_FILENAME.test(source.profileConfig.filename)) {
+      throw new Error(`invalid config filename: ${source.profileConfig.filename}`)
+    }
+    entries.push({ name: `config/${source.profileConfig.filename}`, content: source.profileConfig.text })
+  }
+  if (source.envSnapshot !== undefined) {
+    entries.push({ name: 'env-snapshot.txt', content: source.envSnapshot.text })
+  }
+  return entries
+}

--- a/dsh-plugin-desktop/src/diagnostic-export-worker.ts
+++ b/dsh-plugin-desktop/src/diagnostic-export-worker.ts
@@ -18,6 +18,10 @@ import { dirname, isAbsolute, join, relative, resolve, sep } from 'node:path'
 import { isMainThread, parentPort, workerData } from 'node:worker_threads'
 import AdmZip from 'adm-zip'
 import {
+  buildDiagnosticEvidenceEntries,
+  type DiagnosticEvidenceEntry,
+} from './diagnostic-evidence.ts'
+import {
   DESKTOP_LIFECYCLE_EVIDENCE_ENTRY,
   DESKTOP_LIFECYCLE_SUMMARY_ENTRY,
   summarizeDesktopLifecycleEvidence,
@@ -28,7 +32,7 @@ const DIAGNOSTIC_ARCHIVE = /^diagnostics-\d+(?:-[0-9a-f-]+)?\.zip$/u
 const MAX_DIAGNOSTIC_ARCHIVES = 3
 const SKIPPABLE_FILE_ERRORS = new Set(['EACCES', 'EBUSY', 'ELOOP', 'ENOENT', 'ENOTDIR', 'EPERM'])
 
-interface DiagnosticExportWorkerData {
+export interface DiagnosticExportWorkerData {
   readonly logsDir: string
   readonly userDataDir: string
   readonly appVersion: string
@@ -36,6 +40,12 @@ interface DiagnosticExportWorkerData {
   readonly crashDumpsDir?: string
   readonly runStatePath?: string
   readonly lifecycleEvidencePath?: string
+  readonly errorStack?: string
+  readonly pluginManifest?: string
+  readonly versions?: string
+  readonly profileBundles?: string
+  readonly profileConfig?: { readonly filename: string; readonly text: string }
+  readonly envSnapshot?: string
 }
 
 export type DiagnosticExportWorkerResult =
@@ -164,6 +174,20 @@ function regularArchive(path: string): { path: string, modifiedAt: number } | un
   }
 }
 
+/** Map worker evidence data onto diagnostic evidence entries, omitting absent sources. */
+export function buildWorkerEvidenceEntries(
+  data: DiagnosticExportWorkerData,
+): readonly DiagnosticEvidenceEntry[] {
+  return buildDiagnosticEvidenceEntries({
+    ...(data.errorStack === undefined ? {} : { errorStack: { text: data.errorStack } }),
+    ...(data.pluginManifest === undefined ? {} : { pluginManifest: { text: data.pluginManifest } }),
+    ...(data.versions === undefined ? {} : { versions: { text: data.versions } }),
+    ...(data.profileBundles === undefined ? {} : { profileBundles: { text: data.profileBundles } }),
+    ...(data.profileConfig === undefined ? {} : { profileConfig: data.profileConfig }),
+    ...(data.envSnapshot === undefined ? {} : { envSnapshot: { text: data.envSnapshot } }),
+  })
+}
+
 async function createDiagnosticsArchive(data: DiagnosticExportWorkerData): Promise<string> {
   const logsStats = lstatSync(data.logsDir)
   if (logsStats.isSymbolicLink() || !logsStats.isDirectory()) {
@@ -231,6 +255,15 @@ async function createDiagnosticsArchive(data: DiagnosticExportWorkerData): Promi
     if (entry.name.startsWith('crash-dumps/')) includedCrashDumps += 1
     else if (entry.name === 'crash-evidence/active-run.json') includedActiveRunMarker = true
   }
+  for (const entry of buildWorkerEvidenceEntries(data)) {
+    const buf = Buffer.from(entry.content, 'utf8')
+    if (buf.byteLength <= data.maxEvidenceBytes - includedBytes) {
+      zip.addFile(entry.name, buf)
+      includedBytes += buf.byteLength
+    }
+  }
+  // Build the manifest after the worker-evidence budget loop so
+  // included-evidence-bytes reports the true running total.
   const info = [
     'app: dsh-plugin-desktop',
     `desktop-version: ${data.appVersion}`,

--- a/dsh-plugin-desktop/src/diagnostic-export.ts
+++ b/dsh-plugin-desktop/src/diagnostic-export.ts
@@ -23,6 +23,18 @@ export interface DiagnosticExportOptions {
   readonly runStatePath?: string
   /** Current-run lifecycle JSONL written by the Electron launcher. */
   readonly lifecycleEvidencePath?: string
+  /** Crash stack text captured from a failed boot, exported as error-stack.txt. */
+  readonly errorStack?: string
+  /** Installed plugin manifest JSON text, exported as plugin-manifest.json. */
+  readonly pluginManifest?: string
+  /** Upstream and component version JSON text, exported as versions.json. */
+  readonly versions?: string
+  /** Active profile bundle JSON text, exported as profile-bundles.json. */
+  readonly profileBundles?: string
+  /** Active profile config file, exported under config/<filename>. */
+  readonly profileConfig?: { readonly filename: string; readonly text: string }
+  /** Environment snapshot text, exported as env-snapshot.txt. */
+  readonly envSnapshot?: string
   /** Cancels the short-lived worker when its owning UI or process operation ends. */
   readonly signal?: AbortSignal
 }
@@ -33,6 +45,18 @@ export interface DesktopDiagnosticExportOptions {
   readonly crashDumpsDir?: string
   readonly maxEvidenceBytes?: number
   readonly signal?: AbortSignal
+  /** Crash stack text captured from a failed boot, exported as error-stack.txt. */
+  readonly errorStack?: string
+  /** Installed plugin manifest JSON text, exported as plugin-manifest.json. */
+  readonly pluginManifest?: string
+  /** Upstream and component version JSON text, exported as versions.json. */
+  readonly versions?: string
+  /** Active profile bundle JSON text, exported as profile-bundles.json. */
+  readonly profileBundles?: string
+  /** Active profile config file, exported under config/<filename>. */
+  readonly profileConfig?: { readonly filename: string; readonly text: string }
+  /** Environment snapshot text, exported as env-snapshot.txt. */
+  readonly envSnapshot?: string
 }
 
 function workerEntryUrl(): URL {
@@ -113,6 +137,12 @@ export function exportDiagnosticsZip(
       ...(options.crashDumpsDir === undefined ? {} : { crashDumpsDir: options.crashDumpsDir }),
       ...(options.runStatePath === undefined ? {} : { runStatePath: options.runStatePath }),
       ...(options.lifecycleEvidencePath === undefined ? {} : { lifecycleEvidencePath: options.lifecycleEvidencePath }),
+      ...(options.errorStack === undefined ? {} : { errorStack: options.errorStack }),
+      ...(options.pluginManifest === undefined ? {} : { pluginManifest: options.pluginManifest }),
+      ...(options.versions === undefined ? {} : { versions: options.versions }),
+      ...(options.profileBundles === undefined ? {} : { profileBundles: options.profileBundles }),
+      ...(options.profileConfig === undefined ? {} : { profileConfig: options.profileConfig }),
+      ...(options.envSnapshot === undefined ? {} : { envSnapshot: options.envSnapshot }),
     },
     resourceLimits: { maxOldGenerationSizeMb: 256 },
   })
@@ -133,5 +163,11 @@ export function exportDesktopDiagnostics(
     lifecycleEvidencePath: desktopLifecycleEvidencePath(userDataDir),
     ...(options.maxEvidenceBytes === undefined ? {} : { maxEvidenceBytes: options.maxEvidenceBytes }),
     ...(options.signal === undefined ? {} : { signal: options.signal }),
+    ...(options.errorStack === undefined ? {} : { errorStack: options.errorStack }),
+    ...(options.pluginManifest === undefined ? {} : { pluginManifest: options.pluginManifest }),
+    ...(options.versions === undefined ? {} : { versions: options.versions }),
+    ...(options.profileBundles === undefined ? {} : { profileBundles: options.profileBundles }),
+    ...(options.profileConfig === undefined ? {} : { profileConfig: options.profileConfig }),
+    ...(options.envSnapshot === undefined ? {} : { envSnapshot: options.envSnapshot }),
   })
 }

--- a/dsh-plugin-desktop/src/electron-runtime.ts
+++ b/dsh-plugin-desktop/src/electron-runtime.ts
@@ -112,6 +112,7 @@ export class ElectronDesktopRuntime implements DesktopRuntime {
   private updateCleanupTask: Promise<void> | undefined
   private rendererHealthGate: DesktopRendererHealthGate | undefined
   private profileCreateWindow: ProfileCreateWindow | undefined
+  private recoveryActionHandler: ((action: string) => void) | undefined
 
   constructor(
     private readonly restart: () => Promise<void>,
@@ -232,6 +233,9 @@ export class ElectronDesktopRuntime implements DesktopRuntime {
         abortRendererBootMonitoring: cause => { this.rendererHealthGate?.stop(cause) },
         failRendererBoot: error => { this.failRendererBoot('renderer-failed', error) },
         logError: message => { this.logError(message) },
+        ...(this.recoveryActionHandler === undefined
+          ? {}
+          : { handleRecoveryAction: this.recoveryActionHandler }),
       })
       this.generation = generation
       this.mountTask = generation.mount(beforeInteractive).then(() => {
@@ -424,6 +428,11 @@ export class ElectronDesktopRuntime implements DesktopRuntime {
   /** @inheritdoc */
   async requestRestart(): Promise<void> {
     await this.restart()
+  }
+
+  /** Route recovery-bus actions from the active main window to the launcher. */
+  setRecoveryActionHandler(handler: (action: string) => void): void {
+    this.recoveryActionHandler = handler
   }
 
   /** @inheritdoc */

--- a/dsh-plugin-desktop/src/electron-shell-generation.ts
+++ b/dsh-plugin-desktop/src/electron-shell-generation.ts
@@ -13,11 +13,14 @@ import { formatDesktopExitCode } from './desktop-logger.ts'
 import { applicationNeedsReveal, revealApplication } from './electron-reveal.ts'
 import type { ElectronPlatformStrategy } from './electron-platform.ts'
 import type { DesktopNotification, DesktopShellSpec } from './runtime.ts'
+import { parseDesktopStartupRecoveryAction } from './startup-recovery-window.ts'
 import { prepareTrayIcon } from './tray-icons.ts'
 import { desktopWindowOptions } from './window-options.ts'
 
 const MIN_ZOOM_LEVEL = -4
 const MAX_ZOOM_LEVEL = 4
+/** Recovery-bus scheme owned by the launcher; the main-window banner links here. */
+const RECOVERY_SCHEME = 'dsh-recovery:'
 
 function clampedZoomLevel(level: number): number {
   return Math.min(MAX_ZOOM_LEVEL, Math.max(MIN_ZOOM_LEVEL, level))
@@ -42,6 +45,8 @@ export interface ElectronShellGenerationOptions {
   readonly abortRendererBootMonitoring: (cause: unknown) => void
   readonly failRendererBoot: (error: string) => void
   readonly logError: (message: string) => void
+  /** Route a main-window recovery-bus action (for example `restart`) to the launcher. */
+  readonly handleRecoveryAction?: (action: string) => void
 }
 
 /** Own one BrowserWindow and Tray generation, including every native listener. */
@@ -95,8 +100,18 @@ export class ElectronShellGeneration {
       const step = action === 'in' ? 1 : -1
       window.webContents.setZoomLevel(clampedZoomLevel(window.webContents.getZoomLevel() + step))
     }
+    const handleRecoveryScheme = (event: { preventDefault(): void }, url: string): boolean => {
+      if (!url.startsWith(RECOVERY_SCHEME)) return false
+      // The recovery bus runs before the origin guard: its scheme origin never
+      // matches the Web origin, so a raw navigate would otherwise be blocked.
+      event.preventDefault()
+      const action = parseDesktopStartupRecoveryAction(url)
+      if (action !== undefined) this.options.handleRecoveryAction?.(action.action)
+      return true
+    }
     const navigate = (event: Electron.Event<Electron.WebContentsWillFrameNavigateEventParams>): void => {
       if (!event.isMainFrame) return
+      if (handleRecoveryScheme(event, event.url)) return
       let targetOrigin: string | undefined
       try {
         targetOrigin = new URL(event.url).origin
@@ -112,6 +127,7 @@ export class ElectronShellGeneration {
       isMainFrame: boolean,
     ): void => {
       if (!isMainFrame) return
+      if (handleRecoveryScheme(event, url)) return
       let targetOrigin: string | undefined
       try {
         targetOrigin = new URL(url).origin

--- a/dsh-plugin-desktop/src/index.ts
+++ b/dsh-plugin-desktop/src/index.ts
@@ -4,6 +4,7 @@ import { fileURLToPath } from 'node:url'
 import type { Context } from '@deepseek-ai/cordis'
 import z from '@deepseek-ai/schemastery'
 import type {} from '@deepseek-ai/dsh-cmdline'
+import { readDegradedBundles } from './degraded-mode.ts'
 import {
   LOCALE_SETTINGS_NAMESPACE,
   type LocaleSettings,
@@ -98,6 +99,8 @@ export interface Config {
   minWidth: number
   /** Minimum window height in CSS pixels. */
   minHeight: number
+  /** Durable degraded-mode state path; when present the renderer is told which bundles are skipped. */
+  degradedStatePath?: string
 }
 
 /** Validated native window configuration. */
@@ -108,6 +111,7 @@ export const Config: z<Config> = z.object({
   height: z.number().step(1).min(600).default(840),
   minWidth: z.number().step(1).min(640).default(900),
   minHeight: z.number().step(1).min(480).default(640),
+  degradedStatePath: z.string(),
 })
 
 /**
@@ -121,10 +125,12 @@ export function desktopRendererUrl(
   port: number,
   mode: DesktopShellMode,
   platform: Context['desktopRuntime']['platform'],
+  degradedBundles: readonly string[] = [],
 ): string {
   const url = new URL(`http://127.0.0.1:${String(port)}/`)
   url.searchParams.set('dsh-desktop-mode', mode)
   url.searchParams.set('dsh-desktop-platform', platform)
+  if (degradedBundles.length > 0) url.searchParams.set('dsh-degraded', degradedBundles.join(','))
   return url.href
 }
 
@@ -287,10 +293,19 @@ export function apply(ctx: Context, config: Config): void {
     if (namespace !== UI_LOCALE_SETTINGS_NAMESPACE) return
     runtime.setLocalePreference((next as LocaleSettings).preference)
   })
+  let degradedBundles: readonly string[] = []
+  if (config.degradedStatePath !== undefined) {
+    try {
+      degradedBundles = readDegradedBundles(config.degradedStatePath)
+    } catch {
+      // A broken degraded state must not fail the shell; the renderer just sees no marker.
+      degradedBundles = []
+    }
+  }
   ctx.effect(
     () => runtime.schedule({
       ...config,
-      url: desktopRendererUrl(ctx.webServer.port, config.mode, runtime.platform),
+      url: desktopRendererUrl(ctx.webServer.port, config.mode, runtime.platform, degradedBundles),
       productName: 'DSH Desktop',
       windowTitle: 'DeepSeek Harness Desktop',
       iconPath,

--- a/dsh-plugin-desktop/src/main.ts
+++ b/dsh-plugin-desktop/src/main.ts
@@ -32,6 +32,7 @@ import {
   type DesktopRun,
 } from './crash-evidence.ts'
 import { exportDesktopDiagnostics } from './diagnostic-export.ts'
+import { writeDegradedBundles } from './degraded-mode.ts'
 import { createDesktopLifecycleRecorder } from './lifecycle-events.ts'
 import type {
   DesktopLifecycleFailureReason,
@@ -104,6 +105,36 @@ import { desktopLocaleFromLanguageTag } from './tray-locale.ts'
 
 const BIN_NAME = 'dsh-plugin-desktop'
 const PRODUCT_NAME = 'DSH Desktop'
+
+/** Best-effort evidence wired into the recovery window's diagnostics export. */
+interface StartupRecoveryExportEvidence {
+  /** Crash stack captured from the failed boot, exported as error-stack.txt. */
+  readonly errorStack?: string
+}
+
+/** Explicit allowlist of non-secret environment keys included in diagnostics. */
+const DIAGNOSTIC_ENV_SNAPSHOT_KEYS = [
+  'DSH_TELEMETRY_DISABLED',
+  'HOME',
+  'USERPROFILE',
+  'LANG',
+  'LC_ALL',
+  'SHELL',
+  'COMSPEC',
+  'TZ',
+  'NODE_ENV',
+] as const
+
+/** Render a small allowlisted env projection for diagnostics, masking per line. */
+function buildDiagnosticEnvSnapshot(environment: NodeJS.ProcessEnv): string {
+  const lines: string[] = []
+  for (const name of DIAGNOSTIC_ENV_SNAPSHOT_KEYS) {
+    const value = environment[name]
+    if (value === undefined) continue
+    lines.push(`${name}=${maskSecrets(value)}`)
+  }
+  return lines.join('\n')
+}
 
 class RendererStartupFailure extends Error {
   constructor(
@@ -284,6 +315,8 @@ async function start(): Promise<void> {
   let protectedInstallVerificationActive = false
   let startupStage: DesktopStartupFailureStage = 'electron-ready'
   const appVersion = desktopProductVersion()
+  /** Durable degraded-mode state shared by the recovery window and the main window. */
+  const degradedStatePath = join(app.getPath('userData'), 'startup-recovery', 'degraded.json')
   try {
     logSink = new LogFileSink(join(app.getPath('userData'), 'logs'), {
       maxFileBytes: 10 * 1024 * 1024,
@@ -391,6 +424,7 @@ async function start(): Promise<void> {
   const openStartupRecoveryWindow = async (
     failureDetail: string,
     controller: DesktopStartupRecoveryController | undefined,
+    evidence: StartupRecoveryExportEvidence = {},
   ): Promise<'restart' | 'quit' | 'unavailable'> => {
     if (!app.isReady()) return 'unavailable'
     try {
@@ -402,11 +436,31 @@ async function start(): Promise<void> {
         locale: desktopLocaleFromLanguageTag(app.getLocale()),
         failureStage: startupStage,
         failureDetail: maskSecrets(failureDetail),
-        exportDiagnostics: async signal => await exportDesktopDiagnostics(app.getPath('userData'), {
-          appVersion,
-          crashDumpsDir: app.getPath('crashDumps'),
-          signal,
-        }),
+        degradedStatePath,
+        exportDiagnostics: async signal => {
+          let profileBundles: string | undefined
+          if (controller !== undefined) {
+            try {
+              const snapshot = await controller.snapshot()
+              profileBundles = JSON.stringify(snapshot.bundles.map(({ packageName, status, owner, action }) => ({
+                packageName,
+                status,
+                owner,
+                action,
+              })))
+            } catch {
+              // Best-effort: an unreadable bundle snapshot must not fail the export.
+            }
+          }
+          return await exportDesktopDiagnostics(app.getPath('userData'), {
+            appVersion,
+            crashDumpsDir: app.getPath('crashDumps'),
+            signal,
+            ...(evidence.errorStack === undefined ? {} : { errorStack: evidence.errorStack }),
+            ...(profileBundles === undefined ? {} : { profileBundles }),
+            envSnapshot: buildDiagnosticEnvSnapshot(process.env),
+          })
+        },
         ...(recoveryTerminalAvailable ? { openTerminal: () => { runtime.openTerminal() } } : {}),
         ...(startupRecoveryProfileActions === undefined ? {} : { profileActions: startupRecoveryProfileActions }),
         ...(restoreLastKnownGoodProfile === undefined ? {} : { rollbackLastKnownGood: restoreLastKnownGoodProfile }),
@@ -559,6 +613,7 @@ async function start(): Promise<void> {
         generationId,
       }),
       installRecovery,
+      degradedStatePath,
     })
     startupStage = 'install-recovery'
     lifecycleRecorder.transitionStartupStage(startupStage)
@@ -616,7 +671,15 @@ async function start(): Promise<void> {
           }
         },
       },
+      degradedStatePath,
     )
+    // The desktop-shell patch config is the validated channel through which the
+    // plugin receives launcher-owned values; degraded mode rides the same path
+    // so index.ts can inject the `dsh-degraded` marker into the renderer URL.
+    const desktopShellPatch = prepared.patches.find(patch => patch.id === 'desktop-shell')
+    if (desktopShellPatch !== undefined && desktopShellPatch.config !== undefined) {
+      desktopShellPatch.config = { ...desktopShellPatch.config, degradedStatePath }
+    }
     if (profileCheckpoint === undefined) {
       try {
         profileCheckpoint = new DesktopProfileCheckpoint({
@@ -992,6 +1055,20 @@ async function start(): Promise<void> {
         }
       },
     })
+    // The main-window degraded banner's one-click exit routes here: clear the
+    // degraded set, then restart into a full plugin profile. No recovery-window
+    // detour is needed for the already-running degraded case.
+    runtime.setRecoveryActionHandler((action) => {
+      if (action !== 'restart') return
+      try {
+        writeDegradedBundles(degradedStatePath, [])
+      } catch (cause) {
+        electronLogger.error(`${BIN_NAME}: failed to clear degraded state: ${cause instanceof Error ? cause.message : String(cause)}`)
+      }
+      void runtime.requestRestart().catch((restartCause: unknown) => {
+        electronLogger.error(`${BIN_NAME}: failed to restart after degraded recovery: ${restartCause instanceof Error ? restartCause.message : String(restartCause)}`)
+      })
+    })
     const [, rendererVerdict] = await Promise.all([
       runtime.mountScheduled(),
       rendererBoot,
@@ -1099,10 +1176,13 @@ async function start(): Promise<void> {
     }
     if (exitCode !== 0
       && (failureRoute === 'protected-install-recovery' || failureRoute === 'startup-recovery')) {
-      const detail = cause instanceof Error ? cause.message : String(cause)
+      // The JS stack begins with the message, so it doubles as the window's
+      // failureDetail and carries the full stack for AI diagnostics.
+      const errorStack = cause instanceof Error ? (cause.stack ?? cause.message) : String(cause)
       const recoveryResult = await openStartupRecoveryWindow(
-        detail,
+        errorStack,
         failureCommit.recoveryActionsSafe ? startupRecoveryController : undefined,
+        { errorStack },
       )
       if (recoveryResult === 'restart') {
         nativeExit.requestRelaunch()

--- a/dsh-plugin-desktop/src/native-ui/recovery/App.tsx
+++ b/dsh-plugin-desktop/src/native-ui/recovery/App.tsx
@@ -12,7 +12,7 @@ import {
   Terminal,
   Undo2,
 } from 'lucide-react'
-import type { ReactNode } from 'react'
+import { useState, type ReactNode } from 'react'
 import { Alert, AlertDescription, AlertTitle } from '../components/ui/alert.tsx'
 import { buttonVariants } from '../components/ui/button.tsx'
 import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from '../components/ui/card.tsx'
@@ -76,6 +76,39 @@ interface RecoveryProfile {
   readonly selectable: boolean
 }
 
+interface RecoveryAiResult {
+  readonly planId: string
+  readonly status: string
+  readonly message: string
+}
+
+interface RecoveryAiRepairOption {
+  readonly id: 'A' | 'B' | 'C' | 'D'
+  readonly title: string
+  readonly risk: string
+}
+
+interface RecoveryAiDiagnosis {
+  readonly rootCause: string
+  readonly severity: 'low' | 'medium' | 'high'
+  readonly options: readonly RecoveryAiRepairOption[]
+  readonly recommendation: string
+  readonly disclaimer: string
+}
+
+interface RecoveryAiSelfCheck {
+  readonly ok: boolean
+  readonly checks: readonly { readonly name: string; readonly passed: boolean; readonly detail: string }[]
+  readonly recommendation: string
+}
+
+interface RecoveryAiAnalysis {
+  readonly selectedOption?: string
+  readonly result?: RecoveryAiResult
+  readonly diagnosis?: RecoveryAiDiagnosis
+  readonly selfCheck?: RecoveryAiSelfCheck
+}
+
 interface RecoveryState {
   readonly locale: Locale
   readonly failureStage: FailureStage
@@ -93,6 +126,9 @@ interface RecoveryState {
   readonly terminalAvailable?: boolean
   readonly profileCreatorAvailable?: boolean
   readonly rollbackLastKnownGoodAvailable?: boolean
+  readonly aiAnalysis?: RecoveryAiAnalysis
+  /** Bundles left degraded; the window offers to restore them when non-empty. */
+  readonly degradedBundles?: readonly string[]
 }
 
 interface Copy {
@@ -143,6 +179,18 @@ interface Copy {
   readonly confirmRetry: string
   readonly confirmRetryBody: string
   readonly working: string
+  readonly aiAnalysis: string
+  readonly aiLead: string
+  readonly aiLoadDiagnostics: string
+  readonly aiAutoReadGenerated: string
+  readonly aiSelfCheckPassed: string
+  readonly aiSelfCheckFailed: string
+  readonly executeRepair: string
+  readonly repairSelected: string
+  readonly degradedMode: string
+  readonly degradedBody: string
+  readonly restoreFullPlugins: string
+  readonly repairUnavailable: string
 }
 
 const COPY: Record<Locale, Copy> = {
@@ -204,6 +252,18 @@ const COPY: Record<Locale, Copy> = {
     confirmRetry: 'Retry this configuration once?',
     confirmRetryBody: 'The next Desktop generation will verify the current installation once.',
     working: 'Applying the recovery action…',
+    aiAnalysis: 'AI-assisted failure analysis',
+    aiLead: 'Pick one repair plan to apply. AI only suggests and marks risk; it never changes your configuration until you confirm.',
+    aiLoadDiagnostics: 'Load local diagnostics',
+    aiAutoReadGenerated: 'Auto-read generated package',
+    aiSelfCheckPassed: 'Passed',
+    aiSelfCheckFailed: 'Failed',
+    executeRepair: 'Apply repair',
+    repairSelected: 'Repair plan selected',
+    degradedMode: 'Degraded mode',
+    degradedBody: 'Some plugins could not load and DSH Desktop is running in degraded mode. Restore the full plugin set to restart and reload every plugin.',
+    restoreFullPlugins: 'Restore full plugin set',
+    repairUnavailable: 'Not available',
   },
   zh: {
     title: 'DSH Desktop 恢复助手',
@@ -263,6 +323,18 @@ const COPY: Record<Locale, Copy> = {
     confirmRetry: '确认重试当前配置一次？',
     confirmRetryBody: '下一代 Desktop 会使用当前安装状态再验证一次。',
     working: '正在执行恢复操作…',
+    aiAnalysis: 'AI 辅助故障分析',
+    aiLead: '选择一项修复方案后执行。AI 只给出建议与风险提示，未经你确认不会修改任何配置。',
+    aiLoadDiagnostics: '加载本地诊断包',
+    aiAutoReadGenerated: '自动读取已生成包',
+    aiSelfCheckPassed: '通过',
+    aiSelfCheckFailed: '失败',
+    executeRepair: '执行修复',
+    repairSelected: '已选择修复方案',
+    degradedMode: '降级模式',
+    degradedBody: '部分插件未能加载，DSH Desktop 正在降级模式下运行。恢复完整插件集后将重新启动，并重新加载全部插件。',
+    restoreFullPlugins: '恢复完整插件集',
+    repairUnavailable: '暂不可用',
   },
 }
 
@@ -279,23 +351,25 @@ function decodeState(): RecoveryState | undefined {
   return undefined
 }
 
-function href(action: string, id?: string, name?: string): string {
+function href(action: string, id?: string, name?: string, option?: string): string {
   const url = new URL(`${SCHEME}//${action}`)
   if (id !== undefined) url.searchParams.set('id', id)
   if (name !== undefined) url.searchParams.set('name', name)
+  if (option !== undefined) url.searchParams.set('option', option)
   return url.href
 }
 
-function Action({ action, children, className, icon, id, name, variant = 'outline' }: {
+function Action({ action, children, className, icon, id, name, option, variant = 'outline' }: {
   readonly action: string
   readonly children: ReactNode
   readonly className?: string
   readonly icon?: ReactNode
   readonly id?: string
   readonly name?: string
+  readonly option?: string
   readonly variant?: 'default' | 'outline' | 'secondary' | 'destructive'
 }): JSX.Element {
-  return <a className={cn(buttonVariants({ variant }), className)} href={href(action, id, name)}>{icon}{children}</a>
+  return <a className={cn(buttonVariants({ variant }), className)} href={href(action, id, name, option)}>{icon}{children}</a>
 }
 
 function Owner({ owner, copy }: { readonly owner: RecoveryBundle['owner']; readonly copy: Copy }): JSX.Element {
@@ -324,10 +398,73 @@ function Confirmation({ confirmation, copy }: { readonly confirmation: RecoveryC
   </Card>
 }
 
+/** Static repair plans offered to the user. AI enriches these with root cause and risk. */
+const REPAIR_PLAN_OPTIONS: Record<Locale, readonly { readonly id: string; readonly title: string; readonly risk: string; readonly disabled: boolean }[]> = {
+  en: [
+    { id: 'A', title: 'Temporarily disable the failing plugin', risk: 'Low risk — only that plugin stops loading.', disabled: false },
+    { id: 'B', title: 'Roll back the submodule version', risk: 'High risk (developers) — changes the upstream submodule pin.', disabled: true },
+    { id: 'C', title: 'Reset the plugin manifest', risk: 'Medium risk — may drop custom plugin combinations.', disabled: true },
+    { id: 'D', title: 'Restore the default config', risk: 'Low–medium risk — restores the last healthy profile snapshot.', disabled: false },
+  ],
+  zh: [
+    { id: 'A', title: '临时禁用故障插件', risk: '低风险 —— 仅该插件不再加载。', disabled: false },
+    { id: 'B', title: '回滚子模块版本', risk: '高风险（仅开发者） —— 会改动上游子模块版本锁定。', disabled: true },
+    { id: 'C', title: '重置插件加载清单', risk: '中风险 —— 可能丢失自定义插件组合。', disabled: true },
+    { id: 'D', title: '恢复默认配置', risk: '低~中风险 —— 恢复上次健康配置快照。', disabled: false },
+  ],
+}
+
+function AiAnalysis({ state, copy }: { readonly state: RecoveryState; readonly copy: Copy }): JSX.Element {
+  const analysis = state.aiAnalysis ?? {}
+  const plans = REPAIR_PLAN_OPTIONS[state.locale]
+  const [selected, setSelected] = useState(analysis.selectedOption ?? plans[0]?.id ?? '')
+  const diagnosis = analysis.diagnosis
+  const selfCheck = analysis.selfCheck
+  const result = analysis.result
+  const severityTone = diagnosis?.severity === 'high' ? 'destructive' : diagnosis?.severity === 'medium' ? 'outline' : 'secondary'
+  return <Card>
+    <CardHeader><CardTitle>{copy.aiAnalysis}</CardTitle><CardDescription>{copy.aiLead}</CardDescription></CardHeader>
+    <CardContent className="space-y-3">
+      <div className="flex flex-wrap gap-2">
+        <Action action="ai-analyze" icon={<RefreshCw />}>{copy.aiLoadDiagnostics}</Action>
+        <Action action="ai-analyze" icon={<RefreshCw />}>{copy.aiAutoReadGenerated}</Action>
+      </div>
+      {diagnosis === undefined ? null : <div className="space-y-2">
+        <p className="text-sm font-medium">{diagnosis.rootCause}</p>
+        <span className={cn('rounded-full px-2 py-1 text-xs', severityTone === 'destructive' && 'bg-destructive/10 text-destructive', severityTone === 'secondary' && 'bg-muted')}>{diagnosis.severity}</span>
+        <p className="text-sm text-muted-foreground">{diagnosis.recommendation}</p>
+        <p className="text-xs text-muted-foreground">{diagnosis.disclaimer}</p>
+      </div>}
+      {selfCheck === undefined ? null : <div className="space-y-2">
+        <p className="text-sm text-muted-foreground">{selfCheck.recommendation}</p>
+        {selfCheck.checks.length === 0 ? null : <div className="divide-y">
+          {selfCheck.checks.map(check => <div className="flex items-center justify-between gap-4 py-2" key={check.name}>
+            <code className="text-xs">{check.name}</code>
+            <div className="flex items-center gap-2"><span className={cn('rounded-full px-2 py-1 text-xs', check.passed ? 'bg-emerald-500/10 text-emerald-600' : 'bg-destructive/10 text-destructive')}>{check.passed ? copy.aiSelfCheckPassed : copy.aiSelfCheckFailed}</span><span className="text-xs text-muted-foreground">{check.detail}</span></div>
+          </div>)}
+        </div>}
+        {selfCheck.ok ? <div className="flex justify-end"><Action action="restart" variant="default">{copy.restart}</Action></div> : null}
+      </div>}
+    </CardContent>
+    <CardContent className="divide-y p-0">
+      {plans.map(plan => <div className="flex items-center gap-3 px-6 py-3" key={plan.id}>
+        <input type="radio" name="repair-option" value={plan.id} checked={selected === plan.id} disabled={plan.disabled} onChange={() => setSelected(plan.id)} aria-label={plan.title} />
+        <div className="min-w-0"><p className={cn('text-sm font-medium', plan.disabled && 'text-muted-foreground')}>{plan.title}</p><p className="text-xs text-muted-foreground">{plan.risk}</p>{plan.disabled ? <p className="text-xs text-muted-foreground">{copy.repairUnavailable}</p> : null}</div>
+      </div>)}
+    </CardContent>
+    <CardFooter className="justify-end pt-6"><Action action="execute-repair" option={selected} variant="default">{copy.executeRepair}</Action></CardFooter>
+    {result === undefined ? null : <CardContent className="border-t"><Alert className="border-blue-500/50"><AlertTriangle /><AlertTitle>{copy.repairSelected}</AlertTitle><AlertDescription>{result.message}</AlertDescription></Alert></CardContent>}
+  </Card>
+}
+
 function RecoveryContent({ state, copy }: { readonly state: RecoveryState; readonly copy: Copy }): JSX.Element {
   const pending = state.snapshot?.pendingInstall
   if (state.confirmation !== undefined) return <Confirmation confirmation={state.confirmation} copy={copy} />
   return <>
+    {(state.degradedBundles?.length ?? 0) === 0 ? null : <Card className="border-amber-500/60">
+      <CardHeader><CardTitle>{copy.degradedMode}</CardTitle><CardDescription>{copy.degradedBody}</CardDescription></CardHeader>
+      <CardFooter className="justify-end pt-6"><Action action="restore-full-plugins" icon={<RefreshCw />} variant="default">{copy.restoreFullPlugins}</Action></CardFooter>
+    </Card>}
     {pending === undefined ? null : <Card>
       <CardHeader><CardTitle>{copy.recentInstall}</CardTitle><CardDescription>{pending.packageName}@{pending.packageVersion}</CardDescription></CardHeader>
       <CardContent className="space-y-2"><p className="text-sm text-muted-foreground">{copy.rollbackBody}</p>{pending.retryAvailable ? <p className="text-sm text-muted-foreground">{copy.retryBody}</p> : null}</CardContent>
@@ -377,6 +514,8 @@ function RecoveryContent({ state, copy }: { readonly state: RecoveryState; reado
         {state.rollbackLastKnownGoodAvailable && state.profileActionToken !== undefined ? <Action action="rollback-last-known-good" icon={<RotateCcw />} id={state.profileActionToken} variant="default">{copy.restoreLastSuccessful}</Action> : null}
       </CardFooter>
     </Card>
+
+    <AiAnalysis copy={copy} state={state} />
   </>
 }
 

--- a/dsh-plugin-desktop/src/profile.ts
+++ b/dsh-plugin-desktop/src/profile.ts
@@ -41,6 +41,7 @@ import {
   type DesktopMarketProvider,
   type DesktopMarketSnapshot,
 } from './desktop-market.ts'
+import { readDegradedBundles } from './degraded-mode.ts'
 
 /** Persistent profile managed by the desktop launcher and the ordinary dsh plugin command. */
 export const DESKTOP_PROFILE_NAME = 'desktop'
@@ -78,7 +79,7 @@ const DESKTOP_SETTINGS_NAMESPACE = 'dsh-desktop'
 const UI_LAYOUT_PACKAGE = '@deepseek-ai/dsh-client-ui-layout'
 const UI_SIDEBAR_PACKAGE = '@deepseek-ai/dsh-client-ui-sidebar'
 const UI_CONVERSATION_PACKAGE = '@deepseek-ai/dsh-client-ui-conversation'
-const DEFAULT_DESKTOP_MARKET_SNAPSHOT: DesktopMarketSnapshot = Object.freeze({
+export const DEFAULT_DESKTOP_MARKET_SNAPSHOT: DesktopMarketSnapshot = Object.freeze({
   requested: 'disabled',
   effective: 'disabled',
   legacyDefaulted: true,
@@ -579,6 +580,7 @@ export function prepareDesktopProfile(
   marketSelection: DesktopMarketSnapshot = DEFAULT_DESKTOP_MARKET_SNAPSHOT,
   recoveryStatePath?: string,
   hooks: DesktopProfilePreparationHooks = {},
+  degradedStatePath?: string,
 ): PreparedDesktopProfile {
   const profileDir = profileName === DESKTOP_PROFILE_NAME
     ? ensureDesktopProfile(home)
@@ -597,11 +599,15 @@ export function prepareDesktopProfile(
       ? new Set<string>()
       : new Set(managedDisabledBundles))
     : readDesktopDisabledBundles(recoveryStatePath, profileName)
+  const degradedBundles = degradedStatePath === undefined
+    ? new Set<string>()
+    : new Set(readDegradedBundles(degradedStatePath))
   const disabledBundles = new Set(recoveryDisabledBundles)
   if (recoveryStatePath === undefined
     || marketSelection.requested === DESKTOP_MARKET_IDENTITIES.community.provider) {
     for (const packageName of managedDisabledBundles) disabledBundles.add(packageName)
   }
+  for (const packageName of degradedBundles) disabledBundles.add(packageName)
   const loadedProfile = loadRecoveryFilteredProfile(
     profileName,
     profileDir,

--- a/dsh-plugin-desktop/src/repair-plans.ts
+++ b/dsh-plugin-desktop/src/repair-plans.ts
@@ -1,0 +1,61 @@
+// src/repair-plans.ts
+import type { DesktopStartupRecoveryRepairPlanId } from './startup-recovery-controller.ts'
+import type { RestoreResult } from './profile-checkpoint.ts'
+import { writeDegradedBundles } from './degraded-mode.ts'
+
+export interface DesktopRepairOutcome {
+  readonly status: 'acknowledged' | 'degraded' | 'restored' | 'already-attempted'
+  readonly message: string
+}
+export interface RepairPlanDependencies {
+  readonly degradedStatePath: string | undefined
+  /** Analysis-identified faulting bundle threaded into plan A's degraded commit. */
+  readonly degradedBundle: readonly string[]
+  readonly restoreLatest: () => Promise<RestoreResult>
+}
+export interface DesktopRepairPlan {
+  readonly id: DesktopStartupRecoveryRepairPlanId
+  readonly title: string
+  readonly description: string
+  readonly risk: { readonly severity: 'low' | 'medium' | 'high'; readonly notes: string }
+  readonly audience: 'end-user' | 'developer' | 'both'
+  readonly apply: () => Promise<DesktopRepairOutcome>
+}
+
+export function repairPlans(deps: RepairPlanDependencies): ReadonlyArray<DesktopRepairPlan> {
+  return [
+    { id: 'A', title: '临时禁用故障插件',
+      description: '把故障插件加入降级集合，重启后跳过它进入主页面。',
+      risk: { severity: 'low', notes: '仅该插件不再加载，基础聊天/WebUI 可用。' },
+      audience: 'both',
+      apply: async () => {
+        if (deps.degradedStatePath === undefined || deps.degradedStatePath.length === 0) {
+          throw new Error('degraded state path is required for plan A')
+        }
+        writeDegradedBundles(deps.degradedStatePath, deps.degradedBundle)
+        return { status: 'degraded', message: '已启用降级模式。请重新启动 Desktop。' }
+      } },
+    { id: 'B', title: '回滚子模块版本',
+      description: '把上游子模块 pin 回退到上一有效 commit。',
+      risk: { severity: 'high', notes: '违反"不编辑子模块"纪律，需显式告警。' },
+      audience: 'developer',
+      apply: async () => ({ status: 'acknowledged', message: '方案 B 需开发者二次确认，暂不自动执行。' }) },
+    { id: 'C', title: '重置插件加载清单',
+      description: '把 profile bundle 组合改写为默认/上次健康集。',
+      risk: { severity: 'medium', notes: '可能丢失自定义插件组合。' },
+      audience: 'both',
+      apply: async () => ({ status: 'acknowledged', message: '方案 C 需默认健康集，暂不自动执行。' }) },
+    { id: 'D', title: '恢复默认配置',
+      description: '恢复上次健康配置快照。',
+      risk: { severity: 'low', notes: '恢复上次健康快照。' },
+      audience: 'both',
+      apply: async () => {
+        const result = await deps.restoreLatest()
+        const changed = result.changedFiles.join(', ')
+        return {
+          status: result.status,
+          message: changed === '' ? '已恢复上次健康快照。' : `已恢复上次健康快照（${changed}）。`,
+        }
+      } },
+  ]
+}

--- a/dsh-plugin-desktop/src/repair-self-check.ts
+++ b/dsh-plugin-desktop/src/repair-self-check.ts
@@ -1,0 +1,27 @@
+// src/repair-self-check.ts
+export interface RepairSelfCheckItem {
+  readonly name: string
+  readonly run: () => Promise<{ readonly ok: boolean; readonly detail: string }>
+}
+export interface RepairSelfCheckReport {
+  readonly ok: boolean
+  readonly checks: readonly { readonly name: string; readonly passed: boolean; readonly detail: string }[]
+  readonly recommendation: string
+}
+
+export async function runRepairSelfCheck(
+  items: readonly RepairSelfCheckItem[],
+): Promise<RepairSelfCheckReport> {
+  const checks = await Promise.all(items.map(async item => {
+    const result = await item.run()
+    return { name: item.name, passed: result.ok, detail: result.detail }
+  }))
+  const ok = checks.every(check => check.passed)
+  return {
+    ok,
+    checks,
+    recommendation: ok
+      ? '✅ 修复成功，点击【重新启动 DSH Desktop】生效。'
+      : '❌ 修复失败，请尝试其他方案。',
+  }
+}

--- a/dsh-plugin-desktop/src/startup-recovery-controller.ts
+++ b/dsh-plugin-desktop/src/startup-recovery-controller.ts
@@ -1,7 +1,16 @@
 /** Pre-Host recovery-window authority over one immutable Desktop generation. */
 
 import { randomBytes } from 'node:crypto'
+import { createRequire } from 'node:module'
 import { isAbsolute } from 'node:path'
+import { writeDegradedBundles } from './degraded-mode.ts'
+import type { RestoreResult } from './profile-checkpoint.ts'
+import { repairPlans, type DesktopRepairPlan } from './repair-plans.ts'
+import {
+  runRepairSelfCheck,
+  type RepairSelfCheckItem,
+  type RepairSelfCheckReport,
+} from './repair-self-check.ts'
 import {
   DesktopPluginsError,
   disableDesktopProfileBundle,
@@ -15,7 +24,10 @@ import type {
   DesktopInstallRecoveryRestoreResult,
   DesktopInstallRecoveryTransaction,
 } from './install-recovery.ts'
+import { analyzeDiagnostics } from './diagnostic-analyzer.ts'
+import { runTierOneAnalysis } from './ai-diagnostic-analyzer.ts'
 import { assertDesktopProfileName } from './profile-manager.ts'
+import type { DesktopStartupRecoveryAiAnalysis } from './startup-recovery-window.ts'
 
 const BIN_NAME = 'dsh-plugin-desktop'
 const PREVIEW_TTL_MS = 5 * 60 * 1000
@@ -27,6 +39,19 @@ const ROLLBACK_PREVIEW_ID_PATTERN = /^rollback_[A-Za-z0-9_-]{43}$/u
 const RETRY_PREVIEW_ID_PATTERN = /^retry_[A-Za-z0-9_-]{43}$/u
 const OPAQUE_ID_PATTERN = /^[A-Za-z0-9._:-]{8,160}$/u
 const PACKAGE_NAME_PATTERN = /^(?:@[a-z0-9][a-z0-9._-]*\/)?[a-z0-9][a-z0-9._-]*$/u
+const REPAIR_PLAN_IDS = new Set(['A', 'B', 'C', 'D'])
+
+/** Repair plan identifiers offered by the native recovery window. */
+export type DesktopStartupRecoveryRepairPlanId = 'A' | 'B' | 'C' | 'D'
+
+/** Renderer-safe result of a user-approved repair plan. */
+export interface DesktopStartupRecoveryRepairResult {
+  readonly planId: DesktopStartupRecoveryRepairPlanId
+  readonly status: 'acknowledged' | 'degraded' | 'restored' | 'already-attempted'
+  readonly message: string
+  /** Read-only post-repair verification report, always present. */
+  readonly selfCheck: RepairSelfCheckReport
+}
 
 /** Fixed launcher identity checked before every read and again before mutation. */
 export interface DesktopStartupRecoveryGeneration {
@@ -143,8 +168,20 @@ export interface DesktopStartupRecoveryControllerOptions {
   readonly managedPackageNames?: () => readonly string[] | Promise<readonly string[]>
   /** Recovery WAL already bound by its store to the active profile directory. */
   readonly installRecovery: DesktopStartupRecoveryJournalReader
+  /**
+   * Durable degraded-mode state path committed by plan A. Optional until the
+   * main process wires it at the recovery-window close loop; absent here means
+   * degraded commits fail closed as state-unavailable.
+   */
+  readonly degradedStatePath?: string
   /** Injectable clock used only by focused headless tests. */
   readonly now?: () => number
+  /** Launcher-provided failure stack analyzed by the offline AI diagnosis. */
+  readonly failureStack?: string
+  /** Restore the latest healthy snapshot for plan D; absent means plan D fails closed. */
+  readonly restoreLatest?: () => Promise<RestoreResult>
+  /** Injectable read-only self-check probes; defaults to a module-resolution probe. */
+  readonly selfCheckItems?: () => Promise<ReadonlyArray<RepairSelfCheckItem>>
 }
 
 interface DisablePreviewRecord {
@@ -223,6 +260,7 @@ export class DesktopStartupRecoveryController {
   private readonly installPreviews = new Map<string, InstallPreviewRecord>()
   private operationActive = false
   private disposed = false
+  private readonly aiAbort = new AbortController()
 
   constructor(private readonly options: DesktopStartupRecoveryControllerOptions) {
     assertDesktopProfileName(options.pluginState.profileName)
@@ -410,9 +448,71 @@ export class DesktopStartupRecoveryController {
     }
   }
 
+  /** Persist the degraded bundle set atomically and return the committed image. */
+  async commitDegraded(bundles: readonly string[]): Promise<{ readonly bundles: readonly string[] }> {
+    this.assertCurrentGeneration()
+    if (!Array.isArray(bundles) || bundles.some(item => typeof item !== 'string')) throw this.invalidTarget()
+    const degradedStatePath = this.options.degradedStatePath
+    if (degradedStatePath === undefined) {
+      throw new DesktopStartupRecoveryControllerError(
+        'state-unavailable',
+        'Desktop degraded state is unavailable.',
+      )
+    }
+    writeDegradedBundles(degradedStatePath, bundles)
+    return { bundles }
+  }
+
+  /** Enforce one user-approved repair plan id for the active generation. */
+  async executeRepair(planId: string): Promise<DesktopStartupRecoveryRepairResult> {
+    this.assertCurrentGeneration()
+    if (!REPAIR_PLAN_IDS.has(planId as DesktopStartupRecoveryRepairPlanId)) throw this.invalidTarget()
+    if (this.operationActive) {
+      throw new DesktopStartupRecoveryControllerError(
+        'operation-in-progress',
+        'Another Desktop recovery operation is already running.',
+      )
+    }
+    this.operationActive = true
+    try {
+      const degradedStatePath = this.options.degradedStatePath
+      if (planId === 'A' && degradedStatePath === undefined) {
+        throw new DesktopStartupRecoveryControllerError(
+          'state-unavailable',
+          'Degraded state is unavailable; plan A cannot be committed.',
+        )
+      }
+      const plan = this.buildRepairPlans(degradedStatePath).find(p => p.id === planId)
+      if (plan === undefined) throw this.invalidTarget()
+      const outcome = await plan.apply()
+      const selfCheck = await this.runSelfCheck()
+      return {
+        planId: planId as DesktopStartupRecoveryRepairPlanId,
+        status: outcome.status,
+        message: outcome.message,
+        selfCheck,
+      }
+    } finally {
+      this.operationActive = false
+    }
+  }
+
+  /**
+   * Run the offline AI analysis over the launcher-provided failure stack.
+   * Read-only; the recovery window single-flights this via its busy overlay.
+   */
+  async runAiAnalysis(): Promise<DesktopStartupRecoveryAiAnalysis> {
+    this.assertCurrentGeneration()
+    const input = this.lastFailureStack()
+    const tier1 = await runTierOneAnalysis(input, this.aiAbort.signal)
+    const diagnosis = tier1 ?? analyzeDiagnostics(input)
+    return { diagnosis }
+  }
+
   /** Invalidate every generation-local target and confirmation. */
   dispose(): void {
     this.disposed = true
+    this.aiAbort.abort()
     this.packageBundleIds.clear()
     this.bundlePackages.clear()
     this.disablePreviews.clear()
@@ -547,6 +647,50 @@ export class DesktopStartupRecoveryController {
       // Market must never prevent a direct mutable bundle from being disabled.
       return new Set()
     }
+  }
+
+  /**
+   * Identify the faulting bundle from the launcher-provided failure stack so
+   * plan A degrades exactly that bundle instead of silently clearing the set.
+   */
+  private targetDegradedBundle(): readonly string[] {
+    const match = /Cannot find module ['"]([^'"]+)['"]/u.exec(this.lastFailureStack())
+    return match === null ? [] : [match[1]!]
+  }
+
+  private lastFailureStack(): string {
+    return this.options.failureStack ?? ''
+  }
+
+  private buildRepairPlans(degradedStatePath: string | undefined): ReadonlyArray<DesktopRepairPlan> {
+    return repairPlans({
+      degradedStatePath,
+      degradedBundle: this.targetDegradedBundle(),
+      restoreLatest: this.options.restoreLatest ?? (async () => { throw new Error('restore not configured') }),
+    })
+  }
+
+  /** Run the injected or default read-only post-repair self-check probes. */
+  private async runSelfCheck(): Promise<RepairSelfCheckReport> {
+    const items = this.options.selfCheckItems ?? this.defaultSelfCheckItems.bind(this)
+    return runRepairSelfCheck(await items())
+  }
+
+  /** Default probe: resolve the analysis-identified bundle; an empty target passes. */
+  private defaultSelfCheckItems(): ReadonlyArray<RepairSelfCheckItem> {
+    return [{
+      name: 'degraded bundle resolvable',
+      run: async () => {
+        const target = this.targetDegradedBundle()[0] ?? ''
+        if (target === '') return { ok: true, detail: 'no degraded bundle to resolve' }
+        try {
+          createRequire(import.meta.url).resolve(target)
+          return { ok: true, detail: `resolved ${target}` }
+        } catch (cause) {
+          return { ok: false, detail: cause instanceof Error ? cause.message : String(cause) }
+        }
+      },
+    }]
   }
 
   private assertCurrentGeneration(): void {

--- a/dsh-plugin-desktop/src/startup-recovery-window.ts
+++ b/dsh-plugin-desktop/src/startup-recovery-window.ts
@@ -6,6 +6,9 @@ import { mkdir, writeFile } from 'node:fs/promises'
 import { basename, dirname } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import type { DesktopLocale } from './runtime.ts'
+import { readDegradedBundles, writeDegradedBundles } from './degraded-mode.ts'
+import type { AiDiagnosis } from './diagnostic-analyzer.ts'
+import type { RepairSelfCheckReport } from './repair-self-check.ts'
 import { applicationNeedsReveal, revealApplication } from './electron-reveal.ts'
 import {
   DesktopStartupRecoveryController,
@@ -16,12 +19,14 @@ import {
 
 const RECOVERY_SCHEME = 'dsh-recovery:'
 const RECOVERY_DOCUMENT = fileURLToPath(new URL('./native-ui/recovery.html', import.meta.url))
-const MAX_FAILURE_DETAIL_LENGTH = 4_000
+const MAX_FAILURE_DETAIL_LENGTH = 16_000
 const DEFAULT_RECOVERY_WIDTH = 800
 const DEFAULT_RECOVERY_HEIGHT = 760
 const DEFAULT_RECOVERY_MIN_WIDTH = 680
 const DEFAULT_RECOVERY_MIN_HEIGHT = 560
 const RECOVERY_WORK_AREA_INSET = 48
+/** Safe token for the user-chosen repair plan carried in the no-script action bus. */
+const REPAIR_OPTION_PATTERN = /^[A-Za-z0-9_-]{1,32}$/u
 
 type RecoveryWindowResult = 'restart' | 'quit'
 type RecoveryNoticeTone = 'info' | 'success' | 'warning' | 'error'
@@ -53,6 +58,21 @@ interface RecoveryDiagnosticsState {
   readonly filename?: string
 }
 
+/** Player-visible result of a user-approved repair plan in this generation. */
+export interface DesktopStartupRecoveryAiResult {
+  readonly planId: string
+  readonly status: string
+  readonly message: string
+}
+
+/** Selection + result state for the AI-assisted repair area. */
+export interface DesktopStartupRecoveryAiAnalysis {
+  readonly selectedOption?: string
+  readonly result?: DesktopStartupRecoveryAiResult
+  readonly diagnosis?: AiDiagnosis
+  readonly selfCheck?: RepairSelfCheckReport
+}
+
 export interface DesktopStartupRecoveryWindowOptions {
   readonly controller?: DesktopStartupRecoveryController
   /** Fixed active-profile paths selected by the main process. */
@@ -67,6 +87,8 @@ export interface DesktopStartupRecoveryWindowOptions {
   readonly profileActions?: DesktopStartupRecoveryProfileActions
   /** Restore the last healthy Profile and its declarative checkpoint. */
   readonly rollbackLastKnownGood?: (token: string) => void | Promise<void>
+  /** Durable degraded-mode state path read at open; absent means no degraded card. */
+  readonly degradedStatePath?: string
 }
 
 export interface DesktopStartupRecoveryProfile {
@@ -173,6 +195,9 @@ export interface DesktopStartupRecoveryViewModel {
   readonly terminalAvailable?: boolean
   readonly profileCreatorAvailable?: boolean
   readonly rollbackLastKnownGoodAvailable?: boolean
+  readonly aiAnalysis: DesktopStartupRecoveryAiAnalysis
+  /** Bundles left degraded; the window offers to restore them when non-empty. */
+  readonly degradedBundles?: readonly string[]
 }
 
 interface RecoveryCopy {
@@ -223,6 +248,19 @@ interface RecoveryCopy {
   readonly openProfilePatch: string
   readonly openProfileManifest: string
   readonly openProfileDirectory: string
+  readonly aiAnalysis: string
+  readonly aiLead: string
+  readonly aiRunAnalysis: string
+  readonly aiLoadDiagnostics: string
+  readonly aiAutoReadGenerated: string
+  readonly aiSelfCheckPassed: string
+  readonly aiSelfCheckFailed: string
+  readonly executeRepair: string
+  readonly repairSelected: string
+  readonly degradedMode: string
+  readonly degradedBody: string
+  readonly restoreFullPlugins: string
+  readonly repairUnavailable: string
 }
 
 const COPY: Record<DesktopLocale, RecoveryCopy> = {
@@ -284,6 +322,19 @@ const COPY: Record<DesktopLocale, RecoveryCopy> = {
     openProfilePatch: 'Edit configuration patch',
     openProfileManifest: 'Edit plugin manifest',
     openProfileDirectory: 'Open configuration folder',
+    aiAnalysis: 'AI-assisted failure analysis',
+    aiLead: 'Pick one repair plan to apply. AI only suggests and marks risk; it never changes your configuration until you confirm.',
+    aiRunAnalysis: 'Run AI failure analysis',
+    aiLoadDiagnostics: 'Load local diagnostics package',
+    aiAutoReadGenerated: 'Auto-read generated package',
+    aiSelfCheckPassed: 'Passed',
+    aiSelfCheckFailed: 'Failed',
+    executeRepair: 'Apply repair',
+    repairSelected: 'Repair plan selected',
+    degradedMode: 'Degraded mode',
+    degradedBody: 'Some plugins could not load and DSH Desktop is running in degraded mode. Restore the full plugin set to restart and reload every plugin.',
+    restoreFullPlugins: 'Restore full plugin set',
+    repairUnavailable: 'Not available',
   },
   zh: {
     title: 'DSH Desktop 恢复',
@@ -343,7 +394,41 @@ const COPY: Record<DesktopLocale, RecoveryCopy> = {
     openProfilePatch: '编辑配置补丁',
     openProfileManifest: '编辑插件加载清单',
     openProfileDirectory: '打开配置目录',
+    aiAnalysis: 'AI 辅助故障分析',
+    aiLead: '选择一项修复方案后执行。AI 只给出建议与风险提示，未经你确认不会修改任何配置。',
+    aiRunAnalysis: '运行 AI 故障分析',
+    aiLoadDiagnostics: '加载本地诊断包',
+    aiAutoReadGenerated: '自动读取已生成包',
+    aiSelfCheckPassed: '通过',
+    aiSelfCheckFailed: '失败',
+    executeRepair: '执行修复',
+    repairSelected: '已选择修复方案',
+    degradedMode: '降级模式',
+    degradedBody: '部分插件未能加载，DSH Desktop 正在降级模式下运行。恢复完整插件集后将重新启动，并重新加载全部插件。',
+    restoreFullPlugins: '恢复完整插件集',
+    repairUnavailable: '暂不可用',
   },
+}
+
+/** Static repair plans offered to the user. AI enriches these with root cause and risk. */
+const REPAIR_PLAN_OPTIONS: Record<DesktopLocale, ReadonlyArray<{
+  readonly id: string
+  readonly title: string
+  readonly risk: string
+  readonly disabled: boolean
+}>> = {
+  en: [
+    { id: 'A', title: 'Temporarily disable the failing plugin', risk: 'Low risk — only that plugin stops loading.', disabled: false },
+    { id: 'B', title: 'Roll back the submodule version', risk: 'High risk (developers) — changes the upstream submodule pin.', disabled: true },
+    { id: 'C', title: 'Reset the plugin manifest', risk: 'Medium risk — may drop custom plugin combinations.', disabled: true },
+    { id: 'D', title: 'Restore the default config', risk: 'Low–medium risk — restores the last healthy profile snapshot.', disabled: false },
+  ],
+  zh: [
+    { id: 'A', title: '临时禁用故障插件', risk: '低风险 —— 仅该插件不再加载。', disabled: false },
+    { id: 'B', title: '回滚子模块版本', risk: '高风险（仅开发者） —— 会改动上游子模块版本锁定。', disabled: true },
+    { id: 'C', title: '重置插件加载清单', risk: '中风险 —— 可能丢失自定义插件组合。', disabled: true },
+    { id: 'D', title: '恢复默认配置', risk: '低~中风险 —— 恢复上次健康配置快照。', disabled: false },
+  ],
 }
 
 function escapeHtml(value: string): string {
@@ -385,6 +470,31 @@ function confirmationHtml(model: DesktopStartupRecoveryViewModel, copy: Recovery
   }
   const rollback = confirmation.kind === 'rollback'
   return `<section class="card confirmation"><h2>${escapeHtml(rollback ? copy.confirmRollback : copy.confirmRetry)}</h2><p><code>${escapeHtml(confirmation.preview.packageName)}@${escapeHtml(confirmation.preview.packageVersion)}</code></p><p>${escapeHtml(rollback ? copy.confirmRollbackBody : copy.confirmRetryBody)}</p><div class="actions">${button(copy.cancel, 'home')}${button(rollback ? copy.rollback : copy.retry, rollback ? 'confirm-rollback' : 'confirm-retry', confirmation.preview.previewId, true)}</div></section>`
+}
+
+/** Repair options rendered as a no-script radio form that submits to the action bus. */
+function aiAnalysisHtml(model: DesktopStartupRecoveryViewModel, copy: RecoveryCopy): string {
+  const plans = REPAIR_PLAN_OPTIONS[model.locale]
+  const selected = model.aiAnalysis.selectedOption ?? plans[0]?.id ?? ''
+  const rows = plans.map(plan =>
+    `<label class="plan-option"><input type="radio" name="option" value="${escapeHtml(plan.id)}"${plan.id === selected && !plan.disabled ? ' checked' : ''}${plan.disabled ? ' disabled' : ''}><span><strong>${escapeHtml(plan.title)}</strong><span class="muted">${escapeHtml(plan.risk)}</span>${plan.disabled ? `<span class="muted">${escapeHtml(copy.repairUnavailable)}</span>` : ''}</span></label>`,
+  ).join('')
+  const diagnosis = model.aiAnalysis.diagnosis
+  const diagnosisHtml = diagnosis === undefined
+    ? ''
+    : `<p><strong>${escapeHtml(diagnosis.rootCause)}</strong></p><p><span class="pill">${escapeHtml(diagnosis.severity)}</span></p><p>${escapeHtml(diagnosis.recommendation)}</p><p class="muted">${escapeHtml(diagnosis.disclaimer)}</p>`
+  const selfCheck = model.aiAnalysis.selfCheck
+  const selfCheckRows = selfCheck?.checks.map(check =>
+    `<li><code>${escapeHtml(check.name)}</code><span class="pill">${escapeHtml(check.passed ? copy.aiSelfCheckPassed : copy.aiSelfCheckFailed)}</span><span class="muted">${escapeHtml(check.detail)}</span></li>`,
+  ).join('') ?? ''
+  const selfCheckHtml = selfCheck === undefined
+    ? ''
+    : `<p>${escapeHtml(selfCheck.recommendation)}</p>${selfCheckRows.length === 0 ? '' : `<ul>${selfCheckRows}</ul>`}`
+  const restartCta = selfCheck?.ok === true ? button(copy.restart, 'restart', undefined, true) : ''
+  const result = model.aiAnalysis.result === undefined
+    ? ''
+    : noticeHtml({ tone: 'info', title: copy.repairSelected, body: model.aiAnalysis.result.message })
+  return `<section class="card"><h2>${escapeHtml(copy.aiAnalysis)}</h2><p>${escapeHtml(copy.aiLead)}</p><div class="actions">${button(copy.aiLoadDiagnostics, 'ai-analyze')}${button(copy.aiAutoReadGenerated, 'ai-analyze')}</div>${diagnosisHtml}${selfCheckHtml}${restartCta}<form method="GET" action="${escapeHtml(recoveryHref('execute-repair'))}">${rows}<div class="actions"><button type="submit" class="button primary">${escapeHtml(copy.executeRepair)}</button></div></form>${result}</section>`
 }
 
 /** Render the complete no-script local recovery document. */
@@ -431,18 +541,23 @@ export function renderDesktopStartupRecoveryHtml(model: DesktopStartupRecoveryVi
   const restart = model.restartReady || pending === undefined
     ? button(copy.restart, 'restart', undefined, model.restartReady)
     : ''
+  const repairAreaHtml = aiAnalysisHtml(model, copy)
+  const degradedHtml = (model.degradedBundles?.length ?? 0) === 0
+    ? ''
+    : `<section class="card degraded"><h2>${escapeHtml(copy.degradedMode)}</h2><p>${escapeHtml(copy.degradedBody)}</p><div class="actions">${button(copy.restoreFullPlugins, 'restore-full-plugins', undefined, true)}</div></section>`
   const body = confirmation.length > 0
     ? confirmation
-    : `${pendingHtml}${bundlesHtml}${profileHtml}${configurationHtml}<section class="card"><h2>${escapeHtml(copy.diagnostics)}</h2><p>${escapeHtml(diagnosticsText)}</p>${model.diagnostics.filename === undefined ? '' : `<p><code>${escapeHtml(model.diagnostics.filename)}</code></p>`}<p class="muted">${escapeHtml(copy.privacy)}</p><div class="actions">${diagnosticAction}${terminalAction}${rollbackAction}</div></section>`
+    : `${degradedHtml}${pendingHtml}${bundlesHtml}${profileHtml}${configurationHtml}<section class="card"><h2>${escapeHtml(copy.diagnostics)}</h2><p>${escapeHtml(diagnosticsText)}</p>${model.diagnostics.filename === undefined ? '' : `<p><code>${escapeHtml(model.diagnostics.filename)}</code></p>`}<p class="muted">${escapeHtml(copy.privacy)}</p><div class="actions">${diagnosticAction}${terminalAction}${rollbackAction}</div></section>${repairAreaHtml}`
   return `<!doctype html>
 <html lang="${model.locale === 'zh' ? 'zh-CN' : 'en'}">
 <head>
   <meta charset="utf-8">
-  <meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src 'unsafe-inline'; img-src data:; connect-src 'none'; object-src 'none'; base-uri 'none'; form-action 'none'; frame-ancestors 'none'">
+  <!-- form-action is limited to the recovery bus scheme so the no-script radio form can submit; the bus always preventDefault()s and allowlists. -->
+  <meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src 'unsafe-inline'; img-src data:; connect-src 'none'; object-src 'none'; base-uri 'none'; form-action dsh-recovery:; frame-ancestors 'none'">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>${escapeHtml(copy.title)}</title>
   <style>
-    :root{color-scheme:light dark;font:15px/1.5 -apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif;background:#f2f3f5;color:#202124}*{box-sizing:border-box}body{margin:0}main{width:min(820px,100%);margin:0 auto;padding:34px 30px 28px}h1{font-size:28px;margin:0 0 8px}h2{font-size:17px;margin:0 0 10px}p{margin:7px 0}.lead{color:#5f6368;margin-bottom:20px}.profile{font-size:13px;color:#6b7280}.card,.notice{background:#fff;border:1px solid #dfe1e5;border-radius:12px;padding:18px;margin:14px 0;box-shadow:0 1px 2px #0000000d}.error-detail{white-space:pre-wrap;overflow-wrap:anywhere;max-height:130px;overflow:auto;font:13px/1.45 ui-monospace,SFMono-Regular,Menlo,monospace;background:#f6f7f8;border-radius:8px;padding:12px}.notice strong{display:block}.notice.error,.notice.warning{border-color:#d97706}.notice.success{border-color:#16a34a}.notice.info{border-color:#2563eb}ul{list-style:none;padding:0;margin:14px 0 0;border-top:1px solid #e5e7eb}li{display:flex;justify-content:space-between;align-items:center;gap:14px;padding:12px 0;border-bottom:1px solid #e5e7eb}.meta{display:block;color:#6b7280;font-size:12px;margin-top:2px}.row-actions,.actions{display:flex;align-items:center;gap:9px;flex-wrap:wrap}.actions{margin-top:15px}.button{display:inline-flex;align-items:center;justify-content:center;min-height:36px;padding:7px 13px;border:1px solid #9aa0a6;border-radius:9px;color:inherit;text-decoration:none;background:transparent}.button:hover{background:#eef0f2}.button.primary{background:#1a73e8;border-color:#1a73e8;color:white}.pill{font-size:12px;padding:3px 8px;border-radius:999px;background:#e8eaed}.muted{font-size:12px;color:#6b7280}.footer{display:flex;justify-content:flex-end;gap:10px;flex-wrap:wrap;margin-top:18px}.busy{opacity:.7;pointer-events:none}@media(max-width:640px){main{padding:22px 16px 18px}h1{font-size:24px}.card,.notice{padding:14px}.footer{justify-content:stretch}.footer .button{flex:1 1 180px}}@media(max-width:420px){main{padding:18px 12px 14px}li{align-items:stretch;flex-direction:column}.row-actions,.actions,.footer{align-items:stretch;flex-direction:column}.button{width:100%}}@media(prefers-color-scheme:dark){:root{background:#202124;color:#f1f3f4}.lead,.profile,.meta,.muted{color:#9aa0a6}.card,.notice{background:#292a2d;border-color:#45464a}.error-detail{background:#202124}.button:hover{background:#35363a}.pill{background:#3c4043}ul,li{border-color:#45464a}}
+    :root{color-scheme:light dark;font:15px/1.5 -apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif;background:#f2f3f5;color:#202124}*{box-sizing:border-box}body{margin:0}main{width:min(820px,100%);margin:0 auto;padding:34px 30px 28px}h1{font-size:28px;margin:0 0 8px}h2{font-size:17px;margin:0 0 10px}p{margin:7px 0}.lead{color:#5f6368;margin-bottom:20px}.profile{font-size:13px;color:#6b7280}.card,.notice{background:#fff;border:1px solid #dfe1e5;border-radius:12px;padding:18px;margin:14px 0;box-shadow:0 1px 2px #0000000d}.error-detail{white-space:pre-wrap;overflow-wrap:anywhere;max-height:130px;overflow:auto;font:13px/1.45 ui-monospace,SFMono-Regular,Menlo,monospace;background:#f6f7f8;border-radius:8px;padding:12px}.notice strong{display:block}.notice.error,.notice.warning{border-color:#d97706}.notice.success{border-color:#16a34a}.notice.info{border-color:#2563eb}ul{list-style:none;padding:0;margin:14px 0 0;border-top:1px solid #e5e7eb}li{display:flex;justify-content:space-between;align-items:center;gap:14px;padding:12px 0;border-bottom:1px solid #e5e7eb}.meta{display:block;color:#6b7280;font-size:12px;margin-top:2px}.row-actions,.actions{display:flex;align-items:center;gap:9px;flex-wrap:wrap}.actions{margin-top:15px}.button{display:inline-flex;align-items:center;justify-content:center;min-height:36px;padding:7px 13px;border:1px solid #9aa0a6;border-radius:9px;color:inherit;text-decoration:none;background:transparent}.button:hover{background:#eef0f2}.button.primary{background:#1a73e8;border-color:#1a73e8;color:white}.pill{font-size:12px;padding:3px 8px;border-radius:999px;background:#e8eaed}.plan-option{display:block;padding:7px 0}.plan-option .muted{display:block;margin-left:22px}button.button{cursor:pointer;font:inherit}.muted{font-size:12px;color:#6b7280}.footer{display:flex;justify-content:flex-end;gap:10px;flex-wrap:wrap;margin-top:18px}.busy{opacity:.7;pointer-events:none}@media(max-width:640px){main{padding:22px 16px 18px}h1{font-size:24px}.card,.notice{padding:14px}.footer{justify-content:stretch}.footer .button{flex:1 1 180px}}@media(max-width:420px){main{padding:18px 12px 14px}li{align-items:stretch;flex-direction:column}.row-actions,.actions,.footer{align-items:stretch;flex-direction:column}.button{width:100%}}@media(prefers-color-scheme:dark){:root{background:#202124;color:#f1f3f4}.lead,.profile,.meta,.muted{color:#9aa0a6}.card,.notice{background:#292a2d;border-color:#45464a}.error-detail{background:#202124}.button:hover{background:#35363a}.pill{background:#3c4043}ul,li{border-color:#45464a}}
   </style>
 </head>
 <body><main class="${model.busy ? 'busy' : ''}">
@@ -460,7 +575,7 @@ export function renderDesktopStartupRecoveryHtml(model: DesktopStartupRecoveryVi
 /** Parse only the fixed action origin used by this no-script document. */
 export function parseDesktopStartupRecoveryAction(
   href: string,
-): { readonly action: string; readonly id?: string; readonly name?: string } | undefined {
+): { readonly action: string; readonly id?: string; readonly name?: string; readonly option?: string } | undefined {
   let url: URL
   try { url = new URL(href) } catch { return undefined }
   if (url.protocol !== RECOVERY_SCHEME
@@ -490,8 +605,20 @@ export function parseDesktopStartupRecoveryAction(
     'rollback-last-known-good',
     'restart',
     'quit',
+    'execute-repair',
+    'ai-analyze',
+    'restore-full-plugins',
   ])
   if (!allowed.has(action)) return undefined
+  if (action === 'execute-repair') {
+    const keys = [...url.searchParams.keys()]
+    if (keys.some(key => key !== 'option') || url.searchParams.getAll('option').length !== 1) {
+      return undefined
+    }
+    const option = url.searchParams.get('option') ?? ''
+    if (REPAIR_OPTION_PATTERN.test(option)) return { action, option }
+    return undefined
+  }
   const keys = [...url.searchParams.keys()]
   if (keys.some(key => key !== 'id' && key !== 'name') || url.searchParams.getAll('id').length > 1 || url.searchParams.getAll('name').length > 1) return undefined
   const id = url.searchParams.get('id') ?? undefined
@@ -515,6 +642,8 @@ export class DesktopStartupRecoveryWindow {
   private readonly diagnosticAbort = new AbortController()
   private confirmation: RecoveryConfirmation | undefined
   private notice: RecoveryNotice | undefined
+  private aiAnalysis: DesktopStartupRecoveryAiAnalysis = {}
+  private degradedBundles: readonly string[] = []
   private busy = false
   private restartReady = false
   private profiles: readonly DesktopStartupRecoveryProfile[] | undefined
@@ -532,6 +661,7 @@ export class DesktopStartupRecoveryWindow {
       this.snapshotError = cause instanceof Error ? cause.message : String(cause)
     }
     this.refreshProfiles()
+    this.degradedBundles = this.loadDegradedBundles()
     const window = new BrowserWindow({
       title: COPY[this.options.locale].title,
       ...desktopStartupRecoveryWindowBounds(),
@@ -585,7 +715,7 @@ export class DesktopStartupRecoveryWindow {
     revealApplication(this.window)
   }
 
-  private async handleAction(action: { readonly action: string; readonly id?: string; readonly name?: string }): Promise<void> {
+  private async handleAction(action: { readonly action: string; readonly id?: string; readonly name?: string; readonly option?: string }): Promise<void> {
     if (this.busy || this.settled) return
     try {
       if (action.action === 'home') {
@@ -685,7 +815,30 @@ export class DesktopStartupRecoveryWindow {
         await this.openConfigurationPath('profileManifest')
       } else if (action.action === 'open-profile-directory') {
         await this.openConfigurationPath('profileDirectory')
+      } else if (action.action === 'execute-repair' && action.option !== undefined) {
+        await this.runBusy(async () => {
+          const result = await this.requireController().executeRepair(action.option!)
+          this.aiAnalysis = {
+            selectedOption: result.planId,
+            result: { planId: result.planId, status: result.status, message: result.message },
+            ...(result.selfCheck === undefined ? {} : { selfCheck: result.selfCheck }),
+          }
+        })
+      } else if (action.action === 'ai-analyze') {
+        await this.runBusy(async () => {
+          const analysis = await this.requireController().runAiAnalysis()
+          this.aiAnalysis = analysis
+        })
+      } else if (action.action === 'restore-full-plugins') {
+        const statePath = this.options.degradedStatePath
+        if (statePath === undefined) {
+          throw new Error('Desktop degraded state is unavailable.')
+        }
+        writeDegradedBundles(statePath, [])
+        this.finish('restart')
+        return
       } else if (action.action === 'restart') {
+        // Footer restart keeps the degraded set intact; only restore-full-plugins clears it.
         this.finish('restart')
         return
       } else if (action.action === 'quit') {
@@ -723,6 +876,17 @@ export class DesktopStartupRecoveryWindow {
       this.profiles = this.options.profileActions?.list()
     } catch {
       this.profiles = undefined
+    }
+  }
+
+  private loadDegradedBundles(): readonly string[] {
+    const statePath = this.options.degradedStatePath
+    if (statePath === undefined) return []
+    try {
+      return readDegradedBundles(statePath)
+    } catch {
+      // A broken degraded state must not block recovery; the window just shows no card.
+      return []
     }
   }
 
@@ -777,6 +941,7 @@ export class DesktopStartupRecoveryWindow {
       locale: this.options.locale,
       failureStage: this.options.failureStage,
       failureDetail: this.options.failureDetail,
+      degradedBundles: this.degradedBundles,
       ...(this.snapshot === undefined ? {} : { snapshot: this.snapshot }),
       ...(this.snapshotError === undefined ? {} : { snapshotError: this.snapshotError }),
       diagnostics: this.diagnostics,
@@ -790,6 +955,7 @@ export class DesktopStartupRecoveryWindow {
       ...(this.options.openTerminal === undefined ? {} : { terminalAvailable: true }),
       ...(this.options.profileActions === undefined ? {} : { profileCreatorAvailable: true }),
       ...(this.options.rollbackLastKnownGood === undefined ? {} : { rollbackLastKnownGoodAvailable: true }),
+      aiAnalysis: this.aiAnalysis,
     }
     const state = Buffer.from(JSON.stringify(model), 'utf8').toString('base64url')
     await window.loadFile(RECOVERY_DOCUMENT, { query: { state } })

--- a/dsh-plugin-desktop/tests/ai-diagnostic-analyzer.spec.ts
+++ b/dsh-plugin-desktop/tests/ai-diagnostic-analyzer.spec.ts
@@ -1,0 +1,74 @@
+import { EventEmitter } from 'node:events'
+import { afterEach, expect, it, vi } from 'vitest'
+import { runTierOneAnalysis } from '../src/ai-diagnostic-analyzer.ts'
+
+interface FakeChild {
+  readonly child: EventEmitter & {
+    kill: ReturnType<typeof vi.fn>
+    stdout: EventEmitter
+    stdin: EventEmitter & { end: ReturnType<typeof vi.fn> }
+    stderr: EventEmitter
+  }
+}
+
+function fakeChild(): FakeChild {
+  const child = new EventEmitter() as FakeChild['child']
+  child.kill = vi.fn(() => true)
+  child.stdout = new EventEmitter()
+  child.stdin = Object.assign(new EventEmitter(), { end: vi.fn() })
+  child.stderr = new EventEmitter()
+  return { child }
+}
+
+const mockState = vi.hoisted(() => ({
+  spawn: (() => { throw new Error('no dsh') }) as (...args: unknown[]) => unknown,
+}))
+
+vi.mock('node:child_process', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:child_process')>()
+  return { ...actual, spawn: (...args: unknown[]) => mockState.spawn(...args) }
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+it('degrades to undefined when the CLI is unavailable', async () => {
+  mockState.spawn = () => { throw new Error('no dsh') }
+  await expect(runTierOneAnalysis('Error: Cannot find module \'x\'')).resolves.toBeUndefined()
+})
+
+it('kills the tier-1 child and degrades after the analysis timeout', async () => {
+  const fake = fakeChild()
+  mockState.spawn = () => fake.child
+  vi.useFakeTimers()
+
+  const pending = runTierOneAnalysis('input')
+  await vi.advanceTimersByTimeAsync(15_000)
+
+  await expect(pending).resolves.toBeUndefined()
+  expect(fake.child.kill).toHaveBeenCalledWith('SIGKILL')
+})
+
+it('kills the tier-1 child and degrades when the caller aborts', async () => {
+  const fake = fakeChild()
+  mockState.spawn = () => fake.child
+  const controller = new AbortController()
+
+  const pending = runTierOneAnalysis('input', controller.signal)
+  controller.abort()
+
+  await expect(pending).resolves.toBeUndefined()
+  expect(fake.child.kill).toHaveBeenCalledWith('SIGKILL')
+})
+
+it('swallows a stdin EPIPE and degrades when the child exits non-zero', async () => {
+  const fake = fakeChild()
+  mockState.spawn = () => fake.child
+
+  const pending = runTierOneAnalysis('input')
+  fake.child.stdin.emit('error', Object.assign(new Error('write EPIPE'), { code: 'EPIPE' }))
+  fake.child.emit('exit', 1)
+
+  await expect(pending).resolves.toBeUndefined()
+})

--- a/dsh-plugin-desktop/tests/client-environment.spec.ts
+++ b/dsh-plugin-desktop/tests/client-environment.spec.ts
@@ -32,9 +32,21 @@ describe('desktop client environment', () => {
 
   it('accepts the Electron-owned kebab query markers', () => {
     expect(parseDesktopClientEnvironment('?dsh-desktop-mode=advanced&dsh-desktop-platform=darwin'))
-      .toEqual({ mode: 'advanced', platform: 'darwin' })
+      .toEqual({ mode: 'advanced', platform: 'darwin', degradedBundles: [] })
     expect(parseDesktopClientEnvironment('?dsh-desktop-platform=win32&dsh-desktop-mode=compatibility'))
-      .toEqual({ mode: 'compatibility', platform: 'win32' })
+      .toEqual({ mode: 'compatibility', platform: 'win32', degradedBundles: [] })
+  })
+
+  it('parses the degraded-bundle marker, defaulting to empty when absent or malformed', () => {
+    expect(parseDesktopClientEnvironment(
+      '?dsh-desktop-mode=advanced&dsh-desktop-platform=darwin&dsh-degraded=plugin-a,plugin-b',
+    )).toEqual({ mode: 'advanced', platform: 'darwin', degradedBundles: ['plugin-a', 'plugin-b'] })
+    expect(parseDesktopClientEnvironment(
+      '?dsh-desktop-mode=advanced&dsh-desktop-platform=darwin&dsh-degraded=%20plugin-a%20,plugin-b',
+    )).toEqual({ mode: 'advanced', platform: 'darwin', degradedBundles: ['plugin-a', 'plugin-b'] })
+    expect(parseDesktopClientEnvironment(
+      '?dsh-desktop-mode=advanced&dsh-desktop-platform=darwin&dsh-degraded=,,,',
+    )).toEqual({ mode: 'advanced', platform: 'darwin', degradedBundles: [] })
   })
 
   it.each([

--- a/dsh-plugin-desktop/tests/client/degraded-notice.spec.ts
+++ b/dsh-plugin-desktop/tests/client/degraded-notice.spec.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest'
+import { desktopDegradedNotice } from '../../src/client/degraded-notice.ts'
+
+describe('desktop degraded notice', () => {
+  it('formats a degraded banner only when bundles are present', () => {
+    expect(desktopDegradedNotice([], 'zh')).toEqual({
+      active: false,
+      title: '',
+      body: '',
+      dismissLabel: '',
+      restoreLabel: '',
+    })
+    expect(desktopDegradedNotice(['plugin-x'], 'zh')).toMatchObject({
+      active: true,
+      title: '安全降级模式',
+    })
+  })
+
+  it('carries the exact body copy for zh and en', () => {
+    expect(desktopDegradedNotice(['plugin-a', 'plugin-b'], 'zh')).toMatchObject({
+      body: '插件 plugin-a, plugin-b 未加载，基础聊天/WebUI 可用，部分功能受限。',
+    })
+    expect(desktopDegradedNotice(['plugin-a'], 'en')).toEqual({
+      active: true,
+      title: 'Safe degraded mode',
+      body: 'Plugins plugin-a did not load. Core chat/WebUI is available; some features are limited.',
+      dismissLabel: 'Dismiss',
+      restoreLabel: 'Restore',
+    })
+  })
+
+  it('labels the dismiss and restore actions per locale', () => {
+    expect(desktopDegradedNotice(['plugin-x'], 'zh')).toMatchObject({
+      dismissLabel: '忽略',
+      restoreLabel: '立即恢复',
+    })
+    expect(desktopDegradedNotice(['plugin-x'], 'en')).toMatchObject({
+      dismissLabel: 'Dismiss',
+      restoreLabel: 'Restore',
+    })
+  })
+})

--- a/dsh-plugin-desktop/tests/degraded-mode.spec.ts
+++ b/dsh-plugin-desktop/tests/degraded-mode.spec.ts
@@ -1,0 +1,38 @@
+// tests/degraded-mode.spec.ts
+import { mkdirSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
+import {
+  readDegradedBundles,
+  writeDegradedBundles,
+} from '../src/degraded-mode.ts'
+
+const roots: string[] = []
+afterEach(() => { for (const r of roots.splice(0)) rmSync(join(r, 'degraded.json'), { force: true }) })
+
+function root(): string {
+  const r = join(tmpdir(), `dsh-degraded-${Date.now()}-${Math.random().toString(36).slice(2)}`)
+  mkdirSync(r, { recursive: true })
+  roots.push(r)
+  return r
+}
+
+describe('degraded mode state', () => {
+  it('round-trips the degraded bundle set', () => {
+    const path = join(root(), 'degraded.json')
+    writeDegradedBundles(path, ['plugin-x', 'plugin-y'])
+    expect(readDegradedBundles(path)).toEqual(['plugin-x', 'plugin-y'])
+  })
+
+  it('falls back to an empty set when the file is absent', () => {
+    expect(readDegradedBundles(join(root(), 'degraded.json'))).toEqual([])
+  })
+
+  it('preserves an empty degraded set (clearing a prior degrade)', () => {
+    const path = join(root(), 'degraded.json')
+    writeDegradedBundles(path, ['plugin-x'])
+    writeDegradedBundles(path, [])
+    expect(readDegradedBundles(path)).toEqual([])
+  })
+})

--- a/dsh-plugin-desktop/tests/diagnostic-analyzer.spec.ts
+++ b/dsh-plugin-desktop/tests/diagnostic-analyzer.spec.ts
@@ -1,0 +1,9 @@
+import { expect, it } from 'vitest'
+import { analyzeDiagnostics } from '../src/diagnostic-analyzer.ts'
+it('maps a module-not-found stack to a plain-Chinese root cause with four options', () => {
+  const d = analyzeDiagnostics("Error: Cannot find module 'plugin-x'\n  at boot (main.ts:831)")
+  expect(d.rootCause).toContain('缺失模块')
+  expect(d.severity).toBe('medium')
+  expect(d.options.map(o => o.id)).toEqual(['A', 'B', 'C', 'D'])
+  expect(d.disclaimer).toContain('仅供参考')
+})

--- a/dsh-plugin-desktop/tests/diagnostic-evidence.spec.ts
+++ b/dsh-plugin-desktop/tests/diagnostic-evidence.spec.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest'
+import {
+  buildDiagnosticEvidenceEntries,
+  type DiagnosticEvidenceSource,
+} from '../src/diagnostic-evidence.ts'
+
+describe('diagnostic evidence entries', () => {
+  it('encodes each present source under the archive layout name and skips absent ones', () => {
+    const source: DiagnosticEvidenceSource = {
+      errorStack: { text: 'Error: Cannot find module \'plugin-x\'\n  at boot (main.ts:831)' },
+      pluginManifest: { text: '[]' },
+      versions: { text: 'upstream: a1b2c3\nnode: 22' },
+      profileBundles: { text: '{"bundles":[]}' },
+      profileConfig: { filename: 'package.json', text: '{}' },
+      envSnapshot: { text: 'DSH_TELEMETRY_DISABLED=1' },
+    }
+    expect(buildDiagnosticEvidenceEntries(source)).toEqual([
+      { name: 'error-stack.txt', content: source.errorStack!.text },
+      { name: 'plugin-manifest.json', content: source.pluginManifest!.text },
+      { name: 'versions.json', content: source.versions!.text },
+      { name: 'profile-bundles.json', content: source.profileBundles!.text },
+      { name: 'config/package.json', content: source.profileConfig!.text },
+      { name: 'env-snapshot.txt', content: source.envSnapshot!.text },
+    ])
+  })
+
+  it('returns an empty array for an empty source', () => {
+    expect(buildDiagnosticEvidenceEntries({})).toEqual([])
+  })
+
+  it('rejects a config filename that is not a bare basename', () => {
+    expect(() => buildDiagnosticEvidenceEntries({
+      profileConfig: { filename: '../escape.txt', text: 'x' },
+    })).toThrow(/invalid config filename/u)
+  })
+})

--- a/dsh-plugin-desktop/tests/diagnostic-export.spec.ts
+++ b/dsh-plugin-desktop/tests/diagnostic-export.spec.ts
@@ -378,4 +378,57 @@ describe('exportDiagnosticsZip', () => {
     expect(names).not.toContain('dsh-2026-08-14.log')
     expect(zip.readAsText('system-info.txt')).toContain('omitted-log-files: 2')
   })
+
+  it('reports included-evidence-bytes as the true running total including worker evidence', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'dsh-dx-worker-evidence-'))
+    const logs = join(root, 'logs')
+    mkdirSync(logs)
+    writeFileSync(join(logs, 'dsh-2026-08-16.log'), 'hello\n')
+    const errorStack = 'Error: Cannot find module \'plugin-x\''
+
+    const out = await exportDiagnosticsZip(logs, root, {
+      appVersion: APP_VERSION,
+      errorStack,
+    })
+
+    const zip = new AdmZip(out)
+    expect(zip.readAsText('error-stack.txt')).toBe(errorStack)
+    const expected = Buffer.byteLength('hello\n', 'utf8') + Buffer.byteLength(errorStack, 'utf8')
+    expect(zip.readAsText('system-info.txt')).toContain(`included-evidence-bytes: ${String(expected)}`)
+  })
+})
+
+import {
+  buildWorkerEvidenceEntries,
+} from '../src/diagnostic-export-worker.ts'
+import type { DiagnosticExportWorkerData } from '../src/diagnostic-export-worker.ts'
+
+it('maps worker evidence data into the archive layout', () => {
+  const data: DiagnosticExportWorkerData = {
+    logsDir: '/logs',
+    userDataDir: '/data',
+    appVersion: '1.0.0',
+    maxEvidenceBytes: 50 * 1024 * 1024,
+    errorStack: 'Error: Cannot find module \'plugin-x\'',
+    pluginManifest: '[]',
+    versions: 'upstream: a1b2c3',
+    profileBundles: '{}',
+    profileConfig: { filename: 'package.json', text: '{}' },
+    envSnapshot: 'DSH_TELEMETRY_DISABLED=1',
+  }
+  expect(buildWorkerEvidenceEntries(data).map(entry => entry.name)).toEqual([
+    'error-stack.txt',
+    'plugin-manifest.json',
+    'versions.json',
+    'profile-bundles.json',
+    'config/package.json',
+    'env-snapshot.txt',
+  ])
+})
+
+it('omits evidence sources that are absent from worker data', () => {
+  const data: DiagnosticExportWorkerData = {
+    logsDir: '/logs', userDataDir: '/data', appVersion: '1.0.0', maxEvidenceBytes: 1,
+  }
+  expect(buildWorkerEvidenceEntries(data)).toEqual([])
 })

--- a/dsh-plugin-desktop/tests/profile.spec.ts
+++ b/dsh-plugin-desktop/tests/profile.spec.ts
@@ -5,6 +5,7 @@ import { fileURLToPath, pathToFileURL } from 'node:url'
 import { afterEach, describe, expect, it } from 'vitest'
 import { composeEntries, initProfile, PROFILE_TEMPLATES } from '@deepseek-ai/dsh-app-boot'
 import {
+  DEFAULT_DESKTOP_MARKET_SNAPSHOT,
   DESKTOP_PACKAGE_NAME,
   desktopShellModeFromSettings,
   desktopStartupSettingsFromSettings,
@@ -435,6 +436,32 @@ describe('desktop profile composition', {
     expect(composeEntries([prepared.patches])).not.toContainEqual(expect.objectContaining({
       id: 'third-party-marker',
     }))
+  })
+
+  it('drops a degraded mutable external bundle but keeps a core bundle', () => {
+    const home = temporaryHome()
+    const packageName = 'plugin-x'
+    installBundle(home, packageName, '- insert:\n    - id: plugin-x-marker\n      name: cordis:example\n')
+    const profileManifestPath = join(ensureDesktopProfile(home), 'package.json')
+    const profileManifest = JSON.parse(readFileSync(profileManifestPath, 'utf8')) as {
+      dsh: { profile: { bundles: string[] } }
+    }
+    profileManifest.dsh.profile.bundles.push(packageName)
+    writeFileSync(profileManifestPath, JSON.stringify(profileManifest) + '\n')
+    const degradedStatePath = join(home, 'user-data', 'degraded-mode', 'degraded.json')
+    mkdirSync(dirname(degradedStatePath), { recursive: true })
+    writeFileSync(degradedStatePath, JSON.stringify({
+      version: 1,
+      bundles: [packageName],
+    }) + '\n')
+
+    const prepared = prepareDesktopProfile(
+      undefined, home, 'darwin', 'desktop', undefined, DEFAULT_DESKTOP_MARKET_SNAPSHOT,
+      undefined, undefined, degradedStatePath,
+    )
+    const layerNames = prepared.profile.layers.map(layer => layer.packageName)
+    expect(layerNames).not.toContain(packageName)
+    expect(layerNames).toContain('@deepseek-ai/dsh-base')
   })
 
   it('filters an unselected dshmarket bundle before resolving or parsing its patch', () => {

--- a/dsh-plugin-desktop/tests/repair-plans.spec.ts
+++ b/dsh-plugin-desktop/tests/repair-plans.spec.ts
@@ -1,0 +1,108 @@
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, expect, it } from 'vitest'
+import { repairPlans } from '../src/repair-plans.ts'
+
+const roots: string[] = []
+
+afterEach(() => {
+  for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true })
+})
+
+function temporaryRoot(): string {
+  const root = mkdtempSync(join(tmpdir(), 'repair-plans-'))
+  roots.push(root)
+  return root
+}
+
+function planById(plans: ReadonlyArray<ReturnType<typeof repairPlans>[number]>, id: string) {
+  const plan = plans.find(p => p.id === id)
+  if (plan === undefined) throw new Error(`missing plan ${id}`)
+  return plan
+}
+
+it('registers four plans with risk and audience', () => {
+  const plans = repairPlans({
+    degradedStatePath: '/x',
+    degradedBundle: ['plugin-x'],
+    restoreLatest: async () => ({ status: 'restored', changedFiles: [], snapshotDirectory: '/s', failureGeneration: 'g' }),
+  })
+  expect(plans.map(p => p.id)).toEqual(['A', 'B', 'C', 'D'])
+  expect(plans[0]!.risk.severity).toBe('low')
+  expect(plans[1]!.audience).toBe('developer')
+})
+
+it('plan A writes the degraded bundle set and throws on a missing or empty path', async () => {
+  const root = temporaryRoot()
+  const statePath = join(root, 'startup-recovery', 'degraded.json')
+  const plans = repairPlans({
+    degradedStatePath: statePath,
+    degradedBundle: ['plugin-x'],
+    restoreLatest: async () => ({ status: 'restored', changedFiles: [], snapshotDirectory: '/s', failureGeneration: 'g' }),
+  })
+
+  await expect(planById(plans, 'A').apply()).resolves.toEqual({
+    status: 'degraded',
+    message: '已启用降级模式。请重新启动 Desktop。',
+  })
+  expect(JSON.parse(readFileSync(statePath, 'utf8'))).toEqual({ version: 1, bundles: ['plugin-x'] })
+
+  const missing = repairPlans({
+    degradedStatePath: undefined,
+    degradedBundle: ['plugin-x'],
+    restoreLatest: async () => ({ status: 'restored', changedFiles: [], snapshotDirectory: '/s', failureGeneration: 'g' }),
+  })
+  await expect(planById(missing, 'A').apply()).rejects.toThrow('degraded state path is required for plan A')
+
+  const empty = repairPlans({
+    degradedStatePath: '',
+    degradedBundle: ['plugin-x'],
+    restoreLatest: async () => ({ status: 'restored', changedFiles: [], snapshotDirectory: '/s', failureGeneration: 'g' }),
+  })
+  await expect(planById(empty, 'A').apply()).rejects.toThrow('degraded state path is required for plan A')
+})
+
+it('plans B and C decline with acknowledged outcomes', async () => {
+  const plans = repairPlans({
+    degradedStatePath: undefined,
+    degradedBundle: [],
+    restoreLatest: async () => { throw new Error('restore not expected') },
+  })
+
+  await expect(planById(plans, 'B').apply()).resolves.toEqual({
+    status: 'acknowledged',
+    message: '方案 B 需开发者二次确认，暂不自动执行。',
+  })
+  await expect(planById(plans, 'C').apply()).resolves.toEqual({
+    status: 'acknowledged',
+    message: '方案 C 需默认健康集，暂不自动执行。',
+  })
+})
+
+it('plan D omits empty changed-file parens and lists files when present', async () => {
+  const empty = repairPlans({
+    degradedStatePath: undefined,
+    degradedBundle: [],
+    restoreLatest: async () => ({ status: 'restored', changedFiles: [], snapshotDirectory: '/s', failureGeneration: 'g' }),
+  })
+  await expect(planById(empty, 'D').apply()).resolves.toEqual({
+    status: 'restored',
+    message: '已恢复上次健康快照。',
+  })
+
+  const changed = repairPlans({
+    degradedStatePath: undefined,
+    degradedBundle: [],
+    restoreLatest: async () => ({
+      status: 'already-attempted',
+      changedFiles: ['package.json', 'pnpm-lock.yaml'],
+      snapshotDirectory: '/s',
+      failureGeneration: 'g',
+    }),
+  })
+  await expect(planById(changed, 'D').apply()).resolves.toEqual({
+    status: 'already-attempted',
+    message: '已恢复上次健康快照（package.json, pnpm-lock.yaml）。',
+  })
+})

--- a/dsh-plugin-desktop/tests/repair-self-check.spec.ts
+++ b/dsh-plugin-desktop/tests/repair-self-check.spec.ts
@@ -1,0 +1,19 @@
+import { expect, it } from 'vitest'
+import { runRepairSelfCheck } from '../src/repair-self-check.ts'
+it('aggregates read-only checks into a report with a recommendation', async () => {
+  const report = await runRepairSelfCheck([
+    { name: 'plugin tree', run: async () => ({ ok: true, detail: 'loaded' }) },
+    { name: 'core import', run: async () => ({ ok: false, detail: 'module not found' }) },
+  ])
+  expect(report.ok).toBe(false)
+  expect(report.checks[0]).toEqual({ name: 'plugin tree', passed: true, detail: 'loaded' })
+  expect(report.checks[1]).toEqual({ name: 'core import', passed: false, detail: 'module not found' })
+  expect(report.recommendation).toContain('请尝试其他方案')
+})
+it('produces an ok report and restart prompt on full pass', async () => {
+  const report = await runRepairSelfCheck([
+    { name: 'core import', run: async () => ({ ok: true, detail: 'ok' }) },
+  ])
+  expect(report.ok).toBe(true)
+  expect(report.recommendation).toContain('重新启动')
+})

--- a/dsh-plugin-desktop/tests/startup-recovery-controller.spec.ts
+++ b/dsh-plugin-desktop/tests/startup-recovery-controller.spec.ts
@@ -8,7 +8,20 @@ import {
 } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { dirname, join } from 'node:path'
-import { afterEach, describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+const aiAnalyzerState = vi.hoisted(() => ({
+  runTierOneAnalysis: (async () => undefined) as (
+    input: string,
+    signal?: AbortSignal,
+  ) => Promise<AiDiagnosis | undefined>,
+}))
+
+vi.mock('../src/ai-diagnostic-analyzer.ts', () => ({
+  runTierOneAnalysis: (input: string, signal?: AbortSignal) => aiAnalyzerState.runTierOneAnalysis(input, signal),
+}))
+import { readDegradedBundles } from '../src/degraded-mode.ts'
+import type { AiDiagnosis } from '../src/diagnostic-analyzer.ts'
 import { disableDesktopProfileBundle } from '../src/desktop-plugins.ts'
 import type {
   DesktopInstallRecoveryPhase,
@@ -80,6 +93,7 @@ interface Harness {
   readonly generation: { profileName: string; generationId: string }
   readonly statePath: string
   readonly manifestPath: string
+  readonly degradedStatePath: string
 }
 
 function createHarness(
@@ -90,6 +104,9 @@ function createHarness(
     pending?: DesktopInstallRecoveryTransaction
     installRecovery?: DesktopStartupRecoveryControllerOptions['installRecovery']
     now?: () => number
+    failureStack?: string
+    restoreLatest?: DesktopStartupRecoveryControllerOptions['restoreLatest']
+    selfCheckItems?: DesktopStartupRecoveryControllerOptions['selfCheckItems']
   } = {},
 ): Harness {
   const bundles = options.bundles ?? [
@@ -101,6 +118,7 @@ function createHarness(
   ]
   const manifestPath = writeManifest(root, bundles)
   const statePath = join(root, 'user-data', 'plugin-management', 'state.json')
+  const degradedStatePath = join(root, 'user-data', 'startup-recovery', 'degraded.json')
   const generation = {
     profileName: 'desktop',
     generationId: 'current-generation-0001',
@@ -119,9 +137,13 @@ function createHarness(
       restore: async () => { throw new Error('restore not configured') },
       requestRetry: async () => { throw new Error('retry not configured') },
     },
+    degradedStatePath,
     ...(options.now === undefined ? {} : { now: options.now }),
+    ...(options.failureStack === undefined ? {} : { failureStack: options.failureStack }),
+    ...(options.restoreLatest === undefined ? {} : { restoreLatest: options.restoreLatest }),
+    ...(options.selfCheckItems === undefined ? {} : { selfCheckItems: options.selfCheckItems }),
   })
-  return { controller, generation, statePath, manifestPath }
+  return { controller, generation, statePath, manifestPath, degradedStatePath }
 }
 
 function errorCode(cause: unknown): string | undefined {
@@ -476,5 +498,129 @@ describe('pre-Host Desktop startup recovery controller', () => {
     const terminalRoot = temporaryRoot()
     const terminal = createHarness(terminalRoot, { pending: transaction('rolled-back') })
     expect((await terminal.controller.snapshot()).pendingInstall).toBeUndefined()
+  })
+
+  it('commits plan A to degraded mode and reports plan D as restored', async () => {
+    const root = temporaryRoot()
+    const harness = createHarness(root, {
+      restoreLatest: async () => ({ status: 'restored', changedFiles: [], snapshotDirectory: '/s', failureGeneration: 'g' }),
+    })
+
+    const a = await harness.controller.executeRepair('A')
+    expect(a).toEqual(expect.objectContaining({
+      planId: 'A',
+      status: 'degraded',
+      message: '已启用降级模式。请重新启动 Desktop。',
+    }))
+    expect(a.selfCheck.ok).toBe(true)
+
+    await expect(harness.controller.executeRepair('D')).resolves.toEqual(
+      expect.objectContaining({
+        planId: 'D',
+        status: 'restored',
+        message: '已恢复上次健康快照。',
+      }),
+    )
+  })
+
+  it('threads the analysis-identified bundle into the degraded set for plan A', async () => {
+    const root = temporaryRoot()
+    const harness = createHarness(root, {
+      failureStack: "Error: Cannot find module 'plugin-x'\n  at boot",
+    })
+
+    const result = await harness.controller.executeRepair('A')
+    expect(result.status).toBe('degraded')
+    expect(readDegradedBundles(harness.degradedStatePath)).toEqual(['plugin-x'])
+  })
+
+  it('commits a degraded bundle set for plan A and clears it when bundled empty', async () => {
+    const root = temporaryRoot()
+    const harness = createHarness(root)
+    const degradedPath = join(root, 'user-data', 'startup-recovery', 'degraded.json')
+
+    const a = await harness.controller.executeRepair('A')
+    expect(a.status).toBe('degraded')
+    const committed = await harness.controller.commitDegraded(['plugin-x'])
+    expect(committed.bundles).toEqual(['plugin-x'])
+    expect(readDegradedBundles(degradedPath)).toEqual(['plugin-x'])
+
+    await harness.controller.commitDegraded([])
+    expect(readDegradedBundles(degradedPath)).toEqual([])
+  })
+
+  it('rejects a repair plan id outside the registry', async () => {
+    const root = temporaryRoot()
+    const harness = createHarness(root)
+
+    await expect(harness.controller.executeRepair('Z')).rejects.toSatisfy(
+      (cause: unknown) => errorCode(cause) === 'invalid-target',
+    )
+  })
+
+  it('rejects a repair plan after the launcher changes generation', async () => {
+    const root = temporaryRoot()
+    const harness = createHarness(root)
+
+    harness.generation.generationId = 'next-generation-0002'
+    await expect(harness.controller.executeRepair('A')).rejects.toSatisfy(
+      (cause: unknown) => errorCode(cause) === 'generation-changed',
+    )
+  })
+
+  it('analyzes the failure stack into a diagnosis naming the missing module', async () => {
+    const root = temporaryRoot()
+    const harness = createHarness(root, {
+      failureStack: "Error: Cannot find module 'plugin-x'\n  at boot",
+    })
+
+    const analysis = await harness.controller.runAiAnalysis()
+    expect(analysis.diagnosis).toBeDefined()
+    expect(analysis.diagnosis?.rootCause).toContain('plugin-x')
+    expect(analysis.diagnosis?.rootCause).toContain('缺失模块')
+  })
+
+  it('rejects an ai analysis after the launcher changes generation', async () => {
+    const root = temporaryRoot()
+    const harness = createHarness(root, {
+      failureStack: "Error: Cannot find module 'plugin-x'\n  at boot",
+    })
+
+    harness.generation.generationId = 'next-generation-0002'
+    await expect(harness.controller.runAiAnalysis()).rejects.toSatisfy(
+      (cause: unknown) => errorCode(cause) === 'generation-changed',
+    )
+  })
+
+  it('aborts an in-flight tier-1 analysis when the controller is disposed', async () => {
+    aiAnalyzerState.runTierOneAnalysis = async (_input: string, signal?: AbortSignal) => {
+      await new Promise<void>((_resolve, reject) => {
+        if (signal === undefined) {
+          reject(new Error('expected an abort signal'))
+          return
+        }
+        if (signal.aborted) {
+          reject(new DOMException('Tier-1 analysis aborted.', 'AbortError'))
+          return
+        }
+        signal.addEventListener('abort', () => {
+          reject(new DOMException('Tier-1 analysis aborted.', 'AbortError'))
+        }, { once: true })
+      })
+      return undefined
+    }
+    try {
+      const root = temporaryRoot()
+      const harness = createHarness(root, {
+        failureStack: "Error: Cannot find module 'plugin-x'\n  at boot",
+      })
+
+      const analysis = harness.controller.runAiAnalysis()
+      harness.controller.dispose()
+
+      await expect(analysis).rejects.toMatchObject({ name: 'AbortError' })
+    } finally {
+      aiAnalyzerState.runTierOneAnalysis = async () => undefined
+    }
   })
 })

--- a/dsh-plugin-desktop/tests/startup-recovery-window.spec.ts
+++ b/dsh-plugin-desktop/tests/startup-recovery-window.spec.ts
@@ -29,6 +29,7 @@ function viewModel(
     busy: false,
     restartReady: false,
     configurationAvailable: false,
+    aiAnalysis: {},
     ...overrides,
   }
 }
@@ -45,7 +46,7 @@ describe('Desktop startup recovery document', () => {
     expect(html).toContain("connect-src 'none'")
     expect(html).toContain("object-src 'none'")
     expect(html).toContain("base-uri 'none'")
-    expect(html).toContain("form-action 'none'")
+    expect(html).toContain('form-action dsh-recovery:')
     expect(html).toContain("frame-ancestors 'none'")
     expect(html).not.toMatch(/<script\b/iu)
     expect(html).not.toMatch(/\son[a-z]+\s*=/iu)
@@ -164,6 +165,80 @@ describe('Desktop startup recovery document', () => {
     expect(html).toContain('example-plugin')
     expect(html).toContain('安装前配置已恢复。请重新启动 Desktop。')
     expect(html).toContain('class="button primary" href="dsh-recovery://restart"')
+  })
+
+  it('renders the no-script radio repair form with a GET action to the action bus', () => {
+    const html = renderDesktopStartupRecoveryHtml(viewModel())
+
+    expect(html).toContain('AI 辅助故障分析')
+    expect(html).toContain('name="option"')
+    expect(html).toContain('value="A"')
+    expect(html).toContain('临时禁用故障插件')
+    expect(html).toContain('value="D"')
+    expect(html).toContain('恢复默认配置')
+    expect(html).toContain('action="dsh-recovery://execute-repair"')
+    expect(html).toContain('type="submit"')
+    expect(html).toContain('执行修复')
+    expect(html).not.toMatch(/<script\b/iu)
+  })
+
+  it('marks repair plans B and C as disabled and unavailable in the radio list', () => {
+    const html = renderDesktopStartupRecoveryHtml(viewModel())
+
+    expect(html).toContain('value="B" disabled')
+    expect(html).toContain('回滚子模块版本')
+    expect(html).toContain('value="C" disabled')
+    expect(html).toContain('重置插件加载清单')
+    expect(html).toContain('暂不可用')
+    expect(html).not.toContain('value="A" disabled')
+    expect(html).not.toContain('value="D" disabled')
+  })
+
+  it('never checks a disabled repair option even when it is preselected', () => {
+    const html = renderDesktopStartupRecoveryHtml(viewModel({
+      aiAnalysis: { selectedOption: 'B' },
+    }))
+
+    expect(html).toContain('value="B" disabled')
+    expect(html).not.toContain('value="B" checked')
+    expect(html).not.toContain('value="C" checked')
+  })
+
+  it('renders the analyzed root cause, risk badge, and self-check report', () => {
+    const html = renderDesktopStartupRecoveryHtml(viewModel({
+      aiAnalysis: {
+        selectedOption: 'A',
+        diagnosis: {
+          rootCause: '依赖解析失败：缺失模块 plugin-x。', severity: 'medium',
+          options: [], recommendation: '建议先尝试方案 A。', disclaimer: 'AI 辅助建议，仅供参考。',
+        },
+        selfCheck: { ok: true, checks: [{ name: 'core import', passed: true, detail: 'ok' }],
+          recommendation: '✅ 修复成功，点击【重新启动 DSH Desktop】生效。' },
+      },
+    }))
+    expect(html).toContain('缺失模块 plugin-x')
+    expect(html).toContain('medium')
+    expect(html).toContain('重新启动 DSH Desktop')
+  })
+
+  it('surfaces a restart CTA after a passing self-check', () => {
+    const html = renderDesktopStartupRecoveryHtml(viewModel({
+      restartReady: true,
+      aiAnalysis: { result: { planId: 'A', status: 'degraded', message: '已启用降级。' } },
+    }))
+    expect(html).toContain('dsh-recovery://restart')
+    expect(html).toContain('重新启动 DSH Desktop')
+  })
+
+  it('appends an in-card restart CTA when the post-repair self-check passed', () => {
+    const html = renderDesktopStartupRecoveryHtml(viewModel({
+      aiAnalysis: {
+        result: { planId: 'A', status: 'degraded', message: '已启用降级模式。' },
+        selfCheck: { ok: true, checks: [{ name: 'degraded bundle resolvable', passed: true, detail: 'resolved plugin-x' }],
+          recommendation: '✅ 修复成功，点击【重新启动 DSH Desktop】生效。' },
+      },
+    }))
+    expect((html.match(/dsh-recovery:\/\/restart/g) ?? []).length).toBeGreaterThanOrEqual(2)
   })
 })
 
@@ -344,6 +419,7 @@ describe('Desktop startup recovery action parser', () => {
       'open-profile-directory',
       'restart',
       'quit',
+      'ai-analyze',
     ]) {
       expect(parseDesktopStartupRecoveryAction(`dsh-recovery://${action}`)).toEqual({ action })
     }
@@ -360,6 +436,11 @@ describe('Desktop startup recovery action parser', () => {
         `dsh-recovery://${action}?id=opaque-id_0001`,
       )).toEqual({ action, id: 'opaque-id_0001' })
     }
+
+    expect(parseDesktopStartupRecoveryAction('dsh-recovery://execute-repair?option=A'))
+      .toEqual({ action: 'execute-repair', option: 'A' })
+    expect(parseDesktopStartupRecoveryAction('dsh-recovery://execute-repair?option=D'))
+      .toEqual({ action: 'execute-repair', option: 'D' })
   })
 
   it.each([
@@ -377,6 +458,11 @@ describe('Desktop startup recovery action parser', () => {
     'dsh-recovery://preview-disable?id=opaque-id_0001&id=opaque-id_0002',
     'dsh-recovery://preview-disable?id=opaque-id_0001&extra=value',
     `dsh-recovery://preview-disable?id=${'x'.repeat(161)}`,
+    'dsh-recovery://execute-repair',
+    'dsh-recovery://execute-repair?option=',
+    'dsh-recovery://execute-repair?option=A&option=B',
+    'dsh-recovery://execute-repair?option=A&extra=x',
+    'dsh-recovery://execute-repair?option=<xss>',
   ])('rejects invalid or over-privileged navigation: %s', href => {
     expect(parseDesktopStartupRecoveryAction(href)).toBeUndefined()
   })


### PR DESCRIPTION
## 概述 / Summary

修复「插件 / 子模块 / 依赖问题导致完全无法进入主页面」的故障恢复体验。

核心原则：**不能因插件、子模块兼容、依赖问题导致完全无法进入主页面。** 当必需插件加载失败时，用户现在可以一键「安全降级」跳过故障插件进入主页，而不是被困在恢复窗口；恢复窗口新增 AI 辅助分析，给出普通人能看懂的根因、风险与可执行的修复方案。

三条绑定约束全程落实：
1. **AI 只做分析与建议**，绝不自动修改本地配置 —— 写配置仅发生在用户点击【执行修复】后，由非 AI 的 `repair-plans.ts` 执行；
2. **降级模式明确提示 + 一键退出** —— 主窗显示「安全降级模式」气泡（忽略 / 立即恢复），一键恢复完整插件集并重启；
3. **原有全部旧功能完整保留** —— 禁用插件、编辑配置、导出诊断、回滚/重试、重启/退出均未改动，且通过既有测试套件验证。

## 改动点 / What changed

### 1. 安全降级模式（Safe degraded mode）—— 新增

| 文件 | 改动 |
|---|---|
| `src/degraded-mode.ts`（新） | `degraded.json` 持久化读写（版本化、原子写、容量上限） |
| `src/profile.ts` | patch 组合阶段读取 `degraded.json`，把降级 bundle 从各层 patch 剔除（复用 `omitUnresolvedOptionalEntries` 思路，不改上游 `boot()`） |
| `src/client/degraded-notice.ts`（新） | 主窗降级气泡文案（中/英，标题/正文/忽略/立即恢复） |
| `src/client/AdvancedFrame.tsx` + `src/client/styles.ts` | 右下角通知气泡 UI：`position:absolute; right/bottom:16px`，忽略不重启、立即恢复清空 degraded.json 并 relaunch |

降级档位与「永久禁用」严格分离：`degraded.json`（生成级、可逆）vs `plugin-management/state.json`（永久）。降级只作用于**非核心** bundle，核心行（最小健康集）故障时禁止降级，只能禁用/回滚/恢复配置，避免「降级了还是黑屏」。

### 2. 诊断包增强 —— 新增关键证据

`src/diagnostic-export-worker.ts` / `src/diagnostic-evidence.ts`（新）：
- `error-stack.txt`：完整报错堆栈（含 cause 链）
- `plugin-manifest.json`：插件加载树 / 清单
- `versions.json`：各子模块 commit 版本
- `profile-bundles.json`：当前插件清单
- `config/*`：受保护配置文件快照
- `env-snapshot.txt`：系统环境快照（复用 `mask-secrets.ts` 脱敏，仅白名单 key）

沿用 50MB 预算、脱敏、原子发布、保留 3 份。

### 3. AI 辅助故障分析 —— 新增（分层、永不阻塞）

| 文件 | 职责 |
|---|---|
| `src/diagnostic-analyzer.ts`（新） | **Tier 0** 确定性规则分析：堆栈解构 → 正则定位 `Cannot find module 'X'` → 中文根因 + 风险等级 + 方案列表（纯函数、无 IO、永不失败） |
| `src/ai-diagnostic-analyzer.ts`（新） | **Tier 1** 本地 DSH 独立 CLI 推理（`spawn` 只读模式，不加载桌面插件树），超时 15s / 失败静默降级 Tier 0，绝不阻塞恢复页 |
| `src/repair-plans.ts`（新） | 方案 A–D 注册表 + 风险 + `apply()`（**唯一写配置的地方**，非 AI 可执行） |
| `src/repair-self-check.ts`（新） | 修复后只读自检：插件树可加载 + 关键模块可 import，输出 `{ ok, checks, recommendation }` |
| `src/startup-recovery-controller.ts` | `runAiAnalysis()` / `executeRepair()` / `commitDegraded()` + single-flight + dispose 清理 |
| `src/startup-recovery-window.ts` | 新动作入总线白名单；AI 卡片 + radio 方案表单；`MAX_FAILURE_DETAIL_LENGTH` 上调容纳堆栈 |
| `src/native-ui/recovery/App.tsx` | **恢复窗口已迁移到 React SPA**（master 演进），将 AI 分析卡片 + 降级卡片移植进 React UI |

AI 能力为**分层设计**：Tier 0 规则兜底 → Tier 1 本地模型增强 → Tier 2 外部模型（可选，默认关闭）。即使模型完全不可用，恢复页也不会卡住。

UI：恢复窗口在 Diagnostics 卡片下新增【AI 辅助故障分析】卡片 —— 加载诊断 → 根因 + 风险 badge → 4 个修复方案 radio +【执行修复】→ 自检报告 ✅/❌ →【重新启动】闭环。主窗右下角新增降级通知气泡。

## 价值点 / Why it matters

1. **消除「进不去主页」的空窗**：故障时不再是死路，一键降级先进主页，功能逐步恢复；
   - `profile.ts:602-610` 读 `degraded.json` 将降级 bundle 剔除出 patch 组合，跳过故障插件进主页
   - `startup-recovery-window.ts:847-854` 恢复窗口 `restore-full-plugins`：清空降级集 + `finish('restart')`
   - `AdvancedFrame.tsx:112-130` 主窗右下角降级气泡 + `dsh-recovery://restart` 一键恢复
2. **降级可逆、语义清晰**：生成级降级 ≠ 永久禁用，气泡明确标注并一键退出；
   - `degraded-mode.ts:6-8` `degraded.json` 版本化、原子写（tmp+rename），与 `plugin-management/state.json` 分离
   - 降级档位每次启动重判、可逆；永久禁用才写 `state.json`
3. **AI 决策权在用户**：分析建议、人点确认、代码执行，三层分离，AI 零写配置；
   - `startup-recovery-controller.ts:504-510` `runAiAnalysis()` 只读，产出 `{ diagnosis }`，不写任何配置
   - `startup-recovery-controller.ts:467-489` `executeRepair(planId)` 仅在用户点【执行修复】后触发
   - `startup-recovery-window.ts:821-830` 窗口 handler 校验 `option` 后才调用 `executeRepair`
   - 写配置的唯一入口是非 AI 的 `repair-plans.ts#apply()`
4. **诊断信息充分**：一个 zip 拿到堆栈 / 插件树 / 子模块版本 / 配置 / 环境快照，排障不再靠猜；
   - `diagnostic-evidence.ts:9-38` `buildDiagnosticEvidenceEntries()` 产出 6 类证据（error-stack / plugin-manifest / versions / profile-bundles / config/* / env-snapshot）
   - `CONFIG_FILENAME` 白名单正则防路径穿越；env 快照走 `mask-secrets.ts` 脱敏
5. **分层 AI 永不阻塞**：无模型 / 无网络时规则兜底，恢复页始终可用；
   - `startup-recovery-controller.ts:507-508` `const tier1 = await runTierOneAnalysis(...)`；失败返回 `undefined`，`tier1 ?? analyzeDiagnostics(input)` 静默降级 Tier0
   - `ai-diagnostic-analyzer.ts:16-60` Tier1 独立 CLI：15s 超时、SIGKILL、吞 EPIPE，任何异常不阻塞恢复页
   - `analyzeDiagnostics` 为纯函数无 IO，规则兜底永不失败；Tier2 外部模型默认关闭

## 测试 / Verification

- `yarn typecheck` ✅ exit 0
- `yarn test` ✅ 84+19 文件，801+274 通过（新增 7 个测试文件 + 5 个增强，覆盖 degraded-mode / diagnostic-analyzer / ai-diagnostic-analyzer / repair-plans / repair-self-check / diagnostic-evidence / client degraded-notice）
- `yarn build` ✅ 含 native-ui React 打包
- 端到端验证 ✅ 种子 degraded.json → 主窗气泡渲染（标题/正文/忽略/立即恢复）→ 忽略不重启 → 立即恢复清空并 relaunch

## 兼容性说明

- 恢复窗口渲染路径随 master 演进迁移至 React SPA（`native-ui/recovery.html` + `App.tsx`），feature 的降级卡片与 AI 卡片已移植进 React UI；内联 HTML 渲染函数 `renderDesktopStartupRecoveryHtml` 保留供测试
- `prepareDesktopProfile` 签名新增可选 `degradedStatePath` 参数（与既有 `hooks` 参数并存，向后兼容）
- `electron-runtime.ts` 同时保留 master 的 `profileCreateWindow` 与 feature 的 `recoveryActionHandler`（互不冲突）
- 未触碰 `deepseek-harness/` 子模块、`@deepseek-ai/dsh-app-boot`、`src/startup-failure-routing.ts`