### PR TITLE
docs: 为生态项目表里的 dshfind 补充官网链接

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ Discord：[加入 DSH Desktop 社区](https://discord.gg/TJeGqKRNM)
 
 | 项目 | 简介 | 链接 |
 | --- | --- | --- |
-| dshfind | DeepSeek Harness（DSH）学习与分享社区。 | [GitHub](https://github.com/hikariming/dshfind) |
+| dshfind | DeepSeek Harness（DSH）学习与分享社区。 | [GitHub](https://github.com/hikariming/dshfind) · [官网](https://dshfind.com) |
 | DSH 1024Store | 面向 DeepSeek Harness（dsh）生态的社区插件目录（收录 4120 个插件），并开源了在线插件市场、目录流水线与公开查询 API，可 fork 自建市场。 | [GitHub](https://github.com/imsai-sh/awesome-deepseek-harness-plugins) |
 | Awesome DSH Plugin | DeepSeek Harness（DSH）插件精选列表。 | [GitHub](https://github.com/awesome-dsh-plugin/awesome-dsh-plugin) |
 | dsh-market | DeepSeek Harness 内的可视化插件市场，支持浏览、搜索与一键安装插件。 | [GitHub](https://github.com/dsh-market/dsh-market) |


### PR DESCRIPTION
生态项目表里 dshfind 那一行目前只有 GitHub 链接，补上官网 https://dshfind.com 。

格式与表内已有条目一致（ModLens、dsh-web-ui、Awesome DeepSeek Harness 都是 `[GitHub](…) · [官网](…)`），只改了这一行，没有其他改动。

```diff
-| dshfind | … | [GitHub](https://github.com/hikariming/dshfind) |
+| dshfind | … | [GitHub](https://github.com/hikariming/dshfind) · [官网](https://dshfind.com) |
```

我是 dshfind 的作者，感谢收录 🙏 简介那一栏我没有动，如果你觉得需要调整我再改。