### PR TITLE
fix(runtime): recover negative token-meter projections

### DIFF
--- a/dsh-plugin-desktop/tests/token-meter-negative-projection.spec.ts
+++ b/dsh-plugin-desktop/tests/token-meter-negative-projection.spec.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from 'vitest'
+import { Context } from '@deepseek-ai/cordis'
+import { createUserMessage } from '@deepseek-ai/dsh-llm'
+import type { SessionEvent } from '@deepseek-ai/dsh-session'
+import SessionStore from '@deepseek-ai/dsh-session'
+import SessionProjectionRegistry from '@deepseek-ai/dsh-session-projection'
+import TokenMeter from '@deepseek-ai/dsh-token-meter'
+import { contextBreakdownProjectionDefinition } from '../node_modules/@deepseek-ai/dsh-token-meter/lib/types/breakdown-projection.js'
+import { contextPressureProjectionDefinition } from '../node_modules/@deepseek-ai/dsh-token-meter/lib/types/usage-projection.js'
+
+async function harness(): Promise<Context> {
+  const ctx = new Context()
+  await ctx.plugin(SessionStore)
+  await ctx.plugin(SessionProjectionRegistry)
+  await ctx.plugin(TokenMeter)
+  return ctx
+}
+
+function replaceEvent(seq: number, start: number, end: number, text = '.'): SessionEvent {
+  return {
+    type: 'user/message',
+    seq,
+    time: 0,
+    data: createUserMessage({
+      content: [{ type: 'text', text }],
+      source: { kind: 'plugin', plugin: 'test' },
+    }),
+    surfaceOp: { op: 'replace', start, end },
+    sourceEventSeqs: [start, end],
+  } as unknown as SessionEvent
+}
+
+describe('token-meter negative projection recovery', () => {
+  it('invalidates pre-fix negative checkpoint rows via stateVersion mismatch', async () => {
+    const ctx = await harness()
+
+    expect(contextBreakdownProjectionDefinition.stateVersion).toBe(3)
+    expect(contextPressureProjectionDefinition.stateVersion).toBe(5)
+
+    const restored = ctx.sessionProjections.restore({
+      contextBreakdown: {
+        ver: 2,
+        seq: 38481,
+        val: { systemTokens: 5640, toolsTokens: 11075, messageTokens: -4840 },
+      },
+      contextPressure: {
+        ver: 4,
+        seq: 38481,
+        val: {
+          surfaceTokens: -4840,
+          contextWindow: 1_000_000,
+          pressureTokens: 89_773,
+          sampledSurfaceTokens: 36_309,
+        },
+      },
+    }, [], 0)
+
+    expect(restored.snapshot.values.contextBreakdown).toEqual({
+      systemTokens: 0,
+      toolsTokens: 0,
+      messageTokens: 0,
+    })
+    expect(restored.snapshot.values.contextPressure).toEqual({})
+    expect(restored.checkpoint.contextBreakdown).toMatchObject({
+      ver: 3,
+      seq: -1,
+      val: { systemTokens: 0, toolsTokens: 0, messageTokens: 0 },
+    })
+    expect(restored.checkpoint.contextPressure).toMatchObject({
+      ver: 5,
+      seq: -1,
+      val: { surfaceTokens: 0 },
+    })
+  })
+
+  it('clamps drifted replacement deltas before they can persist negative state', () => {
+    const replacement = replaceEvent(38482, 100, 200)
+
+    const breakdown = contextBreakdownProjectionDefinition.apply({
+      systemTokens: 5640,
+      toolsTokens: 11075,
+      messageTokens: 0,
+      claim: { start: 100, end: 200, tokens: 47095 },
+    }, replacement)
+    expect(breakdown.messageTokens).toBe(0)
+
+    const pressure = contextPressureProjectionDefinition.apply({
+      surfaceTokens: 0,
+      contextWindow: 1_000_000,
+      pressureTokens: 89_773,
+      sampledSurfaceTokens: 36_309,
+      claim: { start: 100, end: 200, tokens: 47095 },
+    }, replacement)
+    expect(pressure.surfaceTokens).toBe(0)
+  })
+})

--- a/package.json
+++ b/package.json
@@ -30,6 +30,8 @@
     "@deepseek-ai/dsh-client-ui-trajectory@npm:^0.1.1-rc.2": "patch:@deepseek-ai/dsh-client-ui-trajectory@npm%3A0.1.1-rc.2#./patches/dsh-client-ui-trajectory@0.1.1-rc.2.patch",
     "@deepseek-ai/dsh-client-ui-settings-models@npm:0.1.1-rc.2": "patch:@deepseek-ai/dsh-client-ui-settings-models@npm%3A0.1.1-rc.2#./patches/dsh-client-ui-settings-models@0.1.1-rc.2.patch",
     "@deepseek-ai/dsh-client-ui-settings-models@npm:^0.1.1-rc.2": "patch:@deepseek-ai/dsh-client-ui-settings-models@npm%3A0.1.1-rc.2#./patches/dsh-client-ui-settings-models@0.1.1-rc.2.patch",
