### PR TITLE
feat(desktop): enable native directory picker on macOS

### DIFF
--- a/dsh-plugin-desktop/src/electron-platform.ts
+++ b/dsh-plugin-desktop/src/electron-platform.ts
@@ -46,7 +46,7 @@ class WindowsPlatformStrategy implements ElectronPlatformStrategy {
 class MacPlatformStrategy implements ElectronPlatformStrategy {
   readonly platform = 'darwin'
   readonly updateDownloadPlatform = 'darwin'
-  readonly canPickDirectory = false
+  readonly canPickDirectory = true
   readonly canToggleShellMode = true
 
   private applicationName: string | undefined


### PR DESCRIPTION
## Summary

Enable the native directory picker (`desktopRuntime.pickDirectory()`) on macOS by
flipping `MacPlatformStrategy.canPickDirectory` from `false` to `true`.

`dialog.showOpenDialog({ properties: ['openDirectory'] })` already works on macOS,
so this only opens up an existing capability that was previously Windows-only.

## Motivation

Third-party plugins that need the user to choose a local folder — for example, a
local ASR plugin asking where to install its model — currently can only offer that
picker on Windows. This change lets the same plugin present a native folder chooser
on macOS too.

## Changes

- `dsh-plugin-desktop/src/electron-platform.ts`: set `canPickDirectory = true` for
  the macOS platform strategy.