### PR TITLE
feat(desktop): reveal the shell during renderer startup

### DIFF
--- a/dsh-plugin-desktop/src/electron-shell-generation.ts
+++ b/dsh-plugin-desktop/src/electron-shell-generation.ts
@@ -143,6 +143,13 @@ export class ElectronShellGeneration {
     this.flushWindowState = persistWindowState
 
     const show = (): void => { this.show() }
+    let startupSurfaceRevealed = false
+    const revealStartupSurface = (): void => {
+      if (window.isDestroyed()) return
+      if (startupSurfaceRevealed && !applicationNeedsReveal(window, platform.platform)) return
+      startupSurfaceRevealed = true
+      this.show()
+    }
     const activate = (): void => {
       if (applicationNeedsReveal(window, platform.platform)) this.show()
     }
@@ -291,7 +298,7 @@ export class ElectronShellGeneration {
       }
       return { action: 'deny' }
     })
-    window.once('ready-to-show', show)
+    window.once('ready-to-show', revealStartupSurface)
     let tray: Tray | undefined
     this.cleanupListeners = () => {
       app.off('activate', activate)
@@ -301,7 +308,7 @@ export class ElectronShellGeneration {
       window.off('move', scheduleWindowStateWrite)
       window.off('resize', scheduleWindowStateWrite)
       window.off('page-title-updated', preserveBlankTitle)
-      window.off('ready-to-show', show)
+      window.off('ready-to-show', revealStartupSurface)
       cleanupFullscreenTransition()
       window.webContents.off('before-input-event', handleZoomShortcut)
       window.webContents.off('will-frame-navigate', navigate)
@@ -316,6 +323,7 @@ export class ElectronShellGeneration {
     }
 
     try {
+      revealStartupSurface()
       await window.loadURL(spec.url)
       tray = new Tray(prepareTrayIcon(spec.trayIcons, platform.platform))
       this.tray = tray

--- a/dsh-plugin-desktop/src/window-options.ts
+++ b/dsh-plugin-desktop/src/window-options.ts
@@ -22,6 +22,7 @@ function baseWindowOptions(
     minWidth: spec.minWidth,
     minHeight: spec.minHeight,
     show: false,
+    backgroundColor: '#202124',
     icon,
     webPreferences: {
       preload,

--- a/dsh-plugin-desktop/tests/electron-runtime.spec.ts
+++ b/dsh-plugin-desktop/tests/electron-runtime.spec.ts
@@ -948,9 +948,14 @@ describe('Electron desktop runtime', () => {
     expect(trayClick).toEqual(expect.any(Function))
     expect(close).toEqual(expect.any(Function))
 
-    window?.isMinimized.mockReturnValueOnce(true)
+    expect(window?.show).toHaveBeenCalledOnce()
+    expect(window?.focus).toHaveBeenCalledOnce()
+
+    window?.isVisible.mockReturnValue(true)
     ready()
+    window?.isMinimized.mockReturnValue(true)
     activate()
+    window?.isMinimized.mockReturnValue(false)
     trayClick()
     expect(window?.restore).toHaveBeenCalledOnce()
     expect(window?.show).toHaveBeenCalledTimes(3)
@@ -966,6 +971,29 @@ describe('Electron desktop runtime', () => {
     close(quittingCloseEvent)
     expect(quittingCloseEvent.preventDefault).not.toHaveBeenCalled()
     expect(window?.hide).toHaveBeenCalledOnce()
+
+    await release()
+  })
+
+  it('reveals the startup surface before ready-to-show and does not re-show a visible window', async () => {
+    vi.spyOn(process, 'platform', 'get').mockReturnValue('darwin')
+    const { ElectronDesktopRuntime } = await import('../src/electron-runtime.ts')
+    const runtime = new ElectronDesktopRuntime(async () => {})
+    const release = runtime.schedule(spec)
+
+    await runtime.mountScheduled()
+
+    const window = electron.browserWindows[0]
+    const ready = window?.once.mock.calls.find(([event]) => event === 'ready-to-show')?.[1]
+    expect(ready).toEqual(expect.any(Function))
+    expect(window?.show).toHaveBeenCalledOnce()
+    expect(window?.focus).toHaveBeenCalledOnce()
+
+    window?.isVisible.mockReturnValue(true)
+    ready()
+
+    expect(window?.show).toHaveBeenCalledOnce()
+    expect(window?.focus).toHaveBeenCalledOnce()
 
     await release()
   })
@@ -991,8 +1019,8 @@ describe('Electron desktop runtime', () => {
     expect(click).toEqual(expect.any(Function))
     click()
     expect(electron.app.setBadgeCount).toHaveBeenLastCalledWith(0)
-    expect(window?.show).toHaveBeenCalledOnce()
-    expect(window?.focus).toHaveBeenCalledOnce()
+    expect(window?.show).toHaveBeenCalledTimes(2)
+    expect(window?.focus).toHaveBeenCalledTimes(2)
 
     window?.isFocused.mockReturnValue(true)
     runtime.notifyAttention({ title: 'Ignored', body: 'Focused window' })
@@ -1032,8 +1060,8 @@ describe('Electron desktop runtime', () => {
     window?.isFullScreen.mockReturnValue(false)
     runtime.show()
     expect(window?.setFullScreen.mock.calls).toEqual([[false], [true]])
-    expect(window?.show).toHaveBeenCalledOnce()
-    expect(window?.focus).toHaveBeenCalledOnce()
+    expect(window?.show).toHaveBeenCalledTimes(2)
+    expect(window?.focus).toHaveBeenCalledTimes(2)
 
     await release()
   })
@@ -1057,8 +1085,8 @@ describe('Electron desktop runtime', () => {
 
     expect(window?.hide).not.toHaveBeenCalled()
     expect(window?.setFullScreen.mock.calls).toEqual([[false], [true]])
-    expect(window?.show).toHaveBeenCalledOnce()
-    expect(window?.focus).toHaveBeenCalledOnce()
+    expect(window?.show).toHaveBeenCalledTimes(2)
+    expect(window?.focus).toHaveBeenCalledTimes(2)
 
     await release()
   })
@@ -1100,10 +1128,13 @@ describe('Electron desktop runtime', () => {
 
     electron.app.isHidden.mockReturnValue(true)
     window?.isVisible.mockReturnValue(false)
+    const appShowCount = electron.app.show.mock.calls.length
+    const focusCountBeforeReveal = window?.focus.mock.calls.length ?? 0
     didBecomeActive()
-    expect(electron.app.show).toHaveBeenCalledOnce()
-    expect(electron.app.show.mock.invocationCallOrder[0]).toBeLessThan(window?.show.mock.invocationCallOrder[0] ?? Infinity)
-    expect(window?.focus).toHaveBeenCalledOnce()
+    expect(electron.app.show).toHaveBeenCalledTimes(appShowCount + 1)
+    expect((electron.app.show.mock.invocationCallOrder.at(-1) ?? Infinity))
+      .toBeLessThan(window?.show.mock.invocationCallOrder.at(-1) ?? Infinity)
+    expect(window?.focus).toHaveBeenCalledTimes(focusCountBeforeReveal + 1)
 
     electron.app.isHidden.mockReturnValue(false)
     window?.isVisible.mockReturnValue(true)
@@ -1710,8 +1741,8 @@ describe('Electron desktop runtime', () => {
     expect(notification?.once).toHaveBeenCalledWith('click', expect.any(Function))
     const click = notification?.once.mock.calls.find(([event]) => event === 'click')?.[1]
     click()
-    expect(activeWindow?.show).toHaveBeenCalledOnce()
-    expect(activeWindow?.focus).toHaveBeenCalledOnce()
+    expect(activeWindow?.show).toHaveBeenCalledTimes(2)
+    expect(activeWindow?.focus).toHaveBeenCalledTimes(2)
 
     await release()
   })

--- a/dsh-plugin-desktop/tests/window-options.spec.ts
+++ b/dsh-plugin-desktop/tests/window-options.spec.ts
@@ -51,6 +51,7 @@ describe('compatibility BrowserWindow options', () => {
       minWidth: 900,
       minHeight: 640,
       show: false,
+      backgroundColor: '#202124',
       icon,
       titleBarStyle: 'hiddenInset',
       trafficLightPosition: { x: 16, y: DESKTOP_FRAME_MACOS_TRAFFIC_LIGHT_TOP },
@@ -70,6 +71,7 @@ describe('compatibility BrowserWindow options', () => {
     const options = compatibilityWindowOptions(spec, {} as NativeImage, 'win32', preload)
 
     expect(options.title).toBe('DeepSeek Harness Desktop')
+    expect(options.backgroundColor).toBe('#202124')
     expect(options.autoHideMenuBar).toBe(true)
     expect(options.titleBarStyle).toBe('hidden')
     expect(options.titleBarOverlay).toEqual(expect.objectContaining({ height: DESKTOP_FRAME_HEIGHT }))


### PR DESCRIPTION
## Summary

- reveal the generation-owned main shell before waiting for `ready-to-show`
- retain the guarded `ready-to-show` listener as a fallback when the window still needs reveal
- give opaque main windows the same stable dark background as the boot surface
- leave renderer health, navigation denial and recovery routing unchanged

Closes #435.

## Verification

- window/runtime focused suites: 96 passed
- renderer-health suite: 10 passed
- full `yarn check`: Desktop 81 files / 806 passed / 4 skipped; Market 274 passed
- typecheck, build, layout, runtime closure, licenses and operation reliability passed

## Safety inspections

1. Secret/static scan: no credential/private-key signatures; `git diff --check` passed.
2. Dependency/runtime boundary: no manifests, lockfiles, scripts or recovery/health contracts changed; runtime closure and license checks passed.
3. Electron lifecycle boundary: existing frame-navigation, redirect, popup and renderer-gone guards remain installed before navigation; listener cleanup remains generation-scoped; early reveal changes presentation timing only and does not accept renderer health early.

## Scope

Main BrowserWindow visibility timing and opaque startup background only.

## Manual gap

No real Windows/macOS startup recording was captured locally; platform CI and the mocked lifecycle tests cover the code path.