### PR TITLE
fix(agent): stop turns on empty tool-call names

### DIFF
--- a/dsh-plugin-desktop/tests/empty-tool-call-loop.spec.ts
+++ b/dsh-plugin-desktop/tests/empty-tool-call-loop.spec.ts
@@ -1,0 +1,167 @@
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { createRequire } from 'node:module'
+import { tmpdir } from 'node:os'
+import { dirname, join } from 'node:path'
+import { pathToFileURL } from 'node:url'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { TOOL_RUNTIME_SCHEDULER } from '@deepseek-ai/dsh-tools'
+
+type ExecuteToolCalls = (
+  ctx: {
+    agents: { requireInitiator(): { session: SessionRecorder } }
+    tools: {
+      executionMode(exec: unknown): { kind: 'exclusive' | 'parallel' }
+      [TOOL_RUNTIME_SCHEDULER]: {
+        prepare(exec: unknown): Promise<unknown>
+        dispatch(exec: unknown): Promise<unknown>
+        finalize(exec: unknown, result: unknown): unknown
+        finish(exec: unknown, result: unknown): unknown
+      }
+    }
+    agentLoop: { config: { maxParallelToolCalls: number } }
+  },
+  turn: number,
+  step: number,
+  toolCalls: Array<{ id: string; name: string; arguments: string }>,
+  signal: AbortSignal,
+  acceptContext: (context: unknown) => void,
+) => Promise<{ concluded: boolean }>
+
+type SessionEventRecord = {
+  type: string
+  data: unknown
+  options: unknown
+}
+
+class SessionRecorder {
+  readonly events: SessionEventRecord[] = []
+
+  append(type: string, data: unknown, options?: unknown): { seq: number } {
+    this.events.push({ type, data, options })
+    return { seq: this.events.length }
+  }
+}
+
+const require = createRequire(import.meta.url)
+const agentLoopPackageJson = require.resolve('@deepseek-ai/dsh-agent-loop/package.json')
+const agentLoopLibPath = join(dirname(agentLoopPackageJson), 'lib/index.js')
+const cleanupPaths = new Set<string>()
+
+afterEach(() => {
+  vi.restoreAllMocks()
+  for (const path of cleanupPaths) rmSync(path, { force: true, recursive: true })
+  cleanupPaths.clear()
+})
+
+async function loadExecuteToolCalls(): Promise<ExecuteToolCalls> {
+  const original = readFileSync(agentLoopLibPath, 'utf8')
+  const patched = `${original}\nexport { executeToolCalls };\n`
+  const tempDir = mkdtempSync(join(tmpdir(), 'dsh-agent-loop-'))
+  cleanupPaths.add(tempDir)
+  const tempFile = join(tempDir, 'index.mjs')
+  writeFileSync(tempFile, patched)
+  const module = await import(`${pathToFileURL(tempFile).href}?t=${Date.now()}`)
+  return module.executeToolCalls as ExecuteToolCalls
+}
+
+describe('empty tool-call handling', () => {
+  it('fails once with a clear terminal result instead of entering the unknown-tool dispatch path', async () => {
+    const executeToolCalls = await loadExecuteToolCalls()
+    const session = new SessionRecorder()
+    const prepare = vi.fn(async (exec: { name: string }) => ({
+      kind: 'final-result',
+      exec,
+      result: {
+        content: [{ type: 'text', text: `Error: unknown tool "${exec.name}"` }],
+        isError: true,
+      },
+    }))
+    const dispatch = vi.fn()
+    const finalize = vi.fn()
+    const finish = vi.fn((_exec: unknown, result: unknown) => result)
+
+    const result = await executeToolCalls({
+      agents: {
+        requireInitiator: () => ({ session }),
+      },
+      tools: {
+        executionMode: () => ({ kind: 'parallel' }),
+        [TOOL_RUNTIME_SCHEDULER]: {
+          prepare,
+          dispatch,
+          finalize,
+          finish,
+        },
+      },
+      agentLoop: {
+        config: { maxParallelToolCalls: 1 },
+      },
+    }, 1, 1, [
+      {
+        id: 'valid-call',
+        name: 'known-tool',
+        arguments: '{}',
+      },
+      {
+        id: '',
+        name: '',
+        arguments: '{}',
+      },
+    ], new AbortController().signal, () => {})
+
+    expect(result).toEqual({ concluded: true })
+    expect(prepare).toHaveBeenCalledOnce()
+    expect(prepare).toHaveBeenCalledWith(expect.objectContaining({
+      callId: 'valid-call',
+      name: 'known-tool',
+    }))
+    expect(dispatch).not.toHaveBeenCalled()
+    expect(finalize).not.toHaveBeenCalled()
+    expect(finish).toHaveBeenCalledOnce()
+    expect(session.events).toHaveLength(4)
+    expect(session.events[2]).toMatchObject({
+      type: 'tool/call',
+      data: {
+        turn: 1,
+        step: 1,
+        callId: '',
+        name: '',
+        arguments: '{}',
+      },
+    })
+    expect(session.events[3]).toMatchObject({
+      type: 'tool/result',
+      data: {
+        turn: 1,
+        step: 1,
+        message: {
+          role: 'user',
+          content: [{
+            type: 'tool-result',
+            toolCallId: '',
+            isError: true,
+            content: [{
+              type: 'text',
+              text: expect.stringContaining('empty tool name'),
+            }],
+          }],
+        },
+      },
+      options: {
+        surfaceOp: 'append',
+        sourceEventSeqs: [3],
+      },
+    })
+    expect(session.events[3]).toMatchObject({
+      data: {
+        message: {
+          content: [{
+            content: [{
+              text: expect.stringContaining('Start a new session'),
+            }],
+          }],
+        },
+      },
+    })
+  })
+})

