### PR TITLE
docs: collect Profile and plugin context in bug reports

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -82,6 +82,44 @@ body:
     validations:
       required: true
 
+  - type: dropdown
+    id: profile_type
+    attributes:
+      label: Profile type / Profile 类型
+      description: Choose the Profile where the problem occurs / 选择发生问题的 Profile
+      options:
+        - Default or built-in Profile / 默认或内置 Profile
+        - Existing upgraded Profile / 从旧版本升级的 Profile
+        - Newly created Profile / 新建 Profile
+        - Custom Profile / 自定义 Profile
+        - Unknown / 不确定
+    validations:
+      required: true
+
+  - type: textarea
+    id: third_party_plugins
+    attributes:
+      label: Third-party plugins / 第三方插件
+      description: List installed third-party plugins and versions, or write None / 列出已安装的第三方插件及版本；没有时填写“无”
+      placeholder: |
+        plugin-name@version
+        None / 无
+    validations:
+      required: true
+
+  - type: dropdown
+    id: fresh_profile_result
+    attributes:
+      label: Fresh Profile comparison / 全新 Profile 对照结果
+      description: If possible, create a fresh Profile without third-party plugins and retry / 如条件允许，请新建不含第三方插件的 Profile 后重试
+      options:
+        - Still reproduces in a fresh Profile / 全新 Profile 仍可复现
+        - Does not reproduce in a fresh Profile / 全新 Profile 不再复现
+        - Cannot test because the app will not start / 应用无法启动，不能测试
+        - Not tested / 未测试
+    validations:
+      required: true
+
   - type: textarea
     id: actual_behavior
     attributes:


### PR DESCRIPTION
## Summary

Recurring startup and plugin reports often omit the information needed to distinguish Desktop regressions from upgraded Profile state or third-party plugins.

This updates the bug report form to require:
- the affected Profile type
- installed third-party plugins and versions, with a None option
- the result of retrying with a fresh Profile, including explicit not-tested and cannot-start options

## Why

Recent reports have repeatedly required maintainers to ask whether the affected Profile was upgraded, whether plugins were installed, and whether a fresh Profile reproduced the problem. Collecting those variables at submission time should shorten triage without blocking users whose app cannot start.

## Verification

- Issue-form YAML parsed successfully and all field IDs are unique
- `corepack yarn check:layout`
- `corepack yarn test` (1064 passed, 4 skipped)
- `corepack yarn typecheck`
- `corepack yarn build`

## Safety review

1. Changed-content secret scan: passed
2. Executable/workflow-boundary scan: passed; only the issue-form YAML changed
3. Required-field and existing privacy-control validation: passed

No runtime code, workflow permissions, dependencies, or release behavior changed.
