### PR TITLE
feat(desktop): open existing session actions on right-click

### DIFF
--- a/dsh-plugin-desktop/src/client/index.ts
+++ b/dsh-plugin-desktop/src/client/index.ts
@@ -11,6 +11,7 @@ import { applyDesktopSettings } from './desktop-settings.ts'
 import { installDesktopDirectoryPickerBridge, requestDesktopDirectoryValidation } from './directory-picker.ts'
 import { parseDesktopClientEnvironment } from './environment.ts'
 import { applyExtendedShell, applyFramedShell } from './extended-shell.ts'
+import { installDesktopSessionContextMenuBridge } from './session-context-menu.ts'
 import { installWorkspaceFolderDrop } from './workspace-folder-drop.ts'
 import { desktopWindowService, provideDesktopWindow } from './window-service.ts'
 
@@ -100,6 +101,10 @@ export function apply(ctx: ClientContext): void {
         : {}),
     }),
     'dsh-plugin-desktop: workspace folder drop',
+  )
+  ctx.effect(
+    () => installDesktopSessionContextMenuBridge(),
+    'dsh-plugin-desktop: session context menu bridge',
   )
   if (environment.platform === 'win32') {
     ctx.effect(

--- a/dsh-plugin-desktop/src/client/session-context-menu.ts
+++ b/dsh-plugin-desktop/src/client/session-context-menu.ts
@@ -1,0 +1,47 @@
+/** Vertical gap applied by the shared Menu primitive to a bottom-side anchor. */
+const MENU_ANCHOR_GAP = 4
+
+export interface DesktopSessionContextMenuPoint {
+  readonly x: number
+  readonly y: number
+}
+
+export interface DesktopSessionContextMenuEvent {
+  readonly clientX: number
+  readonly clientY: number
+  preventDefault(): void
+  stopPropagation(): void
+}
+
+export type DesktopSessionContextMenuBridge = (
+  event: DesktopSessionContextMenuEvent,
+  blank: boolean,
+) => DesktopSessionContextMenuPoint | undefined
+
+export interface DesktopSessionContextMenuWindow {
+  __DSH_DESKTOP_SESSION_CONTEXT_MENU__?: DesktopSessionContextMenuBridge
+}
+
+/** Suppress the native menu and convert one session event into a shared Menu anchor. */
+export function resolveDesktopSessionContextMenu(
+  event: DesktopSessionContextMenuEvent,
+  blank: boolean,
+): DesktopSessionContextMenuPoint | undefined {
+  event.preventDefault()
+  event.stopPropagation()
+  if (blank) return undefined
+  return { x: event.clientX, y: event.clientY - MENU_ANCHOR_GAP }
+}
+
+/** Install the Desktop-only bridge consumed by the version-pinned workspace UI patch. */
+export function installDesktopSessionContextMenuBridge(
+  target: DesktopSessionContextMenuWindow = window as DesktopSessionContextMenuWindow,
+): () => void {
+  const previous = target.__DSH_DESKTOP_SESSION_CONTEXT_MENU__
+  target.__DSH_DESKTOP_SESSION_CONTEXT_MENU__ = resolveDesktopSessionContextMenu
+  return () => {
+    if (target.__DSH_DESKTOP_SESSION_CONTEXT_MENU__ !== resolveDesktopSessionContextMenu) return
+    if (previous === undefined) delete target.__DSH_DESKTOP_SESSION_CONTEXT_MENU__
+    else target.__DSH_DESKTOP_SESSION_CONTEXT_MENU__ = previous
+  }
+}

--- a/dsh-plugin-desktop/tests/client-session-context-menu.spec.ts
+++ b/dsh-plugin-desktop/tests/client-session-context-menu.spec.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it, vi } from 'vitest'
+import {
+  installDesktopSessionContextMenuBridge,
+  resolveDesktopSessionContextMenu,
+  type DesktopSessionContextMenuWindow,
+} from '../src/client/session-context-menu.ts'
+
+describe('desktop session context-menu bridge', () => {
+  it('suppresses the native menu and anchors a real session at the pointer', () => {
+    const event = {
+      clientX: 240,
+      clientY: 180,
+      preventDefault: vi.fn(),
+      stopPropagation: vi.fn(),
+    }
+
+    expect(resolveDesktopSessionContextMenu(event, false)).toEqual({ x: 240, y: 176 })
+    expect(event.preventDefault).toHaveBeenCalledOnce()
+    expect(event.stopPropagation).toHaveBeenCalledOnce()
+  })
+
+  it('suppresses the native menu without exposing actions for a blank session', () => {
+    const event = {
+      clientX: 12,
+      clientY: 24,
+      preventDefault: vi.fn(),
+      stopPropagation: vi.fn(),
+    }
+
+    expect(resolveDesktopSessionContextMenu(event, true)).toBeUndefined()
+    expect(event.preventDefault).toHaveBeenCalledOnce()
+    expect(event.stopPropagation).toHaveBeenCalledOnce()
+  })
+
+  it('restores the previous bridge without replacing a newer owner', () => {
+    const previous = vi.fn()
+    const replacement = vi.fn()
+    const target = {
+      __DSH_DESKTOP_SESSION_CONTEXT_MENU__: previous,
+    } as DesktopSessionContextMenuWindow
+
+    const dispose = installDesktopSessionContextMenuBridge(target)
+    expect(target.__DSH_DESKTOP_SESSION_CONTEXT_MENU__).toBe(resolveDesktopSessionContextMenu)
+    target.__DSH_DESKTOP_SESSION_CONTEXT_MENU__ = replacement
+    dispose()
+    expect(target.__DSH_DESKTOP_SESSION_CONTEXT_MENU__).toBe(replacement)
+
+    const disposeOwned = installDesktopSessionContextMenuBridge(target)
+    disposeOwned()
+    expect(target.__DSH_DESKTOP_SESSION_CONTEXT_MENU__).toBe(replacement)
+  })
+})

--- a/dsh-plugin-desktop/tests/package.spec.ts
+++ b/dsh-plugin-desktop/tests/package.spec.ts
@@ -242,7 +242,7 @@ describe('published package surface', () => {
     }
   })
 
