### PR TITLE
fix(market): decode localized Windows plugin install failures

### DIFF
--- a/dsh-community-market/src/install/service.ts
+++ b/dsh-community-market/src/install/service.ts
@@ -1,6 +1,7 @@
 import { randomBytes, randomUUID } from 'node:crypto'
 import { lstat, readFile, realpath, rename, stat, unlink, writeFile } from 'node:fs/promises'
 import { isAbsolute, join, relative, resolve } from 'node:path'
+import { finished } from 'node:stream/promises'
 import type { Readable } from 'node:stream'
 import type { SettingsScope } from '@deepseek-ai/dsh-settings'
 import { prerelease, satisfies, valid } from 'semver'
@@ -23,11 +24,14 @@ const CANDIDATE_TTL_MS = 30 * 60 * 1000
 const MAX_INTENTS = 256
 const MAX_CANDIDATES = 10_000
 const MAX_RECEIPTS = 512
+const MAX_OPERATION_STDERR_BYTES = 16 * 1024
 const LIFECYCLE_SCRIPTS = ['preinstall', 'install', 'postinstall', 'prepare'] as const
 const BLOCKED_PRODUCT_PACKAGES = new Set(['dsh-plugin-desktop', 'dsh-community-market'])
 const DSH_RUNTIME_VERSION = '0.1.1-rc.2'
 const CORDIS_RUNTIME_VERSION = '4.0.1'
 const NODE_RUNTIME_VERSION = '24.18.1'
+const UTF8_REPLACEMENT = '\uFFFD'
+const HAN_SCRIPT = /\p{Script=Han}/u
 
 export type { MarketInstallReceipt } from '../api-types.js'
 
