### PR TITLE
fix: repair desktop package CI regressions

### DIFF
--- a/dsh-plugin-desktop/package.json
+++ b/dsh-plugin-desktop/package.json
@@ -331,6 +331,7 @@
       "!node_modules/node-addon-require-builtin-win32-{arm64,ia32}-msvc/**",
       "!node_modules/node-pty/build/**",
       "!node_modules/node-pty/prebuilds/!(${platform}-*)/**",
+      "!node_modules/node-pty/prebuilds/!(${platform}-${arch}|darwin-*)/**",
       "!node_modules/node-pty/third_party/**"
     ],
     "mac": {
@@ -360,9 +361,6 @@
       "format": "ULFO"
     },
     "win": {
-      "files": [
-        "!node_modules/node-pty/prebuilds/{win32-arm64,win32-ia32}/**"
-      ],
       "target": [
         {
           "target": "nsis",
@@ -389,9 +387,6 @@
       "artifactName": "DSH-Desktop-${version}-${arch}-Setup.${ext}"
     },
     "linux": {
-      "files": [
-        "!node_modules/node-pty/prebuilds/!(${platform}-${arch})/**"
-      ],
       "target": [
         {
           "target": "AppImage",

--- a/dsh-plugin-desktop/package.json
+++ b/dsh-plugin-desktop/package.json
@@ -330,7 +330,7 @@
       "!node_modules/@koromix/koffi-win32-{arm64,ia32}/**",
       "!node_modules/node-addon-require-builtin-win32-{arm64,ia32}-msvc/**",
       "!node_modules/node-pty/build/**",
-      "!node_modules/node-pty/prebuilds/!(${platform}-${arch})/**",
+      "!node_modules/node-pty/prebuilds/!(${platform}-*)/**",
       "!node_modules/node-pty/third_party/**"
     ],
     "mac": {
@@ -360,6 +360,9 @@
       "format": "ULFO"
     },
     "win": {
+      "files": [
+        "!node_modules/node-pty/prebuilds/{win32-arm64,win32-ia32}/**"
+      ],
       "target": [
         {
           "target": "nsis",
@@ -386,6 +389,9 @@
       "artifactName": "DSH-Desktop-${version}-${arch}-Setup.${ext}"
     },
     "linux": {
+      "files": [
+        "!node_modules/node-pty/prebuilds/!(${platform}-${arch})/**"
+      ],
       "target": [
         {
           "target": "AppImage",

--- a/dsh-plugin-desktop/src/module-resolution.ts
+++ b/dsh-plugin-desktop/src/module-resolution.ts
@@ -1,6 +1,7 @@
 /** Profile-relative package resolution for Electron's restricted Node runtime. */
 
 import Module, { registerHooks } from 'node:module'
+import { dirname } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import {
   findOverlayPackage,
@@ -44,14 +45,15 @@ function overlayParentUrl(source: 'install' | 'profile', profileBaseUrl: string)
  */
 export function installProfilePackageResolver(profileBaseUrl: string): () => void {
   const profileManifestPath = fileURLToPath(profileBaseUrl)
+  const profileDirectoryPath = dirname(profileManifestPath)
 
   // ClientModuleRegistry intentionally uses createRequire(ctx.baseUrl) to
   // resolve each browser bundle from the config tree. Node's ESM resolve hook
   // does not observe that CommonJS manifest lookup, so without this narrow
   // bridge the Loader can activate the Desktop copy while the browser receives
   // an older Profile copy of the same package. Intercept only exact package
-  // manifests requested from this Profile anchor; every other CJS resolution
-  // remains untouched.
+  // manifests requested from this Profile manifest or createRequire's noop.js
+  // directory anchor; every other CJS resolution remains untouched.
   const commonJsModule = Module as unknown as CommonJsModuleResolver
   const previousResolveFilename = commonJsModule._resolveFilename
   const overlayResolveFilename: CommonJsModuleResolver['_resolveFilename'] = function (
@@ -61,7 +63,9 @@ export function installProfilePackageResolver(profileBaseUrl: string): () => voi
     isMain,
     options,
   ) {
-    const packageName = parent?.filename === profileManifestPath
+    const fromProfileAnchor = parent?.filename === profileManifestPath
+      || (parent?.filename !== undefined && dirname(parent.filename) === profileDirectoryPath)
+    const packageName = fromProfileAnchor
       ? packageNameFromManifestSpecifier(request)
       : undefined
     if (packageName !== undefined) {

--- a/dsh-plugin-desktop/src/module-resolution.ts
+++ b/dsh-plugin-desktop/src/module-resolution.ts
@@ -83,8 +83,9 @@ export function installProfilePackageResolver(profileBaseUrl: string): () => voi
   const overlayModuleUrls = new Set<string>()
   const hooks = registerHooks({
     resolve(specifier, context, nextResolve) {
-      const fromLoader = context.parentURL === LOADER_ENTRY_URL
-      const packageName = fromLoader ? packageNameFromSpecifier(specifier) : undefined
+      const fromOverlayRoot = context.parentURL === LOADER_ENTRY_URL
+        || context.parentURL === profileBaseUrl
+      const packageName = fromOverlayRoot ? packageNameFromSpecifier(specifier) : undefined
       if (packageName !== undefined) {
         const overlay = resolveOverlayPackage(packageName, {
           installPackageUrl: DESKTOP_PACKAGE_URL,

--- a/dsh-plugin-desktop/tests/module-resolution.spec.ts
+++ b/dsh-plugin-desktop/tests/module-resolution.spec.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { join } from 'node:path'
+import { dirname, join } from 'node:path'
 import { tmpdir } from 'node:os'
 import { pathToFileURL } from 'node:url'
 
@@ -201,6 +201,11 @@ describe('installProfilePackageResolver', () => {
     expect(resolveFilename(
       '@deepseek-ai/dsh-client-modules/package.json',
       { filename: profileManifestPath },
+      false,
+    )).toBe('/install/@deepseek-ai/dsh-client-modules/package.json')
+    expect(resolveFilename(
+      '@deepseek-ai/dsh-client-modules/package.json',
+      { filename: join(dirname(profileManifestPath), 'noop.js') },
       false,
     )).toBe('/install/@deepseek-ai/dsh-client-modules/package.json')
     expect(resolveFilename(

--- a/dsh-plugin-desktop/tests/module-resolution.spec.ts
+++ b/dsh-plugin-desktop/tests/module-resolution.spec.ts
@@ -95,6 +95,14 @@ describe('installProfilePackageResolver', () => {
       specifier: 'dsh-plugin-desktop/profile',
       context: { parentURL: profileBaseUrl },
     })
+    expect(harness.resolve?.(
+      '@deepseek-ai/dsh-web-app',
+      { parentURL: profileBaseUrl },
+      nextResolve,
+    )).toEqual({
+      specifier: '@deepseek-ai/dsh-web-app',
+      context: { parentURL: expect.stringMatching(/\/lib\/index\.js$/u) },
+    })
     expect(harness.overlay).toHaveBeenCalledWith('@deepseek-ai/dsh-web-app', expect.any(Object))
     expect(harness.overlay).toHaveBeenCalledWith('dsh-plugin-desktop', expect.any(Object))
   })

--- a/dsh-plugin-desktop/tests/package.spec.ts
+++ b/dsh-plugin-desktop/tests/package.spec.ts
@@ -46,7 +46,7 @@ const manifest = JSON.parse(readFileSync(new URL('package.json', packageRoot), '
       x64ArchFiles?: unknown
     }
     dmg?: Record<string, unknown>
-    win?: { icon?: unknown; target?: unknown; artifactName?: unknown; compression?: unknown }
+    win?: { icon?: unknown; target?: unknown; artifactName?: unknown; compression?: unknown; files?: unknown }
     nsis?: Record<string, unknown>
     portable?: Record<string, unknown>
     linux?: Record<string, unknown>
@@ -610,7 +610,7 @@ describe('published package surface', () => {
       '!node_modules/@koromix/koffi-win32-{arm64,ia32}/**',
       '!node_modules/node-addon-require-builtin-win32-{arm64,ia32}-msvc/**',
       '!node_modules/node-pty/build/**',
-      '!node_modules/node-pty/prebuilds/!(${platform}-${arch})/**',
+      '!node_modules/node-pty/prebuilds/!(${platform}-*)/**',
       '!node_modules/node-pty/third_party/**',
     ])
     expect(manifest.build?.mac?.icon).toBe('build/app-icon-mac.png')
@@ -627,6 +627,9 @@ describe('published package surface', () => {
     }])
     expect(manifest.build?.win?.artifactName).toBe('DSH-Desktop-${version}-${arch}-Portable.${ext}')
     expect(manifest.build?.win?.compression).toBe('normal')
+    expect(manifest.build?.win?.files).toEqual([
+      '!node_modules/node-pty/prebuilds/{win32-arm64,win32-ia32}/**',
+    ])
     expect(manifest.build?.nsis).toEqual({
       license: 'THIRD_PARTY_NOTICES.md',
       oneClick: false,
@@ -641,6 +644,7 @@ describe('published package surface', () => {
       artifactName: 'DSH-Desktop-${version}-${arch}-Setup.${ext}',
     })
     expect(manifest.build?.linux).toEqual({
+      files: ['!node_modules/node-pty/prebuilds/!(${platform}-${arch})/**'],
       target: [
         { target: 'AppImage', arch: ['x64', 'arm64'] },
         { target: 'deb', arch: ['x64', 'arm64'] },

--- a/dsh-plugin-desktop/tests/package.spec.ts
+++ b/dsh-plugin-desktop/tests/package.spec.ts
@@ -46,7 +46,7 @@ const manifest = JSON.parse(readFileSync(new URL('package.json', packageRoot), '
       x64ArchFiles?: unknown
     }
     dmg?: Record<string, unknown>
-    win?: { icon?: unknown; target?: unknown; artifactName?: unknown; compression?: unknown; files?: unknown }
+    win?: { icon?: unknown; target?: unknown; artifactName?: unknown; compression?: unknown }
     nsis?: Record<string, unknown>
     portable?: Record<string, unknown>
     linux?: Record<string, unknown>
@@ -611,6 +611,7 @@ describe('published package surface', () => {
       '!node_modules/node-addon-require-builtin-win32-{arm64,ia32}-msvc/**',
       '!node_modules/node-pty/build/**',
       '!node_modules/node-pty/prebuilds/!(${platform}-*)/**',
+      '!node_modules/node-pty/prebuilds/!(${platform}-${arch}|darwin-*)/**',
       '!node_modules/node-pty/third_party/**',
     ])
     expect(manifest.build?.mac?.icon).toBe('build/app-icon-mac.png')
@@ -627,9 +628,6 @@ describe('published package surface', () => {
     }])
     expect(manifest.build?.win?.artifactName).toBe('DSH-Desktop-${version}-${arch}-Portable.${ext}')
     expect(manifest.build?.win?.compression).toBe('normal')
-    expect(manifest.build?.win?.files).toEqual([
-      '!node_modules/node-pty/prebuilds/{win32-arm64,win32-ia32}/**',
-    ])
     expect(manifest.build?.nsis).toEqual({
       license: 'THIRD_PARTY_NOTICES.md',
       oneClick: false,
@@ -644,7 +642,6 @@ describe('published package surface', () => {
       artifactName: 'DSH-Desktop-${version}-${arch}-Setup.${ext}',
     })
     expect(manifest.build?.linux).toEqual({
-      files: ['!node_modules/node-pty/prebuilds/!(${platform}-${arch})/**'],
       target: [
         { target: 'AppImage', arch: ['x64', 'arm64'] },
         { target: 'deb', arch: ['x64', 'arm64'] },


### PR DESCRIPTION
Fixes the CI regressions introduced by the desktop packaging changes: supports Profile package resolution from createRequire and direct Profile ESM anchors; preserves platform-specific node-pty prebuild filtering while retaining both Darwin architectures for universal packaging; and prevents source maps from being re-included by platform file overrides. Validated on the personal fork: https://github.com/zp-home/deepseek-harness-desktop/actions/runs/32612965453. The full check plus Windows, macOS, Linux, and upstream command jobs all passed. This PR does not push or merge directly to master; merge remains subject to company review.