### PR TITLE
fix(desktop): upgrade bundled pnpm past path-traversal advisory

### DIFF
--- a/dsh-plugin-desktop/THIRD_PARTY_NOTICES.md
+++ b/dsh-plugin-desktop/THIRD_PARTY_NOTICES.md
@@ -482,7 +482,7 @@ the package names, versions, and licenses for transparency.
 | picocolors | 1.1.1 | ISC |
 | picomatch | 4.0.5 | MIT |
 | pkce-challenge | 5.0.1 | MIT |
-| pnpm | 11.7.0 | MIT |
+| pnpm | 11.8.0 | MIT |
 | powershell-utils | 0.2.0 | MIT |
 | property-information | 7.2.0 | MIT |
 | protobufjs | 7.6.5 | BSD-3-Clause |

--- a/dsh-plugin-desktop/package.json
+++ b/dsh-plugin-desktop/package.json
@@ -248,7 +248,7 @@
     "dshmarket": "1.17.1",
     "koffi": "3.1.5",
     "node-addon-require-builtin": "^0.1.4",
-    "pnpm": "11.7.0",
+    "pnpm": "11.8.0",
     "react": "18.3.1",
     "semver": "^7.8.5",
     "yaml": "^2.9.0"

--- a/dsh-plugin-desktop/tests/package.spec.ts
+++ b/dsh-plugin-desktop/tests/package.spec.ts
@@ -782,7 +782,7 @@ describe('published package surface', () => {
     expect(manifest.dependencies).not.toHaveProperty('electron')
     expect(manifest.peerDependencies?.electron).toBe('43.4.0')
     expect(manifest.devDependencies?.electron).toBe('43.4.0')
-    expect(manifest.dependencies?.pnpm).toBe('11.7.0')
+    expect(manifest.dependencies?.pnpm).toBe('11.8.0')
   })
 
   it('packages the native-compiled Koffi Windows runtime', () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -8349,7 +8349,7 @@ __metadata:
     koffi: "npm:3.1.5"
     lucide-react: "npm:^1.33.0"
     node-addon-require-builtin: "npm:^0.1.4"
-    pnpm: "npm:11.7.0"
+    pnpm: "npm:11.8.0"
     react: "npm:18.3.1"
     react-dom: "npm:18.3.1"
     semver: "npm:^7.8.5"
@@ -11833,9 +11833,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"pnpm@npm:11.7.0":
-  version: 11.7.0
-  resolution: "pnpm@npm:11.7.0"
+"pnpm@npm:11.8.0":
+  version: 11.8.0
+  resolution: "pnpm@npm:11.8.0"
   dependencies:
     node-gyp: "npm:latest"
   bin:
@@ -11843,7 +11843,7 @@ __metadata:
     pnpm: bin/pnpm.mjs
     pnpx: bin/pnpx.mjs
     pnx: bin/pnpx.mjs
-  checksum: 10c0/fdc13140f280771191b210385c7cffe288870ba14c6a5e7a212e90703a4327d8903fdcee6409daff9a3f8fba5cc2b323344ed59effeac66df0bdc2235a01cce0
+  checksum: 10c0/a24262bc503a6007a1948c2182377b30d22e8e192cb2b85e8dd7e2bbac0e87ed1426f454a73ed95943f36177d54938a02d5d6cbbadf01f58467c8c2d06d1a35d
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

Upgrade Desktop's bundled pnpm from 11.7.0 to 11.8.0, the first patched 11.x release for GHSA-qrv3-253h-g69c.

The change updates the runtime dependency, lockfile checksum, package contract test, and generated third-party notice. It intentionally stays on the first patched version to avoid unrelated package-manager behavior changes.

## Security impact

GitHub's advisory marks `pnpm >= 11.0.0, < 11.8.0` as vulnerable to path traversal through `configDependencies` environment lockfiles. Desktop currently bundles 11.7.0 for Profile and plugin operations.

Advisory: https://github.com/advisories/GHSA-qrv3-253h-g69c

## Verification

- immutable Yarn install
- 1064 tests passed, 4 skipped
- focused package/Profile/pnpm tests: 78 passed, 1 skipped
- typecheck passed
- production build passed
- runtime closure verified (201 first-party nodes)
- 544 production package licenses verified

## Three safety inspections

1. Dependency audit: the pnpm advisory is absent after the upgrade; unrelated baseline deprecation notices remain.
2. Resolution check: lockfile checksum is updated and the installed executable reports `11.8.0`.
3. Change-boundary scan: no secrets, lifecycle hooks, workflow permissions, or executable scripts were introduced.

## Platform gap

I did not build the full Windows and macOS installer smoke packages locally; repository CI should cover those package surfaces.
