### PR TITLE
fix(desktop): unblock installs after switching profiles

### DIFF
--- a/dsh-plugin-desktop/src/install-recovery.ts
+++ b/dsh-plugin-desktop/src/install-recovery.ts
@@ -20,6 +20,7 @@ const STATE_VERSION = 1
 const STATE_DIRECTORY_NAME = 'plugin-install-recovery'
 const STATE_FILENAME = 'state.json'
 const BACKUP_DIRECTORY_NAME = 'backups'
+const ABANDONED_STATE_FILENAME = 'abandoned-state.json'
 const STATE_FILE_MODE = 0o600
 const PRIVATE_DIRECTORY_MODE = 0o700
 const MAX_STATE_BYTES = 64 * 1024
@@ -403,8 +404,12 @@ export class DesktopInstallRecoveryStore {
     }
     assertPackageVersion(input.packageVersion)
     assertOpaqueId('receipt id', input.receiptId)
-    if (await this.read() !== undefined) {
-      throw new Error(`${BIN_NAME}: another plugin install recovery transaction is pending`)
+    const pending = await this.read()
+    if (pending !== undefined) {
+      if (this.matchesCurrentProfile(pending)) {
+        throw new Error(`${BIN_NAME}: another plugin install recovery transaction is pending`)
+      }
+      await this.archiveForeignTransaction(pending)
     }
     await this.assertProfileDirectory()
     const transactionId = randomUUID()
@@ -814,6 +819,23 @@ export class DesktopInstallRecoveryStore {
 
   private backupDirectory(transactionId: string): string {
     return join(dirname(this.statePath), BACKUP_DIRECTORY_NAME, transactionId)
+  }
+
+  private async archiveForeignTransaction(state: DesktopInstallRecoveryTransaction): Promise<void> {
+    const archiveDir = this.backupDirectory(state.transactionId)
+    const archiveInfo = await lstat(archiveDir)
+    if (archiveInfo.isSymbolicLink() || !archiveInfo.isDirectory()) {
+      throw new Error(`${BIN_NAME}: plugin install recovery backup directory must be a real directory`)
+    }
+    await chmod(archiveDir, PRIVATE_DIRECTORY_MODE)
+    for (const file of state.files) {
+      if (file.before.present) await this.readBackup(state.transactionId, file)
+    }
+    await this.io.writeFileAtomic(join(archiveDir, ABANDONED_STATE_FILENAME), `${JSON.stringify(state, undefined, 2)}\n`, {
+      mode: STATE_FILE_MODE,
+      dirMode: PRIVATE_DIRECTORY_MODE,
+    })
+    await unlink(this.statePath)
   }
 
   private async writeState(state: DesktopInstallRecoveryTransaction): Promise<void> {

--- a/dsh-plugin-desktop/tests/desktop-cli.spec.ts
+++ b/dsh-plugin-desktop/tests/desktop-cli.spec.ts
@@ -1,6 +1,6 @@
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, realpathSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
-import { join } from 'node:path'
+import { dirname, join } from 'node:path'
 import { pathToFileURL } from 'node:url'
 import { describe, expect, it, vi } from 'vitest'
 import {
@@ -10,6 +10,7 @@ import {
 } from '../src/desktop-cli.ts'
 import {
   DESKTOP_INSTALL_RECOVERY_STATE_ENV,
+  DesktopInstallRecoveryStore,
   desktopInstallRecoveryStatePath,
 } from '../src/install-recovery.ts'
 import { packagedDependencyPath, unpackedAsarPath } from '../src/packaged-runtime-path.ts'
@@ -147,6 +148,76 @@ describe('packaged dsh bootstrap', () => {
         phase: 'awaiting-restart',
       })
       expect(JSON.parse(readFileSync(desktopManifest, 'utf8'))).toEqual({ name: 'desktop-profile' })
+    } finally {
+      process.exitCode = originalExitCode
+      rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  it('does not let a foreign built-in terminal snapshot block the next desktop-managed install', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'dsh-desktop-terminal-foreign-profile-'))
+    const homeDir = join(root, 'home')
+    const desktopDir = join(homeDir, 'profiles', 'desktop')
+    const webDir = join(homeDir, 'profiles', 'web')
+    const statePath = desktopInstallRecoveryStatePath(join(root, 'user-data'))
+    const desktopManifest = join(desktopDir, 'package.json')
+    const webManifest = join(webDir, 'package.json')
+    const originalExitCode = process.exitCode
+    try {
+      mkdirSync(desktopDir, { recursive: true })
+      mkdirSync(webDir, { recursive: true })
+      writeFileSync(desktopManifest, JSON.stringify({ name: 'desktop-profile', dependencies: {} }))
+      writeFileSync(webManifest, JSON.stringify({ name: 'web-profile', dependencies: {} }))
+
+      await runDesktopDshCli({
+        DSH_HOME: homeDir,
+        DSH_DESKTOP_DEFAULT_PROFILE: 'desktop',
+        [DESKTOP_INSTALL_RECOVERY_STATE_ENV]: statePath,
+      }, async () => {
+        writeFileSync(webManifest, JSON.stringify({
+          name: 'web-profile',
+          dependencies: { 'example-plugin': '1.0.0' },
+        }))
+        process.exit(0)
+      }, [process.execPath, '/app/desktop-cli.js', 'plugin', '--profile', 'web', 'add', 'example-plugin'])
+
+      const foreign = JSON.parse(readFileSync(statePath, 'utf8')) as { transactionId: string }
+      expect(foreign).toMatchObject({
+        profileName: 'web',
+        packageName: 'manual-plugin-install',
+        phase: 'awaiting-restart',
+      })
+
+      const desktopStore = new DesktopInstallRecoveryStore({
+        statePath,
+        profileName: 'desktop',
+        profileDir: desktopDir,
+        generationId: 'desktop-generation-0001',
+      })
+      const transaction = await desktopStore.begin({
+        packageName: 'market-plugin',
+        packageVersion: '1.0.0',
+        receiptId: 'receipt:test-foreign-profile-0001',
+      })
+
+      expect(transaction).toMatchObject({
+        profileName: 'desktop',
+        packageName: 'market-plugin',
+        phase: 'prepared',
+      })
+      expect(JSON.parse(readFileSync(statePath, 'utf8'))).toMatchObject({
+        transactionId: transaction.transactionId,
+        profileName: 'desktop',
+      })
+      expect(JSON.parse(readFileSync(
+        join(dirname(statePath), 'backups', foreign.transactionId, 'abandoned-state.json'),
+        'utf8',
+      ))).toMatchObject({
+        transactionId: foreign.transactionId,
+        profileName: 'web',
+        packageName: 'manual-plugin-install',
+        phase: 'awaiting-restart',
+      })
     } finally {
       process.exitCode = originalExitCode
       rmSync(root, { recursive: true, force: true })


### PR DESCRIPTION
## Summary

- keep same-profile pending install journals blocking as before
- recognize a validated recovery journal owned by a different Profile
- archive that foreign journal beside its backups before publishing the next install transaction
- reproduce the real built-in terminal `web` -> managed `desktop` Profile transition

Closes #482.

## Root cause

Built-in terminal and Market installs share one recovery WAL path. A sealed journal created for another Profile could remain at that path, remain invisible to the active Profile, and make `begin()` reject before pnpm started. Market then surfaced only “The desktop package manager could not start.”

## Verification

- regression failed before the fix with `another plugin install recovery transaction is pending`
- focused Desktop CLI: 10 passed
- install recovery + pnpm: 36 passed
- full `yarn check`: Desktop 81 files / 806 passed / 4 skipped; Market 274 passed
- typecheck, build, layout, runtime closure, licenses and operation reliability passed

## Safety inspections

1. Secret/static scan: no credential/private-key signatures; `git diff --check` passed.
2. Dependency/executable boundary: no manifest, lockfile, shell or installer changes; runtime closure and license checks passed.
3. Recovery-WAL boundary: same-profile journals still block; foreign backup directories must be real non-symlink directories; every declared preimage is validated before archival; the archived state is atomically written with `0600` mode before the shared WAL is removed.

## Scope

Recovery journal ownership only. This does not relax same-Profile transaction locking or change package-manager commands.