--- a/dsh-plugin-desktop/tests/package.spec.ts
+++ b/dsh-plugin-desktop/tests/package.spec.ts
@@ -172,6 +172,28 @@ describe('published package surface', () => {
     expect(installedBoot).toContain(marker)
   })
 
+  it('patches the agent loop to stop after one empty-name tool call', () => {
+    const patchPath = './patches/dsh-agent-loop@0.1.1-rc.2.patch'
+    expect(workspaceManifest.resolutions).toMatchObject({
+      '@deepseek-ai/dsh-agent-loop@npm:0.1.1-rc.2': expect.stringContaining(patchPath),
+      '@deepseek-ai/dsh-agent-loop@npm:^0.1.1-rc.2': expect.stringContaining(patchPath),
+    })
+    const patch = readFileSync(new URL(patchPath, workspaceRoot), 'utf8')
+    const installedLoop = readFileSync(new URL(
+      'node_modules/@deepseek-ai/dsh-agent-loop/lib/index.js',
+      packageRoot,
+    ), 'utf8')
+    for (const marker of [
+      'const EMPTY_TOOL_NAME_ERROR = "assistant emitted a tool call with an empty tool name";',
+      'const EMPTY_TOOL_NAME_RESULT = "Error: assistant emitted a tool call with an empty tool name.',
+      'appendEmptyToolCallFailure(session, turn, step, first.block);',
+      'if (hasEmptyToolCallName(candidate.block)) break;',
+    ]) {
+      expect(patch).toContain(marker)
+      expect(installedLoop).toContain(marker)
+    }
+  })
+
   it('patches the browse panel with the Windows native-picker icon bridge', () => {
     const patchPath = './patches/dsh-client-ui-directory-picker-browse@0.1.1-rc.2.patch'
     expect(workspaceManifest.resolutions).toMatchObject({

--- a/package.json
+++ b/package.json
@@ -17,6 +17,8 @@
     "app-builder-lib@npm:26.15.7": "patch:app-builder-lib@npm%3A26.15.7#./patches/app-builder-lib@26.15.7.patch",
     "@deepseek-ai/dsh-app-boot@npm:0.1.1-rc.2": "patch:@deepseek-ai/dsh-app-boot@npm%3A0.1.1-rc.2#./patches/dsh-app-boot@0.1.1-rc.2.patch",
     "@deepseek-ai/dsh-app-boot@npm:^0.1.1-rc.2": "patch:@deepseek-ai/dsh-app-boot@npm%3A0.1.1-rc.2#./patches/dsh-app-boot@0.1.1-rc.2.patch",
+    "@deepseek-ai/dsh-agent-loop@npm:0.1.1-rc.2": "patch:@deepseek-ai/dsh-agent-loop@npm%3A0.1.1-rc.2#./patches/dsh-agent-loop@0.1.1-rc.2.patch",
+    "@deepseek-ai/dsh-agent-loop@npm:^0.1.1-rc.2": "patch:@deepseek-ai/dsh-agent-loop@npm%3A0.1.1-rc.2#./patches/dsh-agent-loop@0.1.1-rc.2.patch",
     "@deepseek-ai/dsh-llm-deepseek@npm:^0.1.1-rc.2": "patch:@deepseek-ai/dsh-llm-deepseek@npm%3A0.1.1-rc.2#./patches/dsh-llm-deepseek@0.1.1-rc.2.patch",
     "@deepseek-ai/dsh-sandbox-windows-acl@npm:0.1.1-rc.2": "patch:@deepseek-ai/dsh-sandbox-windows-acl@npm%3A0.1.1-rc.2#./patches/dsh-sandbox-windows-acl@0.1.1-rc.2.patch",
     "@deepseek-ai/dsh-sandbox-windows-acl@npm:^0.1.1-rc.2": "patch:@deepseek-ai/dsh-sandbox-windows-acl@npm%3A0.1.1-rc.2#./patches/dsh-sandbox-windows-acl@0.1.1-rc.2.patch",

--- a/patches/dsh-agent-loop@0.1.1-rc.2.patch
+++ b/patches/dsh-agent-loop@0.1.1-rc.2.patch
@@ -1,0 +1,49 @@
+diff --git a/lib/index.js b/lib/index.js
+index 17e11c9df8..597c77594b 100644
+--- a/lib/index.js
++++ b/lib/index.js
+@@ -114,6 +114,24 @@ var RuntimeContextProjection = class {
+ * @param signal - abort signal shared by the step.
+ * @param acceptContext - accepts committed result context for the next step boundary.
+ */
++const EMPTY_TOOL_NAME_ERROR = "assistant emitted a tool call with an empty tool name";
++const EMPTY_TOOL_NAME_RESULT = "Error: assistant emitted a tool call with an empty tool name. This usually means an upstream proxy or cached long session dropped tool_call.name/id. Start a new session or use the official DeepSeek API directly.";
++function hasEmptyToolCallName(block) {
++	return typeof block.name === "string" && block.name.trim() === "";
++}
++function appendEmptyToolCallFailure(session, turn, step, block) {
++	const callSeq = appendToolCall(session, turn, step, block);
++	appendToolResult(session, turn, step, block, {
++		content: [{
++			type: "text",
++			text: EMPTY_TOOL_NAME_RESULT
++		}],
++		isError: true,
++		error: {
++			message: EMPTY_TOOL_NAME_ERROR
++		}
++	}, callSeq);
++}
+ async function executeToolCalls(ctx, turn, step, toolCalls, signal, acceptContext) {
+ 	const agent = ctx.agents.requireInitiator();
+ 	const { session } = agent;
+@@ -131,8 +149,18 @@ async function executeToolCalls(ctx, turn, step, toolCalls, signal, acceptContex
+ 	let concluded = false;
+ 	while (next < planned.length) {
+ 		const first = planned[next];
++		if (hasEmptyToolCallName(first.block)) {
++			appendEmptyToolCallFailure(session, turn, step, first.block);
++			return { concluded: true };
++		}
+ 		const mode = ctx.tools.executionMode(first.exec).kind;
+-		const outcome = await runGroup(ctx, turn, step, mode === "parallel" ? planned.slice(next) : [first], mode, signal, acceptContext);
++		const group = [first];
++		if (mode === "parallel") while (next + group.length < planned.length) {
++			const candidate = planned[next + group.length];
++			if (hasEmptyToolCallName(candidate.block)) break;
++			group.push(candidate);
++		}
++		const outcome = await runGroup(ctx, turn, step, group, mode, signal, acceptContext);
+ 		next += outcome.consumed;
+ 		concluded ||= outcome.concluded;
+ 		if (outcome.aborted) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1038,7 +1038,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@deepseek-ai/dsh-agent-loop@npm:^0.1.1-rc.2":
+"@deepseek-ai/dsh-agent-loop@npm:0.1.1-rc.2":
   version: 0.1.1-rc.2
   resolution: "@deepseek-ai/dsh-agent-loop@npm:0.1.1-rc.2"
   dependencies:
@@ -1055,6 +1055,26 @@ __metadata:
     "@deepseek-ai/dsh-system-prompt": ^0.1.1-rc.2
     "@deepseek-ai/dsh-tools": ^0.1.1-rc.2
   checksum: 10c0/496fbc145b62b195e386ad45401cc7ecec011e70e8d20c990f1a6e8eb32cedee3fc136b4dbb294a06864416ccaa9350a37f9639ebc0f1102a9b5b3a3a7f7c894
+  languageName: node
+  linkType: hard
+
+"@deepseek-ai/dsh-agent-loop@patch:@deepseek-ai/dsh-agent-loop@npm%3A0.1.1-rc.2#./patches/dsh-agent-loop@0.1.1-rc.2.patch::locator=deepseek-harness-desktop%40workspace%3A.":
+  version: 0.1.1-rc.2
+  resolution: "@deepseek-ai/dsh-agent-loop@patch:@deepseek-ai/dsh-agent-loop@npm%3A0.1.1-rc.2#./patches/dsh-agent-loop@0.1.1-rc.2.patch::version=0.1.1-rc.2&hash=9cb58e&locator=deepseek-harness-desktop%40workspace%3A."
+  dependencies:
+    "@deepseek-ai/schemastery": "npm:^3.18.1"
+  peerDependencies:
+    "@deepseek-ai/cordis": ^4.0.1
+    "@deepseek-ai/dsh-agent": ^0.1.1-rc.2
+    "@deepseek-ai/dsh-invariants": ^0.1.1-rc.2
+    "@deepseek-ai/dsh-llm": ^0.1.1-rc.2
+    "@deepseek-ai/dsh-scope": ^0.1.1-rc.2
+    "@deepseek-ai/dsh-session": ^0.1.1-rc.2
+    "@deepseek-ai/dsh-session-persistence": ^0.1.1-rc.2
+    "@deepseek-ai/dsh-settings": ^0.1.1-rc.2
+    "@deepseek-ai/dsh-system-prompt": ^0.1.1-rc.2
+    "@deepseek-ai/dsh-tools": ^0.1.1-rc.2
+  checksum: 10c0/18ea15dd060316465282b70df1d0e042a7c8e9bb8ae2f8092f28114a33762c6a749965546970ca859f685099b75709c2eed9f388192ac1cff34a28567c193959
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

- patch the shipped agent loop to detect finalized tool calls whose name is empty
- append one explicit synthetic tool error with recovery guidance, then conclude the turn
- preserve preceding valid parallel calls while preventing the empty call from entering normal scheduler dispatch
- add runtime and package-surface regressions

Closes #157.

## Why the loop boundary

The DeepSeek adapter already preserves prior non-empty streamed name deltas. The remaining failure is a finalized empty call from a proxy or damaged long-session stream. Treating only the empty-name case as terminal prevents the repeated `unknown tool ""` feedback loop without changing ordinary unknown-tool behavior.

## Verification

- focused agent-loop, streaming and package tests: 34 passed, 1 skipped
- full `yarn check`: Desktop 82 files / 807 passed / 4 skipped; Market 274 passed
- typecheck, build, immutable install, layout, runtime closure, licenses and operation reliability passed

## Safety inspections

1. Secret/static scan: no credential or private-key signatures; `git diff --check` passed.
2. Dependency/runtime boundary: Yarn patch is exact-version scoped, immutable install succeeds, runtime closure and license checks pass, and package tests verify the installed artifact contains the guard.
3. Tool-execution boundary: an empty name is never passed to `prepare`, `dispatch`, `finalize`, or `finish`; preceding valid parallel work still commits in order; ordinary non-empty unknown tools retain existing behavior.

## Scope

Exact `@deepseek-ai/dsh-agent-loop@0.1.1-rc.2` patch only. Remove it when upstream publishes the equivalent fix.