### PR TITLE
fix(desktop): keep long preset menus scrollable

### DIFF
--- a/dsh-plugin-desktop/tests/package.spec.ts
+++ b/dsh-plugin-desktop/tests/package.spec.ts
@@ -235,6 +235,23 @@ describe('published package surface', () => {
     expect(installedClient).toContain('data-dsh-workspace-drop-target')
   })
 
+  it('keeps long preset menus scrollable inside the viewport', () => {
+    const patchPath = './patches/dsh-client-ui-primitives@0.1.1-rc.2.patch'
+    expect(workspaceManifest.resolutions).toMatchObject({
+      '@deepseek-ai/dsh-client-ui-primitives@npm:0.1.1-rc.2': expect.stringContaining(patchPath),
+      '@deepseek-ai/dsh-client-ui-primitives@npm:^0.1.1-rc.2': expect.stringContaining(patchPath),
+    })
+    const patch = readFileSync(new URL(patchPath, workspaceRoot), 'utf8')
+    const installedStyles = readFileSync(new URL(
+      'node_modules/@deepseek-ai/dsh-client-ui-primitives/lib/Menu.module.css',
+      packageRoot,
+    ), 'utf8')
+    for (const styles of [patch, installedStyles]) {
+      expect(styles).toMatch(/\.scrollable\s*\{[^}]*overflow:\s*hidden;/su)
+      expect(styles).toMatch(/\.scrollable \.viewport\s*\{[^}]*flex:\s*1 1 auto;[^}]*overflow-y:\s*auto;/su)
+    }
+  })
+
   it('keeps API selection available after overriding a provider base URL', () => {
     const patchPath = './patches/dsh-client-ui-settings-models@0.1.1-rc.2.patch'
     expect(workspaceManifest.resolutions).toMatchObject({

--- a/package.json
+++ b/package.json
@@ -22,6 +22,8 @@
     "@deepseek-ai/dsh-sandbox-windows-acl@npm:^0.1.1-rc.2": "patch:@deepseek-ai/dsh-sandbox-windows-acl@npm%3A0.1.1-rc.2#./patches/dsh-sandbox-windows-acl@0.1.1-rc.2.patch",
     "@deepseek-ai/dsh-client-ui-directory-picker-browse@npm:0.1.1-rc.2": "patch:@deepseek-ai/dsh-client-ui-directory-picker-browse@npm%3A0.1.1-rc.2#./patches/dsh-client-ui-directory-picker-browse@0.1.1-rc.2.patch",
     "@deepseek-ai/dsh-client-ui-directory-picker-browse@npm:^0.1.1-rc.2": "patch:@deepseek-ai/dsh-client-ui-directory-picker-browse@npm%3A0.1.1-rc.2#./patches/dsh-client-ui-directory-picker-browse@0.1.1-rc.2.patch",
+    "@deepseek-ai/dsh-client-ui-primitives@npm:0.1.1-rc.2": "patch:@deepseek-ai/dsh-client-ui-primitives@npm%3A0.1.1-rc.2#./patches/dsh-client-ui-primitives@0.1.1-rc.2.patch",
+    "@deepseek-ai/dsh-client-ui-primitives@npm:^0.1.1-rc.2": "patch:@deepseek-ai/dsh-client-ui-primitives@npm%3A0.1.1-rc.2#./patches/dsh-client-ui-primitives@0.1.1-rc.2.patch",
     "@deepseek-ai/dsh-host-directory-picker-browse@npm:0.1.1-rc.2": "patch:@deepseek-ai/dsh-host-directory-picker-browse@npm%3A0.1.1-rc.2#./patches/dsh-host-directory-picker-browse@0.1.1-rc.2.patch",
     "@deepseek-ai/dsh-host-directory-picker-browse@npm:^0.1.1-rc.2": "patch:@deepseek-ai/dsh-host-directory-picker-browse@npm%3A0.1.1-rc.2#./patches/dsh-host-directory-picker-browse@0.1.1-rc.2.patch",
     "@deepseek-ai/dsh-client-ui-workspace@npm:0.1.1-rc.2": "patch:@deepseek-ai/dsh-client-ui-workspace@npm%3A0.1.1-rc.2#./patches/dsh-client-ui-workspace@0.1.1-rc.2.patch",

--- a/patches/dsh-client-ui-primitives@0.1.1-rc.2.patch
+++ b/patches/dsh-client-ui-primitives@0.1.1-rc.2.patch
@@ -1,0 +1,13 @@
+diff --git a/lib/Menu.module.css b/lib/Menu.module.css
+--- a/lib/Menu.module.css
++++ b/lib/Menu.module.css
+@@ -66,3 +66,4 @@
+ .scrollable {
+   max-height: calc(100vh - 24px);
++  overflow: hidden;
+ }
+@@ -76,3 +77,4 @@
+ .scrollable .viewport {
++  flex: 1 1 auto;
+   overflow-y: auto;
+ }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1802,6 +1802,37 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@deepseek-ai/dsh-client-ui-primitives@patch:@deepseek-ai/dsh-client-ui-primitives@npm%3A0.1.1-rc.2#./patches/dsh-client-ui-primitives@0.1.1-rc.2.patch::locator=deepseek-harness-desktop%40workspace%3A.":
+  version: 0.1.1-rc.2
+  resolution: "@deepseek-ai/dsh-client-ui-primitives@patch:@deepseek-ai/dsh-client-ui-primitives@npm%3A0.1.1-rc.2#./patches/dsh-client-ui-primitives@0.1.1-rc.2.patch::version=0.1.1-rc.2&hash=c971ce&locator=deepseek-harness-desktop%40workspace%3A."
+  dependencies:
+    "@shikijs/langs": "npm:^4.3.1"
+    "@types/mdast": "npm:^4.0.4"
+    anser: "npm:^2.3.5"
+    clsx: "npm:^2.0.0"
+    katex: "npm:^0.16.47"
+    mdast-util-from-markdown: "npm:^2.0.3"
+    mdast-util-gfm: "npm:^3.1.0"
+    mdast-util-math: "npm:^3.0.0"
+    micromark-core-commonmark: "npm:^2.0.3"
+    micromark-extension-gfm: "npm:^3.0.0"
+    micromark-extension-math: "npm:^3.1.0"
+    micromark-factory-space: "npm:^2.0.1"
+    micromark-util-character: "npm:^2.1.1"
+    micromark-util-classify-character: "npm:^2.0.1"
+    micromark-util-sanitize-uri: "npm:^2.0.1"
+    micromark-util-symbol: "npm:^2.0.1"
+    micromark-util-types: "npm:^2.0.2"
+    react: "npm:^18.2.0"
+    react-dom: "npm:^18.2.0"
+    shiki: "npm:^4.3.1"
+  peerDependencies:
+    "@deepseek-ai/cordis": ^4.0.1
+    "@deepseek-ai/dsh-invariants": ^0.1.1-rc.2
+  checksum: 10c0/3f17f56a224fff9e6ff2de75bba93386561189ff1208940ca29f43a8c284af3b4f63a12a8fbb798177808f988512d60f53a23ee2a8e57fcf45a27c5b347daff5
+  languageName: node
+  linkType: hard
+
 "@deepseek-ai/dsh-client-ui-reference@npm:^0.1.1-rc.2":
   version: 0.1.1-rc.2
   resolution: "@deepseek-ai/dsh-client-ui-reference@npm:0.1.1-rc.2"


### PR DESCRIPTION
## Summary / 摘要

- Patch the shipped UI primitives menu so a viewport-constrained menu clips its outer container and lets the viewport shrink and scroll.
- Add a regression contract covering both dependency resolutions, the Yarn patch, and the installed stylesheet.
- Keep the pinned `deepseek-harness/` submodule and submenu behavior unchanged.

## Related Issues / 关联 Issue

Fixes #502

## Type / 类型

- [x] Bug fix / 问题修复
- [ ] Feature / 新功能
- [ ] Documentation / 文档
- [ ] Release or packaging / 发布或打包
- [ ] Tests only / 仅测试
- [ ] Other / 其他

## Platforms / 影响平台

- [ ] Windows installer / Windows 安装包
- [ ] Windows portable ZIP / Windows 便携版 ZIP
- [ ] macOS Apple Silicon
- [ ] macOS Intel
- [ ] macOS Universal package / macOS 通用安装包
- [ ] Linux
- [x] Not platform-specific / 与平台无关

## Verification / 验证

- [x] `corepack yarn check:layout`
- [x] `corepack yarn typecheck`
- [ ] `corepack yarn test`
- [ ] `corepack yarn check`
- [ ] Platform package smoke / 平台打包或启动冒烟
- [ ] Manual test / 人工测试

Additional results:

- `corepack yarn workspace dsh-plugin-desktop vitest run tests/package.spec.ts` (33 passed)
- `corepack yarn install --immutable` (passed)
- `corepack yarn check` completed layout, build, typecheck, and all 274 Market tests; Desktop reported 756 passed, 11 skipped, and 7 failures because this Windows environment cannot create test symlinks (`EPERM`).

## Risk

- The patch applies only to menus already marked `.scrollable`; submenu menus retain their existing overflow behavior.
- The regression test verifies the patched installed CSS so a dependency-resolution change fails visibly.

## Release Notes / 发布说明

Agent preset menus with more options remain inside the window and can be scrolled to reach every preset.