@@ -179,6 +183,30 @@ function candidateKey(sourceRecordId: string, itemId: string): string {
 
 function opaqueToken(): string {
   return randomBytes(32).toString('base64url')
+}
+
+function appendStderrChunk(chunks: Buffer[], chunk: string | Buffer, total: number): number {
+  if (total >= MAX_OPERATION_STDERR_BYTES) return total
+  const bytes = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk)
+  const next = bytes.subarray(0, Math.max(0, MAX_OPERATION_STDERR_BYTES - total))
+  if (next.byteLength === 0) return total
+  chunks.push(next)
+  return total + next.byteLength
+}
+
+function decodedOperationStderr(chunks: readonly Buffer[]): string | undefined {
+  if (chunks.length === 0) return undefined
+  const bytes = Buffer.concat(chunks)
+  const utf8 = bytes.toString('utf8').replaceAll('\0', '').trim()
+  if (utf8.length === 0) return undefined
+  if (!utf8.includes(UTF8_REPLACEMENT)) return utf8
+  try {
+    const fallback = new TextDecoder('gb18030').decode(bytes).replaceAll('\0', '').trim()
+    if (fallback.length > 0 && !fallback.includes(UTF8_REPLACEMENT) && HAN_SCRIPT.test(fallback)) {
+      return fallback
+    }
+  } catch {}
+  return utf8
 }
 
 function own(object: object, key: PropertyKey): boolean {
@@ -1132,20 +1160,43 @@ export class MarketInstallService {
     let handle: MarketDesktopPnpmHandle
     try { handle = this.pnpm.run(args, combinedSignal) }
     catch { throw new MarketInstallError('operation-failed', 'The desktop package manager could not start.') }
+    const stderrChunks: Buffer[] = []
+    let stderrBytes = 0
+    const acceptStderr = (chunk: string | Buffer) => { stderrBytes = appendStderrChunk(stderrChunks, chunk, stderrBytes) }
     handle.stdout.resume()
+    handle.stderr.on('data', acceptStderr)
+    const stderrDone = finished(handle.stderr).catch(() => {})
     handle.stderr.resume()
     const cancel = () => handle.cancel()
     combinedSignal.addEventListener('abort', cancel, { once: true })
-    let outcome: MarketDesktopPnpmOutcome
-    try { outcome = await handle.done }
-    catch {
+    try {
+      let outcome: MarketDesktopPnpmOutcome
+      try { outcome = await handle.done }
+      catch {
+        await stderrDone
+        combinedSignal.throwIfAborted()
+        const detail = decodedOperationStderr(stderrChunks)
+        throw new MarketInstallError(
+          'operation-failed',
+          detail === undefined
+            ? 'The desktop package manager failed.'
+            : `The desktop package manager failed: ${detail}`,
+        )
+      }
+      await stderrDone
       combinedSignal.throwIfAborted()
-      throw new MarketInstallError('operation-failed', 'The desktop package manager failed.')
-    }
-    finally { combinedSignal.removeEventListener('abort', cancel) }
-    combinedSignal.throwIfAborted()
-    if (outcome.exitCode !== 0 || outcome.signal !== null) {
-      throw new MarketInstallError('operation-failed', 'The desktop package manager did not complete successfully.')
+      if (outcome.exitCode !== 0 || outcome.signal !== null) {
+        const detail = decodedOperationStderr(stderrChunks)
+        throw new MarketInstallError(
+          'operation-failed',
+          detail === undefined
+            ? 'The desktop package manager did not complete successfully.'
+            : `The desktop package manager did not complete successfully: ${detail}`,
+        )
+      }
+    } finally {
+      combinedSignal.removeEventListener('abort', cancel)
+      handle.stderr.off('data', acceptStderr)
     }
   }
 

--- a/dsh-community-market/tests/market-install.spec.ts
+++ b/dsh-community-market/tests/market-install.spec.ts
@@ -235,6 +235,29 @@ function runner(
   }
 }
 
+function runnerWithStderr(
+  profileDir: string,
+  stderr: Buffer,
+  outcome: { exitCode: number | null; signal: NodeJS.Signals | null } = { exitCode: 1, signal: null },
+): MarketDesktopPnpm {
+  return {
+    run(args) {
+      const done = (async () => {
+        if (outcome.exitCode === 0 && outcome.signal === null && args[0] === 'add') {
+          await writeInstalledPlugin(profileDir)
+        }
+        return outcome
+      })()
+      return {
+        stdout: Readable.from([]),
+        stderr: Readable.from([stderr]),
+        done,
+        cancel: vi.fn(),
+      }
+    },
+  }
+}
+
 describe('npm registry verification', () => {
   it('pins exact identity, repository, origin, and rejects lifecycle/deprecated metadata', async () => {
     const getJson = vi.fn<(...args: any[]) => Promise<{ finalUrl: string; value: unknown }>>(async () => ({
@@ -588,16 +611,7 @@ describe('market install service', () => {
       Buffer.from('cfb5cdb3d5d2b2bbb5bdd6b8b6a8b5c4c2b7beb6a1a3', 'hex'),
       Buffer.from(` dsh: pnpm failed in profile directory ${profileDir}`),
     ])
-    const pnpm = recoverableRunner(profileDir, {
-      runPlugin() {
-        return {
-          stdout: Readable.from([]),
-          stderr: Readable.from([stderr]),
-          done: Promise.resolve({ exitCode: 1, signal: null }),
-          cancel: vi.fn(),
-        }
-      },
-    })
+    const pnpm = runnerWithStderr(profileDir, stderr)
     const service = new MarketInstallService(
       settings.scope,
       () => ({ name: 'web', dir: profileDir }),
@@ -620,16 +634,7 @@ describe('market install service', () => {
   it('bounds package-manager stderr exposed through install failures', async () => {
     const profileDir = await createProfile()
     const settings = memoryScope()
-    const pnpm = recoverableRunner(profileDir, {
-      runPlugin() {
-        return {
-          stdout: Readable.from([]),
-          stderr: Readable.from([Buffer.from(`${'x'.repeat(20 * 1024)}tail-marker`)]),
-          done: Promise.resolve({ exitCode: 1, signal: null }),
-          cancel: vi.fn(),
-        }
-      },
-    })
+    const pnpm = runnerWithStderr(profileDir, Buffer.from(`${'x'.repeat(20 * 1024)}tail-marker`))
     const service = new MarketInstallService(
       settings.scope,
       () => ({ name: 'web', dir: profileDir }),

--- a/dsh-community-market/tests/market-install.spec.ts
+++ b/dsh-community-market/tests/market-install.spec.ts
@@ -581,7 +581,73 @@ describe('market install service', () => {
     expect(JSON.parse(await readFile(join(profileDir, 'package.json'), 'utf8')).dependencies).toEqual({})
   })
 
-  it('does not add install-specific rollback after a nonzero pnpm outcome', async () => {
+  it('decodes Windows-localized package-manager stderr before surfacing install failures', async () => {
+    const profileDir = await createProfile()
+    const settings = memoryScope()
+    const stderr = Buffer.concat([
+      Buffer.from('cfb5cdb3d5d2b2bbb5bdd6b8b6a8b5c4c2b7beb6a1a3', 'hex'),
+      Buffer.from(` dsh: pnpm failed in profile directory ${profileDir}`),
+    ])
+    const pnpm = recoverableRunner(profileDir, {
+      runPlugin() {
+        return {
+          stdout: Readable.from([]),
+          stderr: Readable.from([stderr]),
+          done: Promise.resolve({ exitCode: 1, signal: null }),
+          cancel: vi.fn(),
+        }
+      },
+    })
+    const service = new MarketInstallService(
+      settings.scope,
+      () => ({ name: 'web', dir: profileDir }),
+      pnpm,
+      { verify: vi.fn(async () => verification) },
+    )
+    service.observeCatalog(snapshot())
+    const preview = await service.previewInstall('source-1', 'example/dsh-plugin-safe', new AbortController().signal)
+    let thrown: unknown
+    try {
+      await service.executeInstall(preview.intent, new AbortController().signal)
+    } catch (cause) {
+      thrown = cause
+    }
+    expect(thrown).toBeInstanceOf(MarketInstallError)
+    expect((thrown as Error | undefined)?.message).toContain(`系统找不到指定的路径。 dsh: pnpm failed in profile directory ${profileDir}`)
+    expect(settings.receipts()).toEqual([])
+  })
+
+  it('bounds package-manager stderr exposed through install failures', async () => {
+    const profileDir = await createProfile()
+    const settings = memoryScope()
+    const pnpm = recoverableRunner(profileDir, {
+      runPlugin() {
+        return {
+          stdout: Readable.from([]),
+          stderr: Readable.from([Buffer.from(`${'x'.repeat(20 * 1024)}tail-marker`)]),
+          done: Promise.resolve({ exitCode: 1, signal: null }),
+          cancel: vi.fn(),
+        }
+      },
+    })
+    const service = new MarketInstallService(
+      settings.scope,
+      () => ({ name: 'web', dir: profileDir }),
+      pnpm,
+      { verify: vi.fn(async () => verification) },
+    )
+    service.observeCatalog(snapshot())
+    const preview = await service.previewInstall('source-1', 'example/dsh-plugin-safe', new AbortController().signal)
+
+    await expect(service.executeInstall(preview.intent, new AbortController().signal)).rejects.toSatisfy(
+      (cause: unknown) => cause instanceof MarketInstallError
+        && cause.message.length < 17 * 1024
+        && !cause.message.includes('tail-marker'),
+    )
+    expect(settings.receipts()).toEqual([])
+  })
+
+  it('rolls back a direct dependency written before a nonzero add outcome', async () => {
     const profileDir = await createProfile()
     const calls: string[] = []
     const settings = memoryScope()


### PR DESCRIPTION
## Summary

Fixes #524.

Managed plugin installs previously discarded package-manager stderr and returned a generic failure. On Chinese Windows systems the available stderr can also be encoded with a legacy code page, producing the reported mojibake.

This change:
- captures at most 16 KiB of stderr from the managed operation
- keeps valid UTF-8 unchanged
- falls back to GB18030 only when UTF-8 contains replacement characters and the fallback produces valid Han text
- includes the decoded detail in the local Market API error

## Verification

- `corepack yarn workspace dsh-community-market check` (275 tests)
- focused install suite (27 tests)
- Market typecheck
- repository layout checks
- immutable dependency install

## Three safety inspections

1. Diagnostic exposure is capped at 16 KiB and covered by a regression test.
2. Legacy decoding is fail-narrow: broken UTF-8 and valid Han output are both required.
3. No secret literals, shell/eval path, or executable-string construction was introduced; the local error response remains `no-store` and `nosniff`.

## Platform gap

The exact GBK byte sequence from #524 is covered locally, but I did not reproduce the failure inside a packaged Windows 11 application.
