### PR TITLE
fix(desktop): keep Windows caption draggable after scrolling

### DIFF
--- a/dsh-plugin-desktop/src/client/AdvancedFrame.tsx
+++ b/dsh-plugin-desktop/src/client/AdvancedFrame.tsx
@@ -106,7 +106,6 @@ export function AdvancedFrame({ layout, platform, renderSlot, useSessions }: Adv
       style={{ gridTemplateColumns: `${columns.sidebar}px minmax(0, 1fr) ${columns.details}px` }}
     >
       {platform === 'darwin' && <div className="dshDesktopMacCaptionRow" aria-hidden="true" />}
-      {platform === 'win32' && <div className="dshDesktopWindowsCaptionRow" aria-hidden="true" />}
       <aside className="dshDesktopSidebarSurface">
         <div className="dshDesktopUpstreamSidebar">
           {renderSlot('sidebar', { collapsed, width: sidebarOwnerWidth })}
@@ -114,6 +113,9 @@ export function AdvancedFrame({ layout, platform, renderSlot, useSessions }: Adv
       </aside>
       <main className="dshDesktopConversationSurface">{renderSlot('conversation', {})}</main>
       <aside className="dshDesktopDetailsSurface">{renderSlot('details', {})}</aside>
+      {/* Electron resolves app regions in DOM order. Keep this after upstream content
+          and before desktop-owned overlays. */}
+      {platform === 'win32' && <div className="dshDesktopWindowsCaptionRow" aria-hidden="true" />}
       <div className="dshDesktopOverlay" data-shell-overlay>
         {renderSlot('shell.overlay', {})}
       </div>

--- a/dsh-plugin-desktop/tests/client-environment.spec.ts
+++ b/dsh-plugin-desktop/tests/client-environment.spec.ts
@@ -1,3 +1,4 @@
+import { readFileSync } from 'node:fs'
 import { describe, expect, it, vi } from 'vitest'
 import type { ClientContext } from '@deepseek-ai/dsh-client-runtime/client'
 import { apply } from '../src/client/index.ts'
@@ -102,6 +103,19 @@ describe('advanced desktop layout', () => {
     finally {
       vi.unstubAllGlobals()
     }
+  })
+
+  it('orders the Windows drag region after scrollable content and before overlays', () => {
+    const frame = readFileSync(new URL('../src/client/AdvancedFrame.tsx', import.meta.url), 'utf8')
+    const conversation = frame.indexOf('className="dshDesktopConversationSurface"')
+    const details = frame.indexOf('className="dshDesktopDetailsSurface"')
+    const caption = frame.indexOf('className="dshDesktopWindowsCaptionRow"')
+    const overlay = frame.indexOf('className="dshDesktopOverlay"')
+
+    expect([conversation, details, caption, overlay]).not.toContain(-1)
+    expect(caption).toBeGreaterThan(conversation)
+    expect(caption).toBeGreaterThan(details)
+    expect(caption).toBeLessThan(overlay)
   })
 
   it('releases the Cordis layout service with its owning effect', () => {


### PR DESCRIPTION
## Summary / 摘要

- Move the Windows caption drag annotation after the upstream conversation and details surfaces so their scrolled `no-drag` descendants cannot override it in Electron's DOM-order region collection.
- Keep the caption before Desktop overlays and resize handles so interactive Desktop-owned controls retain precedence.
- Add a regression contract for the required DOM order without relying on ineffective `z-index` behavior.

## Related Issues / 关联 Issue

Fixes #495

## Type / 类型

- [x] Bug fix / 问题修复
- [ ] Feature / 新功能
- [ ] Documentation / 文档
- [ ] Release or packaging / 发布或打包
- [ ] Tests only / 仅测试
- [ ] Other / 其他

## Platforms / 影响平台

- [x] Windows installer / Windows 安装包
- [x] Windows portable ZIP / Windows 便携版 ZIP
- [ ] macOS Apple Silicon
- [ ] macOS Intel
- [ ] macOS Universal package / macOS 通用安装包
- [ ] Linux
- [ ] Not platform-specific / 与平台无关

## Verification / 验证

- [x] `corepack yarn check:layout`
- [x] `corepack yarn typecheck`
- [ ] `corepack yarn test`
- [ ] `corepack yarn check`
- [ ] Platform package smoke / 平台打包或启动冒烟
- [ ] Manual test / 人工测试

Additional results:

- `corepack yarn workspace dsh-plugin-desktop vitest run tests/client-environment.spec.ts` (12 passed)
- `corepack yarn check` completed layout, build, typecheck, and all 274 Market tests; Desktop reported 756 passed, 11 skipped, and 7 failures because this Windows environment cannot create test symlinks (`EPERM`).

## Risk

- The change only reorders the Windows caption node; its geometry and native-control inset are unchanged.
- Modal and Desktop overlay `no-drag` behavior remains later in DOM order, while the macOS caption path is untouched.

## Release Notes / 发布说明

The Windows title-bar drag area remains draggable after scrolling a long conversation.