### PR TITLE
fix(host): preserve model input modalities in the catalog

### DIFF
--- a/dsh-plugin-desktop/tests/package.spec.ts
+++ b/dsh-plugin-desktop/tests/package.spec.ts
@@ -344,6 +344,37 @@ describe('published package surface', () => {
     }
   })
 
+  it('preserves model input modalities in the Host session catalog', () => {
+    const patchPath = './patches/dsh-host-apiproxy-model-modalities@0.1.1-rc.2.patch'
+    expect(workspaceManifest.resolutions).toMatchObject({
+      '@deepseek-ai/dsh-host-apiproxy@npm:0.1.1-rc.2': expect.stringContaining(patchPath),
+      '@deepseek-ai/dsh-host-apiproxy@npm:^0.1.1-rc.2': expect.stringContaining(patchPath),
+    })
+    const patch = readFileSync(new URL(patchPath, workspaceRoot), 'utf8')
+    const installedRoot = new URL(
+      'node_modules/@deepseek-ai/dsh-host-apiproxy/',
+      packageRoot,
+    )
+    const installedRuntime = readFileSync(new URL('lib/index.js', installedRoot), 'utf8')
+    const installedSchema = readFileSync(
+      new URL('lib/types/api/sessions.schema.js', installedRoot),
+      'utf8',
+    )
+    const installedTypes = readFileSync(
+      new URL('lib/types/api/sessions.d.ts', installedRoot),
+      'utf8',
+    )
+    const schemaMarker = 'inputModalities: z.array(z.enum([\'text\', \'image\'])).optional()'
+    const projectionMarker = '{ inputModalities: [...model.inputModalities] }'
+
+    expect(patch).toContain(schemaMarker)
+    expect(patch).toContain(projectionMarker)
+    expect(installedRuntime).toContain('inputModalities: z$1.array(z$1.enum(["text", "image"])).optional()')
+    expect(installedRuntime).toContain(projectionMarker)
+    expect(installedSchema).toContain(schemaMarker)
+    expect(installedTypes).toContain("inputModalities?: readonly ('text' | 'image')[];")
+  })
+
   it('localizes Trajectory toolbar labels in Simplified Chinese', () => {
     const patchPath = './patches/dsh-client-ui-trajectory@0.1.1-rc.2.patch'
     expect(workspaceManifest.resolutions).toMatchObject({

--- a/package.json
+++ b/package.json
@@ -19,6 +19,8 @@
     "@deepseek-ai/dsh-app-boot@npm:^0.1.1-rc.2": "patch:@deepseek-ai/dsh-app-boot@npm%3A0.1.1-rc.2#./patches/dsh-app-boot@0.1.1-rc.2.patch",
     "@deepseek-ai/dsh-agent-loop@npm:0.1.1-rc.2": "patch:@deepseek-ai/dsh-agent-loop@npm%3A0.1.1-rc.2#./patches/dsh-agent-loop@0.1.1-rc.2.patch",
     "@deepseek-ai/dsh-agent-loop@npm:^0.1.1-rc.2": "patch:@deepseek-ai/dsh-agent-loop@npm%3A0.1.1-rc.2#./patches/dsh-agent-loop@0.1.1-rc.2.patch",
+    "@deepseek-ai/dsh-host-apiproxy@npm:0.1.1-rc.2": "patch:@deepseek-ai/dsh-host-apiproxy@npm%3A0.1.1-rc.2#./patches/dsh-host-apiproxy-model-modalities@0.1.1-rc.2.patch",
+    "@deepseek-ai/dsh-host-apiproxy@npm:^0.1.1-rc.2": "patch:@deepseek-ai/dsh-host-apiproxy@npm%3A0.1.1-rc.2#./patches/dsh-host-apiproxy-model-modalities@0.1.1-rc.2.patch",
     "@deepseek-ai/dsh-llm-deepseek@npm:^0.1.1-rc.2": "patch:@deepseek-ai/dsh-llm-deepseek@npm%3A0.1.1-rc.2#./patches/dsh-llm-deepseek@0.1.1-rc.2.patch",
     "@deepseek-ai/dsh-sandbox-windows-acl@npm:0.1.1-rc.2": "patch:@deepseek-ai/dsh-sandbox-windows-acl@npm%3A0.1.1-rc.2#./patches/dsh-sandbox-windows-acl@0.1.1-rc.2.patch",
     "@deepseek-ai/dsh-sandbox-windows-acl@npm:^0.1.1-rc.2": "patch:@deepseek-ai/dsh-sandbox-windows-acl@npm%3A0.1.1-rc.2#./patches/dsh-sandbox-windows-acl@0.1.1-rc.2.patch",

--- a/patches/dsh-host-apiproxy-model-modalities@0.1.1-rc.2.patch
+++ b/patches/dsh-host-apiproxy-model-modalities@0.1.1-rc.2.patch
@@ -1,0 +1,18 @@
+diff --git a/lib/index.js b/lib/index.js
+--- a/lib/index.js
++++ b/lib/index.js
+@@ -509,0 +510 @@ const modelCatalogModelSchema = z$1.object({
++	inputModalities: z$1.array(z$1.enum(["text", "image"])).optional(),
+@@ -1025,0 +1027 @@ async function buildModelCatalog(ctx) {
++					...model.inputModalities === void 0 ? {} : { inputModalities: [...model.inputModalities] },
+diff --git a/lib/types/api/sessions.schema.js b/lib/types/api/sessions.schema.js
+--- a/lib/types/api/sessions.schema.js
++++ b/lib/types/api/sessions.schema.js
+@@ -124,0 +125 @@ export const modelCatalogModelSchema = z.object({
++    inputModalities: z.array(z.enum(['text', 'image'])).optional(),
+diff --git a/lib/types/api/sessions.d.ts b/lib/types/api/sessions.d.ts
+--- a/lib/types/api/sessions.d.ts
++++ b/lib/types/api/sessions.d.ts
+@@ -126,0 +127,2 @@ export interface ModelCatalogModel {
++    /** Accepted request modalities advertised by the exact model route. */
++    inputModalities?: readonly ('text' | 'image')[];

--- a/yarn.lock
+++ b/yarn.lock
@@ -2531,7 +2531,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@deepseek-ai/dsh-host-apiproxy@npm:0.1.1-rc.2, @deepseek-ai/dsh-host-apiproxy@npm:^0.1.1-rc.2":
+"@deepseek-ai/dsh-host-apiproxy@npm:0.1.1-rc.2":
   version: 0.1.1-rc.2
   resolution: "@deepseek-ai/dsh-host-apiproxy@npm:0.1.1-rc.2"
   dependencies:
@@ -2569,6 +2569,47 @@ __metadata:
     "@deepseek-ai/dsh-cordis-host-runner": ^0.1.1-rc.2
     "@deepseek-ai/dsh-invariants": ^0.1.1-rc.2
   checksum: 10c0/dc174667bd31b0a586f88c169caf5f4b091e04a2f5e28866ed8b430523fe8598ee74e3a64fee21afceaf628b85bc8561a683c93b29fb89f260bcbd770c9de540
+  languageName: node
+  linkType: hard
+
+"@deepseek-ai/dsh-host-apiproxy@patch:@deepseek-ai/dsh-host-apiproxy@npm%3A0.1.1-rc.2#./patches/dsh-host-apiproxy-model-modalities@0.1.1-rc.2.patch::locator=deepseek-harness-desktop%40workspace%3A.":
+  version: 0.1.1-rc.2
+  resolution: "@deepseek-ai/dsh-host-apiproxy@patch:@deepseek-ai/dsh-host-apiproxy@npm%3A0.1.1-rc.2#./patches/dsh-host-apiproxy-model-modalities@0.1.1-rc.2.patch::version=0.1.1-rc.2&hash=b516cd&locator=deepseek-harness-desktop%40workspace%3A."
+  dependencies:
+    "@deepseek-ai/dsh-agent": "npm:^0.1.1-rc.2"
+    "@deepseek-ai/dsh-agent-default-model": "npm:^0.1.1-rc.2"
+    "@deepseek-ai/dsh-api-remotes": "npm:^0.1.1-rc.2"
+    "@deepseek-ai/dsh-attachment": "npm:^0.1.1-rc.2"
+    "@deepseek-ai/dsh-brand": "npm:^0.1.1-rc.2"
+    "@deepseek-ai/dsh-commands": "npm:^0.1.1-rc.2"
+    "@deepseek-ai/dsh-credentials": "npm:^0.1.1-rc.2"
+    "@deepseek-ai/dsh-goal": "npm:^0.1.1-rc.2"
+    "@deepseek-ai/dsh-host-directory-picker": "npm:^0.1.1-rc.2"
+    "@deepseek-ai/dsh-jobs": "npm:^0.1.1-rc.2"
+    "@deepseek-ai/dsh-llm": "npm:^0.1.1-rc.2"
+    "@deepseek-ai/dsh-native-command": "npm:^0.1.1-rc.2"
+    "@deepseek-ai/dsh-session": "npm:^0.1.1-rc.2"
+    "@deepseek-ai/dsh-session-persistence": "npm:^0.1.1-rc.2"
+    "@deepseek-ai/dsh-session-projection": "npm:^0.1.1-rc.2"
+    "@deepseek-ai/dsh-session-projection-cache": "npm:^0.1.1-rc.2"
+    "@deepseek-ai/dsh-session-query": "npm:^0.1.1-rc.2"
+    "@deepseek-ai/dsh-session-title": "npm:^0.1.1-rc.2"
+    "@deepseek-ai/dsh-settings": "npm:^0.1.1-rc.2"
+    "@deepseek-ai/dsh-skill": "npm:^0.1.1-rc.2"
+    "@deepseek-ai/dsh-subagent": "npm:^0.1.1-rc.2"
+    "@deepseek-ai/dsh-tools": "npm:^0.1.1-rc.2"
+    "@deepseek-ai/dsh-user-approval": "npm:^0.1.1-rc.2"
+    "@deepseek-ai/dsh-user-questions": "npm:^0.1.1-rc.2"
+    "@deepseek-ai/dsh-workspace": "npm:^0.1.1-rc.2"
+    "@deepseek-ai/schemastery": "npm:^3.18.1"
+    fflate: "npm:^0.8.2"
+    zod: "npm:^4.4.3"
+  peerDependencies:
+    "@deepseek-ai/cordis": ^4.0.1
+    "@deepseek-ai/dsh-agent-presets": ^0.1.1-rc.2
+    "@deepseek-ai/dsh-cordis-host-runner": ^0.1.1-rc.2
+    "@deepseek-ai/dsh-invariants": ^0.1.1-rc.2
+  checksum: 10c0/345890ef07bf6243cca3124a99affc35076837dd1c234363bc8563493bb11b3f254f72d019b8a05bbdf07bca96ec7fdc664f1651764f3a55474082522e06db22
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary
- preserve adapter-owned `inputModalities` in the Host session model catalog
- keep the runtime projection, catalog schema, and public TypeScript type aligned
- constrain advertised modalities to the currently supported `text` and `image` values

This is the protocol-only first stage that supersedes part of #470. It does not add model-selection badges or attachment UI.

## Verification
- full `corepack yarn check`
  - Market: 274 passed
  - Desktop: 808 passed, 4 skipped
  - build, typecheck, layout, runtime closure, loader/profile, licenses, and operation gates passed
- focused package surface: 32 passed, 1 skipped
- schema behavior accepts text/image and rejects audio
- immutable install passed

## Safety review
1. Static and secret scans passed.
2. Dependency graph changes only by an exact patch locator for the already pinned rc.2 Host package.
3. The patch copies immutable provider metadata; it does not change request serialization, credentials, attachments, or model routing.

Manual gap: no packaged end-to-end catalog response was recorded against a live DeepSeek API.

Related: #470