### PR TITLE
fix(runtime): bridge rc.1 LLM adapters on rc.2

### DIFF
--- a/dsh-plugin-desktop/tests/llm-legacy-adapter-compat.spec.ts
+++ b/dsh-plugin-desktop/tests/llm-legacy-adapter-compat.spec.ts
@@ -1,0 +1,78 @@
+import { Context } from '@deepseek-ai/cordis'
+import LlmRuntime, {
+  type GenerateOptions,
+  type LlmAdapter,
+  type LlmResolvedModelInfo,
+  type StreamChunk,
+} from '@deepseek-ai/dsh-llm'
+import { describe, expect, it } from 'vitest'
+
+const SCRIPT: StreamChunk[] = [
+  { type: 'block-start', index: 0, blockType: 'text' },
+  { type: 'text-delta', index: 0, text: 'legacy adapter reply' },
+  { type: 'block-end', index: 0, block: { type: 'text', text: 'legacy adapter reply' } },
+  { type: 'finish', reason: { kind: 'stop' } },
+]
+
+async function collect(stream: AsyncIterable<StreamChunk>): Promise<StreamChunk[]> {
+  const chunks: StreamChunk[] = []
+  for await (const chunk of stream) chunks.push(chunk)
+  return chunks
+}
+
+describe('legacy LLM adapter compatibility', () => {
+  it('adapts the rc.1 resolveModel and stream contract without swallowing invalid adapters', async () => {
+    const resolved: Array<{ provider: string; model: string }> = []
+    const streamed: GenerateOptions[] = []
+    const legacyAdapter = {
+      providerInfo: (provider: string) => ({ id: provider, name: provider }),
+      providerRetryPolicy: () => undefined,
+      listModels: () => Promise.resolve([]),
+      resolveModel: (provider: string, model: string): Promise<LlmResolvedModelInfo> => {
+        resolved.push({ provider, model })
+        return Promise.resolve({ provider, id: model, name: model, defaultMaxTokens: 256 })
+      },
+      stream: async function * (options: GenerateOptions): AsyncIterable<StreamChunk> {
+        streamed.push(options)
+        yield * SCRIPT
+      },
+    } as unknown as LlmAdapter
+
+    const ctx = new Context()
+    await ctx.plugin(LlmRuntime)
+    ctx.llm.registerAdapter(['legacy'], legacyAdapter)
+
+    const prepared = await ctx.llm.prepareCall({ provider: 'legacy', model: 'rc1-model' })
+    expect(prepared.config).toEqual({ provider: 'legacy', model: 'rc1-model', maxTokens: 256 })
+    expect(resolved).toEqual([{ provider: 'legacy', model: 'rc1-model' }])
+
+    expect(await collect(prepared.stream({ ...prepared.config, messages: [] }))).toEqual(SCRIPT)
+    expect(streamed).toHaveLength(1)
+    expect(streamed[0]).toMatchObject({ provider: 'legacy', model: 'rc1-model', maxTokens: 256 })
+
+    expect(await collect(ctx.llm.stream({
+      provider: 'legacy',
+      model: 'direct-model',
+      messages: [],
+    }))).toEqual(SCRIPT)
+    expect(resolved.at(-1)).toEqual({ provider: 'legacy', model: 'direct-model' })
+  })
+
+  it('rejects adapters that match neither the rc.2 nor rc.1 contract', async () => {
+    const malformedAdapter = {
+      providerInfo: (provider: string) => ({ id: provider, name: provider }),
+      providerRetryPolicy: () => undefined,
+      listModels: () => Promise.resolve([]),
+      stream: async function * (): AsyncIterable<StreamChunk> {
+        yield * SCRIPT
+      },
+    } as unknown as LlmAdapter
+
+    const ctx = new Context()
+    await ctx.plugin(LlmRuntime)
+    ctx.llm.registerAdapter(['malformed'], malformedAdapter)
+
+    await expect(ctx.llm.prepareCall({ provider: 'malformed', model: 'model' }))
+      .rejects.toMatchObject({ code: 'INVALID_ADAPTER' })
+  })
+})

--- a/dsh-plugin-desktop/tests/package.spec.ts
+++ b/dsh-plugin-desktop/tests/package.spec.ts
@@ -172,6 +172,22 @@ describe('published package surface', () => {
     expect(installedBoot).toContain(marker)
   })
 
+  it('patches the rc.2 LLM runtime with the explicit rc.1 adapter bridge', () => {
+    const patchPath = './patches/dsh-llm-legacy-adapter@0.1.1-rc.2.patch'
+    expect(workspaceManifest.resolutions).toMatchObject({
+      '@deepseek-ai/dsh-llm@npm:0.1.1-rc.2': expect.stringContaining(patchPath),
+      '@deepseek-ai/dsh-llm@npm:^0.1.1-rc.2': expect.stringContaining(patchPath),
+    })
+    const marker = 'does not implement the rc.2 prepareCall contract or the rc.1 resolveModel/stream contract'
+    const patch = readFileSync(new URL(patchPath, workspaceRoot), 'utf8')
+    const installedLlm = readFileSync(new URL(
+      'node_modules/@deepseek-ai/dsh-llm/lib/index.js',
+      packageRoot,
+    ), 'utf8')
+    expect(patch).toContain(marker)
+    expect(installedLlm).toContain(marker)
+  })
+
   it('patches the browse panel with the Windows native-picker icon bridge', () => {
     const patchPath = './patches/dsh-client-ui-directory-picker-browse@0.1.1-rc.2.patch'
     expect(workspaceManifest.resolutions).toMatchObject({

--- a/package.json
+++ b/package.json
@@ -33,7 +33,9 @@
     "@deepseek-ai/dsh-web-app@npm:0.1.1-rc.2": "patch:@deepseek-ai/dsh-web-app@npm%3A0.1.1-rc.2#./patches/dsh-web-app@0.1.1-rc.2.patch",
     "@deepseek-ai/dsh-web-app@npm:^0.1.1-rc.2": "patch:@deepseek-ai/dsh-web-app@npm%3A0.1.1-rc.2#./patches/dsh-web-app@0.1.1-rc.2.patch",
     "dshmarket@npm:1.17.1": "patch:dshmarket@npm%3A1.17.1#./.yarn/patches/dshmarket-npm-1.17.1-d9fe6da08c.patch",
-    "koffi@npm:^3.1.0": "3.1.5"
+    "koffi@npm:^3.1.0": "3.1.5",
+    "@deepseek-ai/dsh-llm@npm:0.1.1-rc.2": "patch:@deepseek-ai/dsh-llm@npm%3A0.1.1-rc.2#./patches/dsh-llm-legacy-adapter@0.1.1-rc.2.patch",
+    "@deepseek-ai/dsh-llm@npm:^0.1.1-rc.2": "patch:@deepseek-ai/dsh-llm@npm%3A0.1.1-rc.2#./patches/dsh-llm-legacy-adapter@0.1.1-rc.2.patch"
   },
   "dependenciesMeta": {
     "@deepseek-ai/dsh-subprocess-local": {

--- a/patches/dsh-llm-legacy-adapter@0.1.1-rc.2.patch
+++ b/patches/dsh-llm-legacy-adapter@0.1.1-rc.2.patch
@@ -1,0 +1,43 @@
+diff --git a/lib/index.js b/lib/index.js
+index 61e6d90e7da02099362ba0b74e8c4c80d095a4e5..c6265d99a081ca1043b0894afc05282631c55436 100644
+--- a/lib/index.js
++++ b/lib/index.js
+@@ -1486,6 +1486,20 @@ var LlmRuntime = class extends Service {
+ 		};
+ 	}
+ 	/**
++	* Adapt the 0.1.1-rc.1 LlmAdapter contract to rc.2's prepared-call shape.
++	* rc.1 adapters expose resolveModel() and stream(), while rc.2's base class
++	* adds prepareCall() with exactly this default composition. Keep malformed
++	* adapters explicit instead of turning every missing method into a fallback.
++	*/
++	async prepareAdapterCall(adapter, provider, model, signal) {
++		if (typeof adapter.prepareCall === "function") return adapter.prepareCall(provider, model, signal);
++		if (typeof adapter.resolveModel !== "function" || typeof adapter.stream !== "function") throw new LlmError(`adapter for provider "${provider}" does not implement the rc.2 prepareCall contract or the rc.1 resolveModel/stream contract`, "INVALID_ADAPTER");
++		return {
++			model: await adapter.resolveModel(provider, model, signal),
++			stream: (options) => adapter.stream(options)
++		};
++	}
++	/**
+ 	* Resolve one call under its current adapter registration. The returned
+ 	* one-shot handle keeps that registration across header logging and dispatch,
+ 	* so HMR cannot combine one adapter's capability result with another adapter.
+@@ -1495,7 +1509,7 @@ var LlmRuntime = class extends Service {
+ 	*/
+ 	async prepareCall(config, signal) {
+ 		const registration = this.registration(config.provider);
+-		const adapterCall = await registration.adapter.prepareCall(config.provider, config.model, signal);
++		const adapterCall = await this.prepareAdapterCall(registration.adapter, config.provider, config.model, signal);
+ 		const modelInfo = this.normalizeModelInfo(registration, config.model, adapterCall.model);
+ 		const resolved = this.resolveCallWithInfo(config, modelInfo);
+ 		const resolvedConfig = deepFreeze(structuredClone(resolved.config));
+@@ -1565,7 +1579,7 @@ var LlmRuntime = class extends Service {
+ 			let resolvedConfig;
+ 			let dispatch;
+ 			if (prepared === void 0) {
+-				const adapterCall = await adapter.prepareCall(options.provider, options.model, options.signal);
++				const adapterCall = await this.prepareAdapterCall(adapter, options.provider, options.model, options.signal);
+ 				modelInfo = this.normalizeModelInfo(registration, options.model, adapterCall.model);
+ 				resolvedConfig = this.resolveCallWithInfo(options, modelInfo).config;
+ 				dispatch = (options) => adapterCall.stream(options);

--- a/yarn.lock
+++ b/yarn.lock
@@ -2764,7 +2764,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@deepseek-ai/dsh-llm@npm:0.1.1-rc.2, @deepseek-ai/dsh-llm@npm:^0.1.1-rc.2":
+"@deepseek-ai/dsh-llm@npm:0.1.1-rc.2":
   version: 0.1.1-rc.2
   resolution: "@deepseek-ai/dsh-llm@npm:0.1.1-rc.2"
   dependencies:
@@ -2776,6 +2776,21 @@ __metadata:
     "@deepseek-ai/dsh-invariants": ^0.1.1-rc.2
     "@deepseek-ai/dsh-timeout": ^0.1.1-rc.2
   checksum: 10c0/0450f7bbd190f1f4d77045a16b9beab06b100475d5df988eed26c006f2fd6c06529f18169e3c3ac2586a934015da6e4c2407d9e168723c7acc0dbbd517f083be
+  languageName: node
+  linkType: hard
+
+"@deepseek-ai/dsh-llm@patch:@deepseek-ai/dsh-llm@npm%3A0.1.1-rc.2#./patches/dsh-llm-legacy-adapter@0.1.1-rc.2.patch::locator=deepseek-harness-desktop%40workspace%3A.":
+  version: 0.1.1-rc.2
+  resolution: "@deepseek-ai/dsh-llm@patch:@deepseek-ai/dsh-llm@npm%3A0.1.1-rc.2#./patches/dsh-llm-legacy-adapter@0.1.1-rc.2.patch::version=0.1.1-rc.2&hash=411e46&locator=deepseek-harness-desktop%40workspace%3A."
+  dependencies:
+    "@deepseek-ai/schemastery": "npm:^3.18.1"
+  peerDependencies:
+    "@deepseek-ai/cordis": ^4.0.1
+    "@deepseek-ai/dsh-attachment": ^0.1.1-rc.2
+    "@deepseek-ai/dsh-brand": ^0.1.1-rc.2
+    "@deepseek-ai/dsh-invariants": ^0.1.1-rc.2
+    "@deepseek-ai/dsh-timeout": ^0.1.1-rc.2
+  checksum: 10c0/7004fd1bb200a7a4a7dcc03fa92d073e281cad8381bd41730009307b56d93212f1469ee39bd49787a9199cfed9141ceef59903a6fa4ecc0118589e5e171a73e5
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

- preserve the native rc.2 `prepareCall` path
- explicitly adapt the rc.1 `resolveModel` + `stream` contract when an upgraded Desktop profile still contains an older adapter
- reject malformed adapters instead of swallowing a missing method

## Why

Desktop profiles can outlive a bundled Harness upgrade. rc.2 now calls `adapter.prepareCall()` unconditionally, so an otherwise valid rc.1 adapter fails before provider I/O. The bridge is version-bounded and mirrors the rc.2 base-class composition.

Closes #521.

## Validation

- `corepack yarn install --immutable`
- full `corepack yarn check`
- Desktop: 811 passed, 4 skipped
- Market: 274 passed
- focused native rc.2, rc.1 fallback, malformed adapter, and installed-patch checks passed
- three safety passes covered secrets/static residue, dependency/runtime closure, and both dispatch paths

## Remaining validation

The reporter's original macOS Profile and unidentified third-party adapter were not available for packaged-app testing.