+    "@deepseek-ai/dsh-token-meter@npm:0.1.1-rc.2": "patch:@deepseek-ai/dsh-token-meter@npm%3A0.1.1-rc.2#./patches/dsh-token-meter@0.1.1-rc.2.patch",
+    "@deepseek-ai/dsh-token-meter@npm:^0.1.1-rc.2": "patch:@deepseek-ai/dsh-token-meter@npm%3A0.1.1-rc.2#./patches/dsh-token-meter@0.1.1-rc.2.patch",
     "@deepseek-ai/dsh-web-app@npm:0.1.1-rc.2": "patch:@deepseek-ai/dsh-web-app@npm%3A0.1.1-rc.2#./patches/dsh-web-app@0.1.1-rc.2.patch",
     "@deepseek-ai/dsh-web-app@npm:^0.1.1-rc.2": "patch:@deepseek-ai/dsh-web-app@npm%3A0.1.1-rc.2#./patches/dsh-web-app@0.1.1-rc.2.patch",
     "dshmarket@npm:1.17.1": "patch:dshmarket@npm%3A1.17.1#./.yarn/patches/dshmarket-npm-1.17.1-d9fe6da08c.patch",

--- a/patches/dsh-token-meter@0.1.1-rc.2.patch
+++ b/patches/dsh-token-meter@0.1.1-rc.2.patch
@@ -1,0 +1,84 @@
+diff --git a/lib/index.js b/lib/index.js
+index 4d7fc639..58caa027 100644
+--- a/lib/index.js
++++ b/lib/index.js
+@@ -165,7 +165,7 @@ const tokenCount = z$1.number().int().nonnegative();
+ */
+ const contextBreakdownProjectionDefinition = {
+ 	key: "contextBreakdown",
+-	stateVersion: 2,
++	stateVersion: 3,
+ 	stateSchema: z$1.object({
+ 		systemTokens: tokenCount,
+ 		toolsTokens: tokenCount,
+@@ -194,7 +194,7 @@ const contextBreakdownProjectionDefinition = {
+ 		return {
+ 			systemTokens,
+ 			toolsTokens,
+-			messageTokens: state.messageTokens + fold.deltaTokens,
++			messageTokens: Math.max(0, state.messageTokens + fold.deltaTokens),
+ 			...fold.claim === void 0 ? {} : { claim: fold.claim }
+ 		};
+ 	},
+@@ -345,7 +345,7 @@ const tokenUsageProjectionDefinition = {
+ */
+ const contextPressureProjectionDefinition = {
+ 	key: "contextPressure",
+-	stateVersion: 4,
++	stateVersion: 5,
+ 	stateSchema: contextPressureStateSchema,
+ 	init: () => ({ surfaceTokens: 0 }),
+ 	apply: (state, event) => {
+@@ -373,7 +373,7 @@ const contextPressureProjectionDefinition = {
+ 		}
+ 		if (fold.deltaTokens !== 0) next = {
+ 			...next,
+-			surfaceTokens: next.surfaceTokens + fold.deltaTokens
++			surfaceTokens: Math.max(0, next.surfaceTokens + fold.deltaTokens)
+ 		};
+ 		if (state.claim === void 0 && fold.claim === void 0) return next;
+ 		const { claim: _expired, ...withoutClaim } = next;
+diff --git a/lib/types/breakdown-projection.js b/lib/types/breakdown-projection.js
+index 49f817fa..c74c0983 100644
+--- a/lib/types/breakdown-projection.js
++++ b/lib/types/breakdown-projection.js
+@@ -39,7 +39,7 @@ const breakdownSchema = z.object({
+  */
+ export const contextBreakdownProjectionDefinition = {
+     key: 'contextBreakdown',
+-    stateVersion: 2,
++    stateVersion: 3,
+     stateSchema: contextBreakdownStateSchema,
+     init: () => ({ systemTokens: 0, toolsTokens: 0, messageTokens: 0 }),
+     apply: (state, event) => {
+@@ -60,7 +60,7 @@ export const contextBreakdownProjectionDefinition = {
+         return {
+             systemTokens,
+             toolsTokens,
+-            messageTokens: state.messageTokens + fold.deltaTokens,
++            messageTokens: Math.max(0, state.messageTokens + fold.deltaTokens),
+             ...fold.claim === undefined ? {} : { claim: fold.claim },
+         };
+     },
+diff --git a/lib/types/usage-projection.js b/lib/types/usage-projection.js
+index f46460d2..16e7a5ec 100644
+--- a/lib/types/usage-projection.js
++++ b/lib/types/usage-projection.js
+@@ -141,7 +141,7 @@ export const tokenUsageProjectionDefinition = {
+  */
+ export const contextPressureProjectionDefinition = {
+     key: 'contextPressure',
+-    stateVersion: 4,
++    stateVersion: 5,
+     stateSchema: contextPressureStateSchema,
+     init: () => ({ surfaceTokens: 0 }),
+     apply: (state, event) => {
+@@ -167,7 +167,7 @@ export const contextPressureProjectionDefinition = {
+             }
+         }
+         if (fold.deltaTokens !== 0) {
+-            next = { ...next, surfaceTokens: next.surfaceTokens + fold.deltaTokens };
++            next = { ...next, surfaceTokens: Math.max(0, next.surfaceTokens + fold.deltaTokens) };
+         }
+         // A defined fold.claim is always freshly built, so presence decides claim
+         // bookkeeping: no claim before or after this event leaves `next` as is.

--- a/yarn.lock
+++ b/yarn.lock
@@ -3668,7 +3668,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@deepseek-ai/dsh-token-meter@npm:0.1.1-rc.2, @deepseek-ai/dsh-token-meter@npm:^0.1.1-rc.2":
+"@deepseek-ai/dsh-token-meter@npm:0.1.1-rc.2":
   version: 0.1.1-rc.2
   resolution: "@deepseek-ai/dsh-token-meter@npm:0.1.1-rc.2"
   dependencies:
@@ -3682,6 +3682,23 @@ __metadata:
     "@deepseek-ai/dsh-session": ^0.1.1-rc.2
     "@deepseek-ai/dsh-session-projection": ^0.1.1-rc.2
   checksum: 10c0/36821698fb949e23fdea70b0e457de7b37752fcfed0441e3fc6d5c0a6cb1e9dbe642a220bc95c4b583afff2c38eaffc8f9307e52540f6d45b46731f1cb8c415b
+  languageName: node
+  linkType: hard
+
+"@deepseek-ai/dsh-token-meter@patch:@deepseek-ai/dsh-token-meter@npm%3A0.1.1-rc.2#./patches/dsh-token-meter@0.1.1-rc.2.patch::locator=deepseek-harness-desktop%40workspace%3A.":
+  version: 0.1.1-rc.2
+  resolution: "@deepseek-ai/dsh-token-meter@patch:@deepseek-ai/dsh-token-meter@npm%3A0.1.1-rc.2#./patches/dsh-token-meter@0.1.1-rc.2.patch::version=0.1.1-rc.2&hash=ff06c1&locator=deepseek-harness-desktop%40workspace%3A."
+  dependencies:
+    "@deepseek-ai/schemastery": "npm:^3.18.1"
+    zod: "npm:^4.4.3"
+  peerDependencies:
+    "@deepseek-ai/cordis": ^4.0.1
+    "@deepseek-ai/dsh-compaction": ^0.1.1-rc.2
+    "@deepseek-ai/dsh-invariants": ^0.1.1-rc.2
+    "@deepseek-ai/dsh-llm": ^0.1.1-rc.2
+    "@deepseek-ai/dsh-session": ^0.1.1-rc.2
+    "@deepseek-ai/dsh-session-projection": ^0.1.1-rc.2
+  checksum: 10c0/6df3ca60c881f186357ac53c6ff9c0a0805a7dd6ce08f9c4c8a7b6cdddf00c69f19659b4800bb13a71bf0542d5beddab6ff681b783f17806e37bc27f9cab277b
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

- clamp message and surface token projection totals at zero after replacement/compaction deltas
- bump both projection state versions so already-persisted invalid checkpoints are discarded and replayed
- add regressions for stale negative rows and new drifted replacement math
- ship the fix through the existing exact-version Yarn patch layer

Closes #500.

## Verification

- focused negative-projection tests passed
- full `yarn check`: Desktop 82 files / 807 passed / 4 skipped; Market 274 passed
- typecheck, build, immutable install, layout, runtime closure, licenses and operation reliability passed

## Safety inspections

1. Secret/static scan: no credential/private-key signatures; `git diff --check` passed.
2. Dependency/runtime boundary: exact `@deepseek-ai/dsh-token-meter@0.1.1-rc.2` patch resolution, immutable install succeeds, runtime closure and license checks pass, pinned Harness submodule unchanged.
3. State/replay boundary: clamps only two schema-declared nonnegative aggregate totals; state-version bumps invalidate old bad rows so normal projection replay rebuilds them from durable session events; no session event data is deleted or rewritten.

## Scope

Token-meter projection arithmetic and cache-version migration only. Remove the patch once an upstream package release contains the equivalent fix.