### PR TITLE
docs: add a lifecycle-safe external development sandbox recipe

### DIFF
--- a/docs/plugin-development.en.md
+++ b/docs/plugin-development.en.md
@@ -66,33 +66,107 @@ Production code should invoke package operations from an explicit user action, v
 
 ## Plugins that work in Desktop and ordinary DSH
 
-When the same package must also run under ordinary `dsh web`, do not put Desktop services in the top-level required `inject` list. Inject ordinary dependencies first and dynamically detect Desktop:
+When the same package must also run under ordinary `dsh web`, do not put Desktop services in the top-level required `inject` list. Detect Desktop from `ctx.get('desktopProfiles')`, then keep both Desktop services together in one nested Desktop injection so the adapter unloads with either service generation:
 
 ```ts
 export const inject = ['webServer', 'loader']
 
 export function apply(ctx: Context, config: { profile?: string }): void {
-  const profiles = ctx.get('desktopProfiles')
-  if (profiles === undefined) {
+  if (ctx.get('desktopProfiles') === undefined) {
     mountOrdinaryDshManager(ctx, config.profile ?? 'web')
     return
   }
 
-  ctx.inject(['desktopPnpm'], (desktopPnpm) => {
-    mountManager(ctx, {
-      profile: profiles.current.name,
-      profileDir: profiles.current.dir,
-      runPlugin: (args, cwd, signal) => desktopPnpm.runPlugin(args, cwd, signal),
-    })
+  ctx.inject(['desktopProfiles', 'desktopPnpm'], (desktopCtx) => {
+    desktopCtx.effect(() => mountManager(desktopCtx, {
+      profile: desktopCtx.desktopProfiles.current.name,
+      profileDir: desktopCtx.desktopProfiles.current.dir,
+      runPlugin: (args, cwd, signal) =>
+        desktopCtx.desktopPnpm.runPlugin(args, cwd, signal),
+    }), 'example: Desktop plugin manager')
   })
 }
 ```
 
 The ordinary DSH fallback remains the plugin's authoritative implementation. Do not infer the Desktop profile from `process.argv`, `ctx.baseUrl`, settings, or `$DSH_HOME`; in Desktop, use `desktopProfiles.current`.
 
+## External development sandboxes
+
+An external development sandbox is an ordinary `dsh web` mirror built beside Desktop, not a second Electron application. The current public services are enough for a lifecycle-safe recipe:
+
+```ts
+import type { Context } from '@deepseek-ai/cordis'
+import type { DesktopPnpmHandle } from 'dsh-plugin-desktop/pnpm'
+import type {} from 'dsh-plugin-desktop/profile-service'
+import type {} from 'dsh-plugin-desktop/pnpm'
+
+declare function prepareSandboxProfile(options: {
+  readonly sourceProfileDir: string
+  readonly sandboxRoot: string
+  readonly pluginDir: string
+}): Promise<void>
+declare function launchExternalWebMirror(sandboxRoot: string): Promise<void>
+declare function removeSandbox(sandboxRoot: string): Promise<void>
+
+export function apply(ctx: Context): void {
+  if (ctx.get('desktopProfiles') === undefined) return
+
+  ctx.inject(['desktopProfiles', 'desktopPnpm'], (desktopCtx) => {
+    desktopCtx.effect(() => {
+      let build: DesktopPnpmHandle | undefined
+
+      async function buildAndLaunch(pluginDir: string, sandboxRoot: string): Promise<void> {
+        const sourceProfileDir = desktopCtx.desktopProfiles.current.dir
+        await prepareSandboxProfile({ sourceProfileDir, sandboxRoot, pluginDir })
+
+        const deadline = AbortSignal.timeout(5 * 60_000)
+        const operation = desktopCtx.desktopPnpm.run(
+          ['--dir', pluginDir, 'run', 'build'],
+          deadline,
+        )
+        build = operation
+        operation.stdout.resume()
+        operation.stderr.resume()
+
+        try {
+          const outcome = await operation.done
+          if (outcome.exitCode !== 0 || outcome.signal !== null) {
+            await removeSandbox(sandboxRoot)
+            throw new Error(
+              `sandbox build failed: exit=${String(outcome.exitCode)} signal=${String(outcome.signal)}`,
+            )
+          }
+        } catch (error) {
+          await removeSandbox(sandboxRoot)
+          throw error
+        } finally {
+          if (build === operation) build = undefined
+        }
+
+        await launchExternalWebMirror(sandboxRoot)
+      }
+
+      return async () => {
+        const operation = build
+        operation?.cancel()
+        await operation?.done.catch(() => {})
+      }
+    }, 'example: external development sandbox')
+  })
+}
+```
+
+For this pattern:
+
+- Treat `desktopProfiles.current.dir` as the read-only `host-web` mirror source for one Host generation. Do not mutate it, cache it across `select()`, or guess `profiles/web`.
+- Use `desktopPnpm.run(['--dir', pluginDir, 'run', 'build'], signal)` for the local checkout build so Desktop's packaged pnpm, Node ABI, and subprocess ownership remain authoritative without mutating the active profile.
+- Drain both streams, apply your own deadline, and keep the returned handle so disposal can call `cancel()` and still await `done`.
+- If `done` rejects, `exitCode` is nonzero, or `signal` is non-null, remove the temporary sandbox and stop there instead of launching the mirror.
+- The mirror launcher is external by design. The public Desktop contract does not expose a second Electron bootstrap surface.
+
 ## `run()`, `runPlugin()`, and `installPlugin()`
 
