### PR TITLE
fix(desktop): quarantine oversized session projection caches

### DIFF
--- a/dsh-plugin-desktop/src/main.ts
+++ b/dsh-plugin-desktop/src/main.ts
@@ -100,6 +100,10 @@ import {
   desktopRecoveryModeRequested,
   desktopRecoveryRelaunchArguments,
 } from './relaunch-arguments.ts'
+import {
+  recoverOversizedSessionProjectionCache,
+  type SessionProjectionCacheRecoveryResult,
+} from './session-projcache-recovery.ts'
 
 const BIN_NAME = 'dsh-plugin-desktop'
 const PRODUCT_NAME = 'DSH Desktop'
@@ -179,6 +183,21 @@ function notifyWindowsVolumeConcerns(
   }
 }
 
+function notifySessionProjectionCacheRecovery(
+  runtime: ElectronDesktopRuntime,
+  logger: DesktopLogger,
+  _recovery: Extract<SessionProjectionCacheRecoveryResult, { status: 'quarantined' }>,
+): void {
+  try {
+    runtime.updates.notify({
+      title: 'Recovered Session Cache',
+      body: 'An oversized session projection cache was moved aside and will be rebuilt from session history.',
+    })
+  } catch (cause) {
+    logger.error(`${BIN_NAME}: failed to show session projection cache recovery notification: ${cause instanceof Error ? cause.message : String(cause)}`)
+  }
+}
+
 /** Start one Electron process and leave lifetime to the mounted desktop plugin. */
 async function start(): Promise<void> {
   if (!app.requestSingleInstanceLock()) {
@@ -202,6 +221,9 @@ async function start(): Promise<void> {
   let startupRecoveryConfigurationPaths: DesktopStartupRecoveryConfigurationPaths | undefined
   let profileCheckpoint: DesktopProfileCheckpoint | undefined
   let startupRecoveryProfileActions: DesktopStartupRecoveryProfileActions | undefined
+  let sessionProjectionCacheRecovery:
+    | Extract<SessionProjectionCacheRecoveryResult, { status: 'quarantined' }>
+    | undefined
   let profileRecoveryActionUsed = false
   let recoveryTerminalAvailable = false
   let startupStage: DesktopStartupFailureStage = 'electron-ready'
@@ -374,6 +396,14 @@ async function start(): Promise<void> {
     })
     for (const [name, value] of Object.entries(shellEnvironmentResolution.updates)) process.env[name] = value
     const homeDir = resolveDshHome()
+    const projectionCacheRecovery = recoverOversizedSessionProjectionCache(homeDir)
+    if (projectionCacheRecovery.status === 'quarantined') {
+      sessionProjectionCacheRecovery = projectionCacheRecovery
+      electronLogger.error(
+        `${BIN_NAME}: quarantined oversized session projection cache (${String(projectionCacheRecovery.sizeBytes)} bytes) at `
+          + `${projectionCacheRecovery.cachePath}; backup saved to ${projectionCacheRecovery.backupPath}`,
+      )
+    }
     const windowsVolumeConcerns = diagnoseWindowsVolumes(process.platform, [
       { label: 'application install', path: process.execPath },
       { label: 'desktop user data', path: app.getPath('userData') },
@@ -786,6 +816,9 @@ async function start(): Promise<void> {
     lifecycleRecorder.completeStartup(startupStage, rendererReport)
     notifySkippedOptionalEntries(runtime, electronLogger, prepared.skippedOptionalEntries)
     notifyWindowsVolumeConcerns(runtime, electronLogger, windowsVolumeConcerns)
+    if (sessionProjectionCacheRecovery !== undefined) {
+      notifySessionProjectionCacheRecovery(runtime, electronLogger, sessionProjectionCacheRecovery)
+    }
   } catch (cause) {
     runtime.stopRendererBootMonitoring()
     lifecycleRecorder.failRendererBootIfPending(lifecycleRendererFailureReason(runtime.rendererBootFailureReason))

--- a/dsh-plugin-desktop/src/session-projcache-recovery.ts
+++ b/dsh-plugin-desktop/src/session-projcache-recovery.ts
@@ -1,0 +1,95 @@
+import {
+  existsSync,
+  lstatSync,
+  renameSync,
+} from 'node:fs'
+import { basename, dirname, extname, isAbsolute, join } from 'node:path'
+
+const BIN_NAME = 'dsh-plugin-desktop'
+
+export const SESSION_PROJCACHE_MAX_BYTES = 128 * 1024 * 1024
+export const SESSION_PROJCACHE_RELATIVE_PATH = ['storages', 'session_projcache.json'] as const
+
+export interface SessionProjectionCacheRecoveryOptions {
+  readonly maxBytes?: number
+  readonly now?: () => Date
+}
+
+export type SessionProjectionCacheRecoveryResult =
+  | {
+      readonly status: 'missing' | 'within-limit' | 'non-file'
+      readonly cachePath: string
+    }
+  | {
+      readonly status: 'quarantined'
+      readonly cachePath: string
+      readonly backupPath: string
+      readonly sizeBytes: number
+    }
+
+function assertAbsoluteHome(homeDir: string): void {
+  if (!isAbsolute(homeDir) || homeDir.includes('\0')) {
+    throw new Error(`${BIN_NAME}: session projection cache recovery requires an absolute DSH home path`)
+  }
+}
+
+function assertPositiveFinite(label: string, value: number): void {
+  if (!Number.isFinite(value) || value <= 0) {
+    throw new Error(`${BIN_NAME}: session projection cache recovery ${label} must be positive`)
+  }
+}
+
+function compactTimestamp(date: Date): string {
+  const y = String(date.getUTCFullYear())
+  const m = String(date.getUTCMonth() + 1).padStart(2, '0')
+  const d = String(date.getUTCDate()).padStart(2, '0')
+  const hh = String(date.getUTCHours()).padStart(2, '0')
+  const mm = String(date.getUTCMinutes()).padStart(2, '0')
+  const ss = String(date.getUTCSeconds()).padStart(2, '0')
+  const ms = String(date.getUTCMilliseconds()).padStart(3, '0')
+  return `${y}${m}${d}T${hh}${mm}${ss}${ms}Z`
+}
+
+function uniqueBackupPath(cachePath: string, stamp: string): string {
+  const dir = dirname(cachePath)
+  const extension = extname(cachePath)
+  const stem = basename(cachePath, extension)
+  const prefix = join(dir, `${stem}.oversized-${stamp}`)
+  const first = `${prefix}${extension}`
+  if (!existsSync(first)) return first
+  for (let attempt = 1; attempt < Number.MAX_SAFE_INTEGER; attempt += 1) {
+    const candidate = `${prefix}.${String(attempt)}${extension}`
+    if (!existsSync(candidate)) return candidate
+  }
+  throw new Error(`${BIN_NAME}: could not allocate a unique oversized session projection cache backup path`)
+}
+
+export function recoverOversizedSessionProjectionCache(
+  homeDir: string,
+  options: SessionProjectionCacheRecoveryOptions = {},
+): SessionProjectionCacheRecoveryResult {
+  assertAbsoluteHome(homeDir)
+  const maxBytes = options.maxBytes ?? SESSION_PROJCACHE_MAX_BYTES
+  assertPositiveFinite('size limit', maxBytes)
+  const cachePath = join(homeDir, ...SESSION_PROJCACHE_RELATIVE_PATH)
+  let stat
+  try {
+    stat = lstatSync(cachePath)
+  } catch (cause) {
+    if ((cause as NodeJS.ErrnoException).code === 'ENOENT') {
+      return { status: 'missing', cachePath }
+    }
+    throw cause
+  }
+  if (!stat.isFile() || stat.isSymbolicLink()) return { status: 'non-file', cachePath }
+  if (stat.size <= maxBytes) return { status: 'within-limit', cachePath }
+  const stamp = compactTimestamp((options.now ?? (() => new Date()))())
+  const backupPath = uniqueBackupPath(cachePath, stamp)
+  renameSync(cachePath, backupPath)
+  return {
+    status: 'quarantined',
+    cachePath,
+    backupPath,
+    sizeBytes: stat.size,
+  }
+}

--- a/dsh-plugin-desktop/tests/session-projcache-recovery.spec.ts
+++ b/dsh-plugin-desktop/tests/session-projcache-recovery.spec.ts
@@ -1,0 +1,57 @@
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  writeFileSync,
+} from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+import {
+  recoverOversizedSessionProjectionCache,
+  SESSION_PROJCACHE_RELATIVE_PATH,
+} from '../src/session-projcache-recovery.ts'
+
+function fixtureHome(): string {
+  const home = mkdtempSync(join(tmpdir(), 'dsh-projcache-'))
+  mkdirSync(join(home, SESSION_PROJCACHE_RELATIVE_PATH[0]))
+  return home
+}
+
+describe('session projection cache recovery', () => {
+  it('quarantines an oversized cache before the runtime could parse it', () => {
+    const home = fixtureHome()
+    const cachePath = join(home, ...SESSION_PROJCACHE_RELATIVE_PATH)
+    const oversized = 'x'.repeat(33)
+    writeFileSync(cachePath, oversized)
+
+    const recovered = recoverOversizedSessionProjectionCache(home, {
+      maxBytes: 32,
+      now: () => new Date('2026-08-24T08:15:16.123Z'),
+    })
+
+    expect(recovered).toMatchObject({
+      status: 'quarantined',
+      cachePath,
+      sizeBytes: Buffer.byteLength(oversized),
+    })
+    expect(existsSync(cachePath)).toBe(false)
+    expect(recovered.status === 'quarantined' && recovered.backupPath).toContain(
+      'session_projcache.oversized-20260824T081516123Z.json',
+    )
+    expect(recovered.status === 'quarantined' && readFileSync(recovered.backupPath, 'utf8')).toBe(oversized)
+  })
+
+  it('leaves a bounded cache untouched', () => {
+    const home = fixtureHome()
+    const cachePath = join(home, ...SESSION_PROJCACHE_RELATIVE_PATH)
+    writeFileSync(cachePath, 'small-cache')
+
+    expect(recoverOversizedSessionProjectionCache(home, { maxBytes: 32 })).toEqual({
+      status: 'within-limit',
+      cachePath,
+    })
+    expect(readFileSync(cachePath, 'utf8')).toBe('small-cache')
+  })
+})


### PR DESCRIPTION
## Summary

- inspect the persisted session projection cache before Harness startup
- move an oversized regular cache aside so projections can rebuild from durable session history
- preserve the quarantined file with a timestamped name and notify the user after a healthy launch
- add focused oversized and bounded-cache regressions

Closes #499.

## Design

The guard is intentionally Desktop-owned because this repository pins the upstream Harness submodule. It checks only metadata, rejects symlinks/non-files, and uses a 128 MiB threshold, well above the rebuilt cache sizes reported in #499. The move remains in the same directory, so it is atomic on the profile volume and preserves evidence for diagnosis.

## Verification

- focused recovery tests: 2/2 passed
- package tests: 31 passed, 1 skipped
- full `yarn check`: Desktop 82 files / 807 passed / 4 skipped; Market 274 passed
- typecheck, build, layout, runtime closure, licenses and operation reliability passed

## Safety inspections

1. Secret/static scan: no credential or private-key signatures; `git diff --check` passed.
2. Dependency/executable boundary: no package manifest, lockfile, shell, PowerShell or installer changes; runtime closure and license verification passed.
3. File-system boundary: requires an absolute DSH home, uses `lstat`, ignores symlinks and non-files, allocates a non-colliding backup in the same directory, and never parses attacker-sized JSON during preflight.

## Scope

Desktop startup recovery only. The pinned Harness submodule is unchanged.