-  it('marks the upstream Workspace browser as the desktop folder-drop target', () => {
+  it('patches Desktop-owned workspace interactions into the upstream browser', () => {
     const patchPath = './patches/dsh-client-ui-workspace@0.1.1-rc.2.patch'
     expect(workspaceManifest.resolutions).toMatchObject({
       '@deepseek-ai/dsh-client-ui-workspace@npm:0.1.1-rc.2': expect.stringContaining(patchPath),
@@ -253,8 +253,15 @@ describe('published package surface', () => {
       'node_modules/@deepseek-ai/dsh-client-ui-workspace/lib/client.js',
       packageRoot,
     ), 'utf8')
-    expect(patch).toContain('data-dsh-workspace-drop-target')
-    expect(installedClient).toContain('data-dsh-workspace-drop-target')
+    for (const marker of [
+      'data-dsh-workspace-drop-target',
+      '__DSH_DESKTOP_SESSION_CONTEXT_MENU__',
+      'data-dsh-session-context-menu',
+      'contextMenuPoint',
+    ]) {
+      expect(patch).toContain(marker)
+      expect(installedClient).toContain(marker)
+    }
   })
 
   it('keeps API selection available after overriding a provider base URL', () => {

--- a/dsh-plugin-desktop/tsconfig.tests.client.json
+++ b/dsh-plugin-desktop/tsconfig.tests.client.json
@@ -12,6 +12,7 @@
     "tests/client-directory-picker.spec.ts",
     "tests/client-desktop-settings.spec.ts",
     "tests/client-environment.spec.ts",
+    "tests/client-session-context-menu.spec.ts",
     "tests/client-workspace-folder-drop.spec.ts",
     "tests/theme-presenter.spec.ts"
   ]

--- a/patches/dsh-client-ui-workspace@0.1.1-rc.2.patch
+++ b/patches/dsh-client-ui-workspace@0.1.1-rc.2.patch
@@ -1,8 +1,73 @@
 diff --git a/lib/client.js b/lib/client.js
-index 2f0be4e..dfdc4fd 100644
+index 2f0be4e..e463065 100644
 --- a/lib/client.js
 +++ b/lib/client.js
-@@ -1878,6 +1878,7 @@ window.__ModuleLoader__.load({
+@@ -697,6 +697,7 @@ window.__ModuleLoader__.load({
+ 			const statuses = sessionStatuses(node, t);
+ 			const showStatus = statuses[0].state !== "done" || row.completed;
+ 			const [menuOpen, setMenuOpen] = (0, react.useState)(false);
++			const [contextMenuPoint, setContextMenuPoint] = (0, react.useState)(null);
+ 			const sessionMenuItems = [
+ 				{
+ 					id: "rename",
+@@ -719,9 +720,18 @@ window.__ModuleLoader__.load({
+ 					className: clsx(Rows_module_css_default.sessionRow, selected && Rows_module_css_default.selected, menuOpen && Rows_module_css_default.menuOpen, flat && !showStatus && Rows_module_css_default.flatSessionRowWithoutStatus, drag?.marker === "before" && Rows_module_css_default.dropBefore, drag?.marker === "after" && Rows_module_css_default.dropAfter),
+ 					role: "treeitem",
+ 					"aria-selected": selected,
++					"data-dsh-session-context-menu": row.blank ? void 0 : "",
+ 					onClick: () => {
+ 						onOpen(node.id);
+ 					},
++					onContextMenu: (event) => {
++						const bridge = window.__DSH_DESKTOP_SESSION_CONTEXT_MENU__;
++						if (bridge === void 0) return;
++						const point = bridge(event, row.blank);
++						if (point === void 0) return;
++						setContextMenuPoint(point);
++						setMenuOpen(true);
++					},
+ 					draggable: drag !== void 0,
+ 					onDragStart: drag === void 0 ? void 0 : (e) => {
+ 						e.dataTransfer.effectAllowed = "move";
+@@ -759,22 +769,36 @@ window.__ModuleLoader__.load({
+ 								open: menuOpen,
+ 								onClose: () => {
+ 									setMenuOpen(false);
++									setContextMenuPoint(null);
+ 								},
+ 								items: sessionMenuItems,
+ 								onSelect: (id) => {
+ 									setMenuOpen(false);
++									setContextMenuPoint(null);
+ 									if (id === "rename") onRename(node.id, row.title);
+ 									if (id === "fork") onFork(node.id);
+ 									if (id === "archive") onArchive(node.id);
+ 								},
+ 								portal: true,
+-								closeOnPointerLeave: true,
++								closeOnPointerLeave: contextMenuPoint === null,
++								getAnchorRect: contextMenuPoint === null ? void 0 : () => ({
++									left: contextMenuPoint.x,
++									right: contextMenuPoint.x,
++									top: contextMenuPoint.y,
++									bottom: contextMenuPoint.y,
++									width: 0,
++									height: 0,
++									x: contextMenuPoint.x,
++									y: contextMenuPoint.y,
++									toJSON: () => ({})
++								}),
+ 								anchor: (0, react_jsx_runtime.jsx)("button", {
+ 									type: "button",
+ 									className: Rows_module_css_default.iconButton,
+ 									"aria-label": t("actions.session.aria", { name: title }),
+ 									onClick: (e) => {
+ 										e.stopPropagation();
++										setContextMenuPoint(null);
+ 										setMenuOpen((v) => !v);
+ 									},
+ 									children: (0, react_jsx_runtime.jsx)(_deepseek_ai_dsh_client_ui_primitives.IconEllipsisOutline16, {})
+@@ -1878,6 +1902,7 @@ window.__ModuleLoader__.load({
  			};
  			return (0, react_jsx_runtime.jsxs)("div", {
  				className: clsx(WorkspaceBrowser_module_css_default.root, !wide && WorkspaceBrowser_module_css_default.rail),

--- a/yarn.lock
+++ b/yarn.lock
@@ -2159,7 +2159,7 @@ __metadata:
 
 "@deepseek-ai/dsh-client-ui-workspace@patch:@deepseek-ai/dsh-client-ui-workspace@npm%3A0.1.1-rc.2#./patches/dsh-client-ui-workspace@0.1.1-rc.2.patch::locator=deepseek-harness-desktop%40workspace%3A.":
   version: 0.1.1-rc.2
-  resolution: "@deepseek-ai/dsh-client-ui-workspace@patch:@deepseek-ai/dsh-client-ui-workspace@npm%3A0.1.1-rc.2#./patches/dsh-client-ui-workspace@0.1.1-rc.2.patch::version=0.1.1-rc.2&hash=73236e&locator=deepseek-harness-desktop%40workspace%3A."
+  resolution: "@deepseek-ai/dsh-client-ui-workspace@patch:@deepseek-ai/dsh-client-ui-workspace@npm%3A0.1.1-rc.2#./patches/dsh-client-ui-workspace@0.1.1-rc.2.patch::version=0.1.1-rc.2&hash=13d05e&locator=deepseek-harness-desktop%40workspace%3A."
   dependencies:
     clsx: "npm:^2.0.0"
   peerDependencies:
@@ -2170,7 +2170,7 @@ __metadata:
     "@deepseek-ai/dsh-client-ui-conversation": ^0.1.1-rc.2
     "@deepseek-ai/dsh-client-ui-sidebar": ^0.1.1-rc.2
     "@deepseek-ai/dsh-invariants": ^0.1.1-rc.2
-  checksum: 10c0/74966bea1912a2de5b19947003b6932bc300ce13e1ee4340f7178033e932306ae2e1d704ad7b9f7140c520d9290b137f90a59b722d1fd611e6deed240bdefade
+  checksum: 10c0/b358c268b9c13354ded2a971be64e1d79500be153f7cfb5e5c1594767bd3a76959ece6185aea1d1910368d8ec7145bb7ed96a37e9afad165684d978aba141ecd
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary
- open the workspace component's existing session menu from right-click on nonblank rows
- reuse only Rename, Fork, and Archive at the pointer location
- keep the ellipsis menu, Escape/outside-click close, and drag behavior intact
- suppress the native menu on the blank New Session placeholder without exposing actions

This is a clean rc.2 rebuild that supersedes #446. It intentionally omits Pin, Unread, Share, and New Window because DSH does not yet expose matching durable session semantics.

## Verification
- full `corepack yarn check`: Market 274 passed; Desktop 810 passed, 4 skipped; runtime closure 201 nodes; licenses 544 production packages
- focused bridge/package tests: 34 passed, 1 skipped
- immutable install and installed-bundle patch verification passed

## Safety review
1. Static and secret scans passed; no dangerous browser or process API added.
2. No dependency version changes; the exact rc.2 workspace bundle remains pinned through the existing patch boundary.
3. The bridge exposes no action identifiers and the patched UI still routes only Rename/Fork/Archive through existing callbacks.

Manual gap: no packaged Windows/Linux pointer interaction was recorded.