-`desktopPnpm.run(args)` is a low-level pnpm operation with the active profile as its cwd. It does not promise DSH profile initialization, caller-relative `file:`/`link:` anchoring, or `dsh.profile.bundles` reconciliation.
+`desktopPnpm.run(args)` is a low-level pnpm operation with the active profile as its cwd. It is appropriate for lifecycle-owned local work such as `['--dir', pluginDir, 'run', 'build']` when you need Desktop's packaged pnpm and Node surface without mutating the active profile. It does not promise DSH profile initialization, caller-relative `file:`/`link:` anchoring, or `dsh.profile.bundles` reconciliation.
 
 `desktopPnpm.runPlugin(args, invokingDir)` runs packaged `dsh plugin --profile <active>` for non-install mutations and preserves upstream plugin-management semantics. It rejects `add`. `installPlugin(request)` is the recoverable install path: it generates the exact package target from receipt metadata and owns the profile snapshot/WAL lifecycle.
 

--- a/docs/plugin-development.i18n.yaml
+++ b/docs/plugin-development.i18n.yaml
@@ -1,0 +1,5 @@
+# Bilingual-pair consistency record: the git blob hash of each side as of the last
+# confirmed-consistent state. Both languages carry equal authority. Update both files
+# and re-record their hashes with git hash-object after editing either side.
+plugin-development.md: da8d3215883f0a6f1437b072fdb6629f5484763a
+plugin-development.en.md: a10a2ce9a991df51c042c8f0080f9ea02a3a18fd

--- a/docs/plugin-development.md
+++ b/docs/plugin-development.md
@@ -66,33 +66,107 @@ export function apply(ctx: Context): void {
 
 ## 兼容 Desktop 和普通 DSH
 
-如果同一个插件也要在普通 `dsh web` 中运行，不要把 Desktop service 放进顶层 required `inject`。先注入普通依赖，再在 callback 中动态探测：
+如果同一个插件也要在普通 `dsh web` 中运行，不要把 Desktop service 放进顶层 required `inject`。先用 `ctx.get('desktopProfiles')` 判断是否处于 Desktop，再把两个 Desktop service 一起放进同一个嵌套 injection，让 adapter 会随着任一 service 的 generation 一起卸载：
 
 ```ts
 export const inject = ['webServer', 'loader']
 
 export function apply(ctx: Context, config: { profile?: string }): void {
-  const profiles = ctx.get('desktopProfiles')
-  if (profiles === undefined) {
+  if (ctx.get('desktopProfiles') === undefined) {
     mountOrdinaryDshManager(ctx, config.profile ?? 'web')
     return
   }
 
-  ctx.inject(['desktopPnpm'], (desktopPnpm) => {
-    mountManager(ctx, {
-      profile: profiles.current.name,
-      profileDir: profiles.current.dir,
-      runPlugin: (args, cwd, signal) => desktopPnpm.runPlugin(args, cwd, signal),
-    })
+  ctx.inject(['desktopProfiles', 'desktopPnpm'], (desktopCtx) => {
+    desktopCtx.effect(() => mountManager(desktopCtx, {
+      profile: desktopCtx.desktopProfiles.current.name,
+      profileDir: desktopCtx.desktopProfiles.current.dir,
+      runPlugin: (args, cwd, signal) =>
+        desktopCtx.desktopPnpm.runPlugin(args, cwd, signal),
+    }), 'example: Desktop plugin manager')
   })
 }
 ```
 
 普通 DSH 的 fallback 仍然是插件自己的权威实现。不要从 `process.argv`、`ctx.baseUrl`、settings 或 `$DSH_HOME` 推断 Desktop profile；在 Desktop 中以 `desktopProfiles.current` 为准。
 
+## 外部开发沙箱
+
+外部开发沙箱是构建在 Desktop 旁边的普通 `dsh web` 镜像，不是第二个 Electron 应用。当前公开 service 已足够支撑一条生命周期安全的集成路径：
+
+```ts
+import type { Context } from '@deepseek-ai/cordis'
+import type { DesktopPnpmHandle } from 'dsh-plugin-desktop/pnpm'
+import type {} from 'dsh-plugin-desktop/profile-service'
+import type {} from 'dsh-plugin-desktop/pnpm'
+
+declare function prepareSandboxProfile(options: {
+  readonly sourceProfileDir: string
+  readonly sandboxRoot: string
+  readonly pluginDir: string
+}): Promise<void>
+declare function launchExternalWebMirror(sandboxRoot: string): Promise<void>
+declare function removeSandbox(sandboxRoot: string): Promise<void>
+
+export function apply(ctx: Context): void {
+  if (ctx.get('desktopProfiles') === undefined) return
+
+  ctx.inject(['desktopProfiles', 'desktopPnpm'], (desktopCtx) => {
+    desktopCtx.effect(() => {
+      let build: DesktopPnpmHandle | undefined
+
+      async function buildAndLaunch(pluginDir: string, sandboxRoot: string): Promise<void> {
+        const sourceProfileDir = desktopCtx.desktopProfiles.current.dir
+        await prepareSandboxProfile({ sourceProfileDir, sandboxRoot, pluginDir })
+
+        const deadline = AbortSignal.timeout(5 * 60_000)
+        const operation = desktopCtx.desktopPnpm.run(
+          ['--dir', pluginDir, 'run', 'build'],
+          deadline,
+        )
+        build = operation
+        operation.stdout.resume()
+        operation.stderr.resume()
+
+        try {
+          const outcome = await operation.done
+          if (outcome.exitCode !== 0 || outcome.signal !== null) {
+            await removeSandbox(sandboxRoot)
+            throw new Error(
+              `sandbox build failed: exit=${String(outcome.exitCode)} signal=${String(outcome.signal)}`,
+            )
+          }
+        } catch (error) {
+          await removeSandbox(sandboxRoot)
+          throw error
+        } finally {
+          if (build === operation) build = undefined
+        }
+
+        await launchExternalWebMirror(sandboxRoot)
+      }
+
+      return async () => {
+        const operation = build
+        operation?.cancel()
+        await operation?.done.catch(() => {})
+      }
+    }, 'example: external development sandbox')
+  })
+}
+```
+
+这条模式里要注意：
+
+- 把 `desktopProfiles.current.dir` 当作当前 Host generation 的只读 `host-web` 镜像来源；不要修改它、跨 `select()` 缓存它，也不要猜测成 `profiles/web`。
+- 本地 checkout 的构建应使用 `desktopPnpm.run(['--dir', pluginDir, 'run', 'build'], signal)`，这样 Desktop 的打包 pnpm、Node ABI 与 subprocess ownership 才会继续保持权威，而且不会改动激活 profile。
+- 必须持续读取两个输出流，自己设置 deadline，并保留返回 handle，这样 dispose 时才能调用 `cancel()`，随后继续等待 `done`。
+- 只要 `done` rejection、`exitCode` 非零，或 `signal` 非空，就应删除临时沙箱并停止，而不是继续启动镜像。
+- 镜像启动器本身按设计属于外部组件；公开 Desktop contract 不会提供第二套 Electron bootstrap surface。
+
 ## `run()`、`runPlugin()` 和 `installPlugin()` 的区别
 
-`desktopPnpm.run(args)` 是低层 pnpm operation，cwd 是当前 profile。它不保证 DSH 的 profile 初始化、调用方相对 `file:`/`link:` source 锚定或 `dsh.profile.bundles` reconcile。
+`desktopPnpm.run(args)` 是低层 pnpm operation，cwd 是当前 profile。当你需要像 `['--dir', pluginDir, 'run', 'build']` 这样的生命周期自管本地工作，并且希望继承 Desktop 打包的 pnpm 与 Node surface、又不修改激活 profile 时，它是合适的选择。它不保证 DSH 的 profile 初始化、调用方相对 `file:`/`link:` source 锚定或 `dsh.profile.bundles` reconcile。
 
 `desktopPnpm.runPlugin(args, invokingDir)` 为非安装 mutation 执行打包的 `dsh plugin --profile <active>`，并保留上游插件管理语义。它会拒绝 `add`。`installPlugin(request)` 是可恢复安装路径：它从 receipt metadata 生成精确 package 目标，并拥有 profile 快照/WAL 生命周期。
 


### PR DESCRIPTION
## Summary

- keep `desktopProfiles` and `desktopPnpm` in one generation-scoped nested injection
- document a read-only external `dsh web` mirror sourced from the active Desktop Profile
- build local plugin checkouts through the managed argv-only pnpm service
- require stream draining, deadlines, cancellation, awaited disposal, and no launch after failed builds
- add the Chinese/English pair to the repository hash gate

Closes #427.

## Verification

- bilingual docs tests: 4/4 passed
- bilingual hash gate: 43 records / 86 documents consistent
- full `yarn check`: Desktop 81 files / 805 passed / 4 skipped; Market 274 passed
- layout, runtime closure, licenses and operation reliability passed

## Safety inspections

1. Privacy/static scan: no local absolute paths, credentials, keys, tokens or private environment details in either document.
2. Command boundary: examples use structured argv with `desktopPnpm.run`; no shell interpolation, ambient pnpm, or mutation of the active Profile.
3. Lifecycle boundary: both streams are drained, the operation has a deadline, disposal calls `cancel()` and awaits `done`, and rejection/nonzero exit/termination prevents mirror launch and removes the temporary sandbox.

## Scope

Bilingual documentation and its consistency record only; no runtime behavior changes.