### PR TITLE
fix(desktop): defer to upstream layout service instead of failing apply

### DIFF
--- a/dsh-plugin-desktop/src/client/advanced-shell.ts
+++ b/dsh-plugin-desktop/src/client/advanced-shell.ts
@@ -4,21 +4,39 @@ import type {} from './contracts.ts'
 import type { DesktopClientEnvironment } from './environment.ts'
 import { AdvancedFrame } from './AdvancedFrame.tsx'
 import { DesktopLayoutState } from './layout-state.ts'
-import { provideDesktopLayout } from './layout-service.ts'
+import { claimDesktopLayout } from './layout-service.ts'
 import { installDesktopOwnedStyles } from './styles.ts'
 import { DesktopThemePresenter } from './theme-presenter.ts'
 
-/** Own the enhanced layout and root slot without installing an independent frame. */
+/**
+ * Own the enhanced layout and root slot without installing an independent frame.
+ *
+ * When the upstream `dsh-client-ui-layout` wins the shared `layout` service,
+ * this shell keeps only its mode markers (owned by a dedicated cleanup effect)
+ * and leaves presentation — root slot, theme presenter, and desktop-owned
+ * chrome — entirely to upstream (#517).
+ */
 export function applyAdvancedShell(ctx: ClientContext, environment: DesktopClientEnvironment): void {
   if (environment.mode !== 'advanced') {
     throw new Error(`dsh-plugin-desktop: advanced shell received mode ${JSON.stringify(environment.mode)}`)
   }
 
   const desktopLayout = new DesktopLayoutState()
-  ctx.effect(
-    () => provideDesktopLayout(ctx, desktopLayout),
-    'desktop: layout service',
-  )
+  const upstreamOwnsLayout = !claimDesktopLayout(ctx, desktopLayout)
+
+  if (upstreamOwnsLayout) {
+    ctx.effect(() => {
+      document.body.dataset.dshDesktopMode = 'advanced'
+      document.body.dataset.dshDesktopPlatform = environment.platform
+      document.body.dataset.dshDesktopMaterial = environment.material
+      return () => {
+        delete document.body.dataset.dshDesktopMode
+        delete document.body.dataset.dshDesktopPlatform
+        delete document.body.dataset.dshDesktopMaterial
+      }
+    }, 'desktop: advanced shell markers')
+    return
+  }
 
   ctx.effect(() => {
     document.body.dataset.dshDesktopMode = 'advanced'

--- a/dsh-plugin-desktop/src/client/apply-guard.ts
+++ b/dsh-plugin-desktop/src/client/apply-guard.ts
@@ -1,0 +1,42 @@
+import type { DesktopClientEnvironment } from './environment.ts'
+
+/**
+ * Whether a previous application of this entry still owns the page.
+ *
+ * The mode markers are claimed synchronously at `apply()` entry and cleared on
+ * failure, so any value here means another fiber's shell (advanced, extended,
+ * or framed) is alive. Re-application while it stands would stack a second
+ * frame over the live one, so the guard degrades to a no-op instead — the
+ * loader may restart this entry freely and the stale fiber keeps presenting
+ * until its own cleanup runs.
+ */
+export function isDesktopShellAlreadyApplied(doc: Document): boolean {
+  return doc.body.dataset.dshDesktopMode !== undefined
+}
+
+/**
+ * Claim the mode markers synchronously for one entry application.
+ *
+ * Plain writes on purpose: effect scheduling is asynchronous, which would
+ * leave a re-entry window between two `apply()` calls. Every shell effect
+ * re-sets these markers inside its own lifetime and owns their cleanup; this
+ * early claim only closes the concurrency window.
+ */
+export function claimDesktopEntryMarkers(doc: Document, environment: DesktopClientEnvironment): void {
+  doc.body.dataset.dshDesktopMode = environment.mode
+  doc.body.dataset.dshDesktopPlatform = environment.platform
+  doc.body.dataset.dshDesktopMaterial = environment.material
+}
+
+/**
+ * Roll the claimed markers back after a failed startup.
+ *
+ * Any step of the registration walk can throw; a marker left behind then
+ * would make `isDesktopShellAlreadyApplied` swallow every loader restart of
+ * this entry until a full page reload (#517).
+ */
+export function clearDesktopEntryMarkers(doc: Document): void {
+  delete doc.body.dataset.dshDesktopMode
+  delete doc.body.dataset.dshDesktopPlatform
+  delete doc.body.dataset.dshDesktopMaterial
+}

--- a/dsh-plugin-desktop/src/client/extended-shell.ts
+++ b/dsh-plugin-desktop/src/client/extended-shell.ts
@@ -15,17 +15,22 @@ import type { DesktopClientEnvironment } from './environment.ts'
 import { DesktopFrameTitlebar } from './ExtendedTitlebar.tsx'
 import { installExtendedStyles } from './extended-styles.ts'
 import { DesktopLayoutState } from './layout-state.ts'
-import { provideDesktopLayout } from './layout-service.ts'
+import { claimDesktopLayout } from './layout-service.ts'
 import { installDesktopOwnedStyles } from './styles.ts'
 import { DesktopThemePresenter } from './theme-presenter.ts'
 
-/** Own the extended root/sidebar surface without reusing enhanced-mode chrome. */
-function applyExtendedOwnedShell(ctx: ClientContext, environment: DesktopClientEnvironment): void {
+/**
+ * Own the extended root/sidebar surface without reusing enhanced-mode chrome.
+ *
+ * When the upstream `dsh-client-ui-layout` wins the shared `layout` service,
+ * the owned presentation (layout, owned styles, presenter, root slot) is
+ * skipped and `false` returned; the independent framed chrome can still be
+ * layered over the upstream frame by the caller (#517).
+ */
+function applyExtendedOwnedShell(ctx: ClientContext, environment: DesktopClientEnvironment): boolean {
   const desktopLayout = new DesktopLayoutState()
-  ctx.effect(
-    () => provideDesktopLayout(ctx, desktopLayout),
-    'desktop: extended layout service',
-  )
+  const upstreamOwnsLayout = !claimDesktopLayout(ctx, desktopLayout)
+  if (upstreamOwnsLayout) return false
 
   ctx.effect(
     () => installDesktopOwnedStyles(),
@@ -52,6 +57,8 @@ function applyExtendedOwnedShell(ctx: ClientContext, environment: DesktopClientE
     },
     inject: () => ({ layout: desktopLayout, platform: environment.platform }),
   }, ExtendedFrame), 'desktop: extended root slot')
+
+  return true
 }
 
 export function applyFramedShell(
@@ -107,6 +114,8 @@ export function applyExtendedShell(
   if (environment.mode !== 'extended') {
     throw new Error(`dsh-plugin-desktop: extended shell received mode ${JSON.stringify(environment.mode)}`)
   }
+  // Losing the layout race only drops the owned presentation; the framed
+  // chrome (titlebar overlay) still layers over whatever presents the root.
   applyExtendedOwnedShell(ctx, environment)
   applyFramedShell(ctx, environment, settingsControl)
 }

--- a/dsh-plugin-desktop/src/client/index.ts
+++ b/dsh-plugin-desktop/src/client/index.ts
@@ -6,6 +6,11 @@ import type {} from '@deepseek-ai/dsh-client-ui-settings/client'
 import type {} from '@deepseek-ai/dsh-client-ui-theme/client'
 import type {} from '@deepseek-ai/dsh-client-ui-renderer/client'
 import { applyAdvancedShell } from './advanced-shell.ts'
+import {
+  claimDesktopEntryMarkers,
+  clearDesktopEntryMarkers,
+  isDesktopShellAlreadyApplied,
+} from './apply-guard.ts'
 import { startRendererBootReporter } from './boot-health.ts'
 import { applyDesktopSettings } from './desktop-settings.ts'
 import { installDesktopDirectoryPickerBridge, requestDesktopDirectoryValidation } from './directory-picker.ts'
@@ -78,38 +83,59 @@ export const inject = [
   'uiRenderer',
 ]
 
-/** Register desktop-owned client surfaces for the current BrowserWindow mode. @param ctx - browser Cordis context. */
+/**
+ * Register desktop-owned client surfaces for the current BrowserWindow mode.
+ *
+ * The mode markers are claimed synchronously before any effect walks, so a
+ * concurrent application observes the guard immediately; every registration
+ * step runs inside one try block and any failure clears the markers again —
+ * a stale marker would otherwise make the idempotency guard swallow every
+ * loader restart of this entry until the page is fully reloaded (#517).
+ * @param ctx - browser Cordis context.
+ */
 export function apply(ctx: ClientContext): void {
   const environment = parseDesktopClientEnvironment(window.location.search)
   if (!environment) return
-  ctx.effect(
-    () => provideDesktopWindow(ctx, desktopWindowService(environment)),
-    'dsh-plugin-desktop: native window geometry service',
-  )
-  const desktopSettings = applyDesktopSettings(ctx, environment)
-  ctx.effect(
-    () => startRendererBootReporter(ctx.loader),
-    'dsh-plugin-desktop: renderer boot health report',
-  )
-  ctx.effect(
-    () => installWorkspaceFolderDrop({
-      create: input => ctx.workspaces.create(input),
-      startSession: workspaceId => { ctx.workspaces.startSession(workspaceId) },
-      ...(environment.platform === 'win32'
-        ? { validateDirectory: (path: string) => requestDesktopDirectoryValidation(path) }
-        : {}),
-    }),
-    'dsh-plugin-desktop: workspace folder drop',
-  )
-  if (environment.platform === 'win32') {
-    ctx.effect(
-      () => installDesktopDirectoryPickerBridge(),
-      'dsh-plugin-desktop: native directory picker bridge',
-    )
+  if (isDesktopShellAlreadyApplied(document)) {
+    console.warn(`dsh-plugin-desktop: shell already applied for mode ${document.body.dataset.dshDesktopMode}; skipping re-application`)
+    return
   }
-  if (environment.mode === 'advanced') applyAdvancedShell(ctx, environment)
-  if (environment.mode === 'extended') applyExtendedShell(ctx, environment, desktopSettings)
-  if (environment.platform !== 'linux' && environment.mode === 'compatibility') {
-    applyFramedShell(ctx, environment, desktopSettings)
+  // Synchronous plain writes: effect scheduling is asynchronous, which would
+  // leave a re-entry window between apply() calls.
+  claimDesktopEntryMarkers(document, environment)
+  try {
+    ctx.effect(
+      () => provideDesktopWindow(ctx, desktopWindowService(environment)),
+      'dsh-plugin-desktop: native window geometry service',
+    )
+    const desktopSettings = applyDesktopSettings(ctx, environment)
+    ctx.effect(
+      () => startRendererBootReporter(ctx.loader),
+      'dsh-plugin-desktop: renderer boot health report',
+    )
+    ctx.effect(
+      () => installWorkspaceFolderDrop({
+        create: input => ctx.workspaces.create(input),
+        startSession: workspaceId => { ctx.workspaces.startSession(workspaceId) },
+        ...(environment.platform === 'win32'
+          ? { validateDirectory: (path: string) => requestDesktopDirectoryValidation(path) }
+          : {}),
+      }),
+      'dsh-plugin-desktop: workspace folder drop',
+    )
+    if (environment.platform === 'win32') {
+      ctx.effect(
+        () => installDesktopDirectoryPickerBridge(),
+        'dsh-plugin-desktop: native directory picker bridge',
+      )
+    }
+    if (environment.mode === 'advanced') applyAdvancedShell(ctx, environment)
+    if (environment.mode === 'extended') applyExtendedShell(ctx, environment, desktopSettings)
+    if (environment.platform !== 'linux' && environment.mode === 'compatibility') {
+      applyFramedShell(ctx, environment, desktopSettings)
+    }
+  } catch (cause) {
+    clearDesktopEntryMarkers(document)
+    throw cause
   }
 }

--- a/dsh-plugin-desktop/src/client/layout-service.ts
+++ b/dsh-plugin-desktop/src/client/layout-service.ts
@@ -3,12 +3,33 @@ import type {} from './contracts.ts'
 import type { DesktopLayoutState } from './layout-state.ts'
 
 /**
- * Provide the Desktop-owned layout service for one plugin-fiber lifetime.
+ * Try to take ownership of the process-wide `layout` service.
+ *
+ * Harness 0.1.1-rc.* ships `dsh-client-ui-layout`, which registers the same
+ * shared service for its own presentation. When that owner wins the race,
+ * taking a root slot anyway would stack a second frame over the upstream one
+ * and the duplicate registration would fail the whole entry — rolling back
+ * every installed effect, styles included (#517). Losing the race therefore
+ * degrades to `false`: the caller keeps mode markers but leaves presentation
+ * upstream.
+ *
+ * Ownership is detected through the `provide` failure itself — reading the
+ * store (`reflect.get`) would create a cross-fiber trace dependency during
+ * application, which deadlocks the page.
  * @param ctx - active browser Cordis context.
  * @param layout - desktop-owned layout implementation.
- * @returns disposer for the service registration.
+ * @returns whether this fiber now owns the service.
  */
-export function provideDesktopLayout(ctx: ClientContext, layout: DesktopLayoutState): () => void {
-  const dispose = ctx.reflect.provide('layout', layout)
-  return () => { void dispose() }
+export function claimDesktopLayout(ctx: ClientContext, layout: DesktopLayoutState): boolean {
+  try {
+    const dispose = ctx.reflect.provide('layout', layout)
+    // Cordis uses the factory result as the uninstall disposer, so the factory
+    // must return it — a void-returning factory fails the SyncEffect overload.
+    ctx.effect(() => () => { void dispose() }, 'desktop: layout service')
+    return true
+  } catch (cause) {
+    if (!(cause instanceof Error) || !cause.message.includes('has been registered')) throw cause
+    console.warn('dsh-plugin-desktop: layout service owned by upstream dsh-client-ui-layout; deferring to it')
+    return false
+  }
 }

--- a/dsh-plugin-desktop/tests/client-environment.spec.ts
+++ b/dsh-plugin-desktop/tests/client-environment.spec.ts
@@ -4,7 +4,7 @@ import type { ClientContext } from '@deepseek-ai/dsh-client-runtime/client'
 import { apply } from '../src/client/index.ts'
 import { AdvancedFrame } from '../src/client/AdvancedFrame.tsx'
 import { applyAdvancedShell } from '../src/client/advanced-shell.ts'
-import { provideDesktopLayout } from '../src/client/layout-service.ts'
+import { claimDesktopLayout } from '../src/client/layout-service.ts'
 import { parseDesktopClientEnvironment } from '../src/client/environment.ts'
 import { ExtendedFrame } from '../src/client/ExtendedFrame.tsx'
 import { applyExtendedShell, applyFramedShell } from '../src/client/extended-shell.ts'
@@ -144,6 +144,7 @@ describe('advanced desktop layout', () => {
 
   it('releases the Cordis layout service with its owning effect', () => {
     let disposed = false
+    let uninstall: unknown
     const ctx = {
       reflect: {
         provide: (name: string, value: unknown) => {
@@ -152,11 +153,15 @@ describe('advanced desktop layout', () => {
           return () => { disposed = true }
         },
       },
+      // Cordis runs the factory eagerly and registers its result as the
+      // fiber-owned uninstaller; capture that result the same way.
+      effect: (factory: () => unknown) => { uninstall = factory() },
     } as unknown as ClientContext
 
-    const dispose = provideDesktopLayout(ctx, new DesktopLayoutState())
+    expect(claimDesktopLayout(ctx, new DesktopLayoutState())).toBe(true)
     expect(disposed).toBe(false)
-    dispose()
+    expect(typeof uninstall).toBe('function')
+    ;(uninstall as () => void)()
     expect(disposed).toBe(true)
   })
 

--- a/dsh-plugin-desktop/tests/client-layout-service.spec.ts
+++ b/dsh-plugin-desktop/tests/client-layout-service.spec.ts
@@ -1,0 +1,251 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import {
+  claimDesktopEntryMarkers,
+  clearDesktopEntryMarkers,
+  isDesktopShellAlreadyApplied,
+} from '../src/client/apply-guard.ts'
+import { claimDesktopLayout } from '../src/client/layout-service.ts'
+import { applyAdvancedShell } from '../src/client/advanced-shell.ts'
+import { applyExtendedShell } from '../src/client/extended-shell.ts'
+
+interface FakeStyleElement {
+  id: string
+  name: string
+  textContent: string
+  dataset: Record<string, string>
+  isConnected: boolean
+  content: string
+  remove(): void
+}
+
+function stubDocument() {
+  const byId = new Map<string, FakeStyleElement>()
+  const dataset: Record<string, string | undefined> = {}
+  const rootViewport = { id: 'root', dataset: {} as Record<string, string | undefined> }
+  const fakeDocument = {
+    getElementById: (id: string) => {
+      if (id === 'root') return rootViewport
+      return byId.get(id) ?? null
+    },
+    head: {
+      appendChild(child: FakeStyleElement): void {
+        byId.set(child.id, child)
+      },
+    },
+    createElement: (_tag: string): FakeStyleElement => ({
+      id: '',
+      name: '',
+      textContent: '',
+      dataset: {},
+      isConnected: true,
+      content: '',
+      remove() { byId.delete(this.id) },
+    }),
+    body: {
+      dataset,
+      style: { setProperty() {}, removeProperty() {} },
+      setAttribute() {},
+      removeAttribute() {},
+    },
+    documentElement: { style: { colorScheme: '', removeProperty() {}, setProperty() {} } },
+  }
+  vi.stubGlobal('document', fakeDocument)
+  vi.stubGlobal('getComputedStyle', () => ({ backgroundColor: 'rgb(0, 0, 0)' }))
+  return { byId, dataset }
+}
+
+function makeCtx() {
+  return {
+    reflect: { provide: vi.fn(), get: vi.fn() },
+    // Cordis runs effect factories eagerly during the apply walk — mirror
+    // that here so registration assertions observe real calls.
+    effect: vi.fn((factory: () => unknown) => factory()),
+    slots: {
+      register: vi.fn(() => ({})),
+      inject: vi.fn(),
+    },
+    theme: { getTheme: vi.fn(() => ({ active: { colorScheme: 'light', tokens: {} } })) },
+    on: vi.fn(() => () => {}),
+  }
+}
+
+/** Extract the first registered effect factory under `noUncheckedIndexedAccess`. */
+function firstEffect(effect: ReturnType<typeof vi.fn>): () => () => void {
+  const call = effect.mock.calls[0]?.[0]
+  if (typeof call !== 'function') throw new Error('expected one registered effect factory')
+  return call as () => () => void
+}
+
+afterEach(() => { vi.unstubAllGlobals() })
+
+describe('entry marker guard', () => {
+  it('treats any live mode marker as an already-applied signal', () => {
+    const doc = () => ({ body: { dataset: { dshDesktopMode: 'advanced' } } }) as unknown as Document
+    expect(isDesktopShellAlreadyApplied(doc())).toBe(true)
+    expect(isDesktopShellAlreadyApplied({ body: { dataset: { dshDesktopMode: 'extended' } } } as unknown as Document)).toBe(true)
+    expect(isDesktopShellAlreadyApplied({ body: { dataset: { dshDesktopMode: 'compatibility' } } } as unknown as Document)).toBe(true)
+    expect(isDesktopShellAlreadyApplied({ body: { dataset: {} } } as unknown as Document)).toBe(false)
+  })
+
+  it('rolls claimed markers back when a startup step fails midway', () => {
+    const { dataset } = stubDocument()
+    const environment = { mode: 'advanced', platform: 'win32', material: 'off', micaSupported: false, version: '2.0.2' }
+
+    claimDesktopEntryMarkers(document, environment as never)
+
+    // The synchronous claim is what closes the re-entry window between two
+    // apply() calls — it must be visible before any registration step runs.
+    expect(dataset.dshDesktopMode).toBe('advanced')
+    expect(dataset.dshDesktopPlatform).toBe('win32')
+
+    try {
+      throw new Error('startup failed')
+    } catch (cause) {
+      clearDesktopEntryMarkers(document)
+      expect(cause).toBeInstanceOf(Error)
+    }
+
+    // A stale marker would make the guard swallow every loader restart of
+    // this entry until a full page reload — they must go.
+    expect(dataset.dshDesktopMode).toBeUndefined()
+    expect(dataset.dshDesktopPlatform).toBeUndefined()
+    expect(dataset.dshDesktopMaterial).toBeUndefined()
+  })
+})
+
+describe('claimDesktopLayout', () => {
+  it('wins ownership when nothing else registered the service', () => {
+    const ctx = makeCtx()
+    const dispose = vi.fn()
+    ctx.reflect.provide.mockReturnValue(dispose)
+    const layout = { mark: 'state' }
+
+    expect(claimDesktopLayout(ctx as never, layout as never)).toBe(true)
+    expect(ctx.reflect.provide).toHaveBeenCalledWith('layout', layout)
+
+    // The disposal effect must be owned by the fiber so a later unload frees
+    // the registration for whoever applies next; the factory result is what
+    // cordis registers for uninstall.
+    expect(ctx.effect).toHaveBeenCalledWith(expect.any(Function), 'desktop: layout service')
+    const disposer = firstEffect(ctx.effect)()
+    disposer()
+    expect(dispose).toHaveBeenCalled()
+  })
+
+  it('defers safely when another entry already owns the service', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    try {
+      const ctx = makeCtx()
+      ctx.reflect.provide.mockImplementation(() => {
+        throw new Error('service "layout" has been registered at <z5>')
+      })
+      expect(claimDesktopLayout(ctx as never, {} as never)).toBe(false)
+      // No disposal effect may be registered for an ownership we never took.
+      expect(ctx.effect).not.toHaveBeenCalled()
+      expect(warn).toHaveBeenCalled()
+    } finally {
+      warn.mockRestore()
+    }
+  })
+
+  it('rethrows unrelated registration failures', () => {
+    const ctx = makeCtx()
+    ctx.reflect.provide.mockImplementation(() => {
+      throw new TypeError('cannot read properties of undefined')
+    })
+    expect(() => claimDesktopLayout(ctx as never, {} as never)).toThrow(TypeError)
+  })
+})
+
+function environmentFor(mode: 'advanced' | 'extended') {
+  return { mode, platform: 'win32', material: 'off', micaSupported: false, version: '2.0.2' }
+}
+
+describe('applyAdvancedShell presentation ownership', () => {
+  it('owns presentation when the layout race is won', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    try {
+      stubDocument()
+      const ctx = makeCtx()
+      ctx.reflect.provide.mockReturnValue(vi.fn())
+
+      applyAdvancedShell(ctx as never, environmentFor('advanced') as never)
+
+      // layout service + owned styles/markers + theme presenter + root slot
+      expect(ctx.effect).toHaveBeenCalledTimes(4)
+      expect(ctx.slots.register).toHaveBeenCalledTimes(1)
+      expect(warn).not.toHaveBeenCalled()
+    } finally {
+      warn.mockRestore()
+    }
+  })
+
+  it('defers presentation to upstream when the race is lost, keeping only markers', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    try {
+      const { dataset } = stubDocument()
+      const ctx = makeCtx()
+      ctx.reflect.provide.mockImplementation(() => {
+        throw new Error('service "layout" has been registered at <z5>')
+      })
+
+      applyAdvancedShell(ctx as never, environmentFor('advanced') as never)
+
+      // Upstream keeps presenting: no root slot takeover, no presenter, and
+      // none of the desktop-owned chrome styles — just the mode markers,
+      // whose cleanup still runs through their own fiber effect.
+      expect(ctx.slots.register).not.toHaveBeenCalled()
+      expect(ctx.effect).toHaveBeenCalledTimes(1)
+      const cleanup = firstEffect(ctx.effect)()
+      cleanup()
+      expect(dataset.dshDesktopMode).toBeUndefined()
+      expect(dataset.dshDesktopPlatform).toBeUndefined()
+      expect(warn).toHaveBeenCalled()
+    } finally {
+      warn.mockRestore()
+    }
+  })
+})
+
+describe('applyExtendedShell presentation ownership', () => {
+  it('owns the extended presentation and frames it when the race is won', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    try {
+      stubDocument()
+      const ctx = makeCtx()
+      ctx.reflect.provide.mockReturnValue(vi.fn())
+
+      applyExtendedShell(ctx as never, environmentFor('extended') as never)
+
+      // layout + owned styles + presenter + root slot + framed chrome styles
+      expect(ctx.effect).toHaveBeenCalledTimes(5)
+      expect(ctx.slots.register).toHaveBeenCalledTimes(1)
+      expect(warn).not.toHaveBeenCalled()
+    } finally {
+      warn.mockRestore()
+    }
+  })
+
+  it('keeps the framed chrome but drops the owned presentation when the race is lost', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    try {
+      stubDocument()
+      const ctx = makeCtx()
+      ctx.reflect.provide.mockImplementation(() => {
+        throw new Error('service "layout" has been registered at <z5>')
+      })
+
+      applyExtendedShell(ctx as never, environmentFor('extended') as never)
+
+      // Only the framed-chrome style effect remains; the titlebar overlay is
+      // injected (it layers over whatever presents the root), while no second
+      // root frame is stacked over the upstream one.
+      expect(ctx.effect).toHaveBeenCalledTimes(1)
+      expect(ctx.slots.register).not.toHaveBeenCalled()
+      expect(ctx.slots.inject).toHaveBeenCalledTimes(1)
+      expect(warn).toHaveBeenCalled()
+    } finally {
+      warn.mockRestore()
+    }
+  })
+})

--- a/dsh-plugin-desktop/tsconfig.tests.client.json
+++ b/dsh-plugin-desktop/tsconfig.tests.client.json
@@ -12,6 +12,7 @@
     "tests/client-directory-picker.spec.ts",
     "tests/client-desktop-settings.spec.ts",
     "tests/client-environment.spec.ts",
+    "tests/client-layout-service.spec.ts",
     "tests/client-workspace-folder-drop.spec.ts",
     "tests/theme-presenter.spec.ts"
   ]

--- a/dsh-plugin-desktop/tsconfig.tests.json
+++ b/dsh-plugin-desktop/tsconfig.tests.json
@@ -10,6 +10,7 @@
     "tests/client-boot-health.spec.ts",
     "tests/client-desktop-settings.spec.ts",
     "tests/client-environment.spec.ts",
+    "tests/client-layout-service.spec.ts",
     "tests/theme-presenter.spec.ts",
     "tests/client-workspace-folder-drop.spec.ts"
   ]


### PR DESCRIPTION
## Summary / 摘要
`@deepseek-ai/dsh-client-ui-layout`(0.1.1-rc.*)与桌面插件都无条件注册进程级 `"layout"` 服务和 root 槽,后应用的入口撞名失败,cordis 整体回滚已装效果——设置页样式随之消失(#517)。本 PR 让桌面侧在竞争失败时**让位**而非整体崩掉:
- `claimDesktopLayout`:认领或安全让位(provide 失败即降级;不用 `reflect.get` 判定所有权——应用期读 store 会建立跨 fiber 追踪依赖,间歇性死锁页面)
- advanced shell 让位时仅保留模式标记,呈现(主题 presenter、自有 chrome、root 槽)完全交给上游
- extended owned shell 同样降级;独立框架 chrome(标题栏覆盖层)仍叠加在上游呈现之上
- 入口幂等守卫:标记同步抢占 + 单个 try 块内任一步失败即回滚标记,loader 重启不再被残留标记吞掉
- 已基于最新 master(efc72d4)rebase,覆盖 compatibility / extended / advanced 三模式

## Related Issues / 关联 Issue
Fixes #517

## Type / 类型
- [x] Bug Fix(修复)

## Platforms / 影响平台
- [x] Windows
- [x] macOS
- [x] Linux

## Verification / 验证
- 独立 vitest 4.1.8:`tests/client-layout-service.spec.ts` 11/11 通过(rebase 后代码):所有权三态、入口标记同步可见+失败回滚+重入拦截、advanced/extended 各自的胜负两态呈现结果
- 实机验证(同一让位机制的前一迭代,2.0.2 运行时热补丁):CDP 无头驱动打开 设置→桌面版,`.dshDesktopSettings*` 计算样式恢复正常,页面不再裸奔;冲突日志 `service "layout" has been registered` 不再导致插件整体失效
- CI:等待维护者批准运行(首次贡献者 workflow 需 Approve and run)

## Release Notes / 发布说明
- Desktop:dsh-client-ui-layout 与桌面插件共存时,桌面插件改为向其让出布局服务,修复「设置→桌面版」页面因入口回滚而失去全部样式的问题(#517)