### PR TITLE
fix(desktop): preserve restart selection until baseline

### DIFF
--- a/dsh-plugin-desktop/tests/client-runtime-startup-restore.spec.ts
+++ b/dsh-plugin-desktop/tests/client-runtime-startup-restore.spec.ts
@@ -1,0 +1,219 @@
+import { Context } from '@deepseek-ai/cordis'
+import { createRequire } from 'node:module'
+import { pathToFileURL } from 'node:url'
+import type { IApiClient, RpcResponse, SessionId, WorkspaceId, WorkspaceView } from '@deepseek-ai/dsh-api-remotes/client'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+const sid = (id: string): SessionId => id as SessionId
+const wid = (id: string): WorkspaceId => id as WorkspaceId
+
+function workspace(
+  id: string,
+  sessionIds: SessionId[] = [],
+  createdAt = '2026-01-02T00:00:00.000Z',
+): WorkspaceView {
+  return {
+    workspaceId: wid(id),
+    path: `/w/${id}`,
+    title: id,
+    sessionIds,
+    createdAt,
+    updatedAt: createdAt,
+  }
+}
+
+async function flush(): Promise<void> {
+  await Promise.resolve()
+  await new Promise(resolve => setTimeout(resolve, 0))
+}
+
+interface SessionRuntimeCtor {
+  new (ctx: Context, api: IApiClient, remote: unknown): {
+    list: {
+      getSnapshot(): {
+        current: SessionId | undefined
+        phase: 'pending' | 'ready'
+      }
+    }
+    refresh(): Promise<void>
+  }
+}
+
+interface WorkspaceRuntimeCtor {
+  new (ctx: Context, api: IApiClient, sessions: unknown): {
+    startInitialSelection(): () => void
+    refresh(): Promise<void>
+  }
+}
+
+let nextModuleLoad = 0
+
+async function loadClientRuntime(): Promise<{
+  SessionRuntime: SessionRuntimeCtor
+  WorkspaceRuntime: WorkspaceRuntimeCtor
+}> {
+  const bundleUrl = new URL('../node_modules/@deepseek-ai/dsh-client-runtime/lib/client.js', import.meta.url)
+  const require = createRequire(bundleUrl)
+  const moduleLoader = {
+    modules: new Map<string, unknown>(),
+    load(definition: { id: string; factory: (requireFn: NodeRequire) => unknown }) {
+      const value = definition.factory(require)
+      this.modules.set(definition.id, value)
+      return value
+    },
+  }
+  ;(globalThis as { window?: unknown }).window = { __ModuleLoader__: moduleLoader }
+  await import(`${pathToFileURL(bundleUrl.pathname).href}?test-load=${nextModuleLoad++}`)
+  return moduleLoader.modules.get('@deepseek-ai/dsh-client-runtime') as {
+    SessionRuntime: SessionRuntimeCtor
+    WorkspaceRuntime: WorkspaceRuntimeCtor
+  }
+}
+
+let nextRpc = 0
+
+function ok<T>(value: T): RpcResponse<T> {
+  return {
+    rpcId: `fake-${nextRpc++}` as never,
+    result: { ok: true, value },
+  }
+}
+
+function fakeRemote() {
+  return {
+    commands: {
+      list: async () => ({ ok: true, value: [] }),
+      execute: async () => ({ ok: true, value: undefined }),
+    },
+  } as const
+}
+
+class FakeApiClient {
+  readonly calls: Array<{ method: string; payload: unknown }> = []
+
+  onList: () => Promise<RpcResponse<{ items: never[] }>> = async () => ok({ items: [] })
+  onCreate: () => Promise<RpcResponse<{ sessionId: SessionId }>> = async () => ok({ sessionId: sid('s-new') })
+  onHistory: () => Promise<RpcResponse<{ events: never[]; hasMore: boolean }>> = async () => ok({ events: [], hasMore: false })
+  onWorkspaceList: () => Promise<RpcResponse<{ items: WorkspaceView[]; archivedSessionIds?: never[] }>> = async () => ok({ items: [] })
+
+  readonly sessions: Pick<IApiClient['sessions'], 'list' | 'create' | 'history'> = {
+    list: async (payload: unknown) => this.record('session.list', payload, await this.onList()),
+    create: async (payload: unknown) => this.record('session.create', payload, await this.onCreate()),
+    history: async (payload: unknown) => this.record('session.history', payload, await this.onHistory()),
+  }
+
+  readonly workspace: Pick<IApiClient['workspace'], 'list'> = {
+    list: async (payload: unknown) => this.record(
+      'workspace.list',
+      payload,
+      await this.onWorkspaceList().then(response => ({
+        ...response,
+        result: {
+          ok: true as const,
+          value: { archivedSessionIds: [] as never[], ...(response.result as { ok: true; value: { items: WorkspaceView[] } }).value },
+        },
+      })),
+    ),
+  }
+
+  callsOf(method: string): unknown[] {
+    return this.calls.filter(call => call.method === method).map(call => call.payload)
+  }
+
+  private record<T>(method: string, payload: unknown, response: T): T {
+    this.calls.push({ method, payload })
+    return response
+  }
+}
+
+describe('client runtime startup restore', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    delete (globalThis as { window?: unknown }).window
+  })
+
+  it('keeps a persisted selection while the authoritative session baseline is still pending', async () => {
+    const { SessionRuntime, WorkspaceRuntime } = await loadClientRuntime()
+    const storage = new Map<string, string>([
+      ['dsh.sessions.current', JSON.stringify({ sessionId: 's-restored' })],
+    ])
+    vi.stubGlobal('localStorage', {
+      getItem: (key: string) => storage.get(key) ?? null,
+      setItem: (key: string, value: string) => { storage.set(key, value) },
+      removeItem: (key: string) => { storage.delete(key) },
+      clear: () => { storage.clear() },
+    })
+
+    const ctx = new Context()
+    const api = new FakeApiClient()
+    const sessions = new SessionRuntime(ctx, api as unknown as IApiClient, fakeRemote())
+    const workspaces = new WorkspaceRuntime(ctx, api as unknown as IApiClient, sessions)
+    const stop = workspaces.startInitialSelection()
+
+    api.onWorkspaceList = () => Promise.resolve(ok({
+      items: [workspace('recent')],
+    }))
+    let resolveSessionList!: (response: RpcResponse<{ items: never[] }>) => void
+    api.onList = () => new Promise(resolve => { resolveSessionList = resolve })
+    api.onCreate = () => Promise.resolve(ok({ sessionId: sid('s-new') }))
+
+    const sessionRefresh = sessions.refresh()
+    await workspaces.refresh()
+    await flush()
+
+    expect(api.callsOf('session.create')).toEqual([])
+    expect(sessions.list.getSnapshot().current).toBeUndefined()
+    expect(sessions.list.getSnapshot().phase).toBe('pending')
+    expect(storage.get('dsh.sessions.current')).toContain('s-restored')
+
+    resolveSessionList(ok({
+      items: [{
+        sessionId: sid('s-restored'),
+        updatedAt: Date.parse('2026-01-03T00:00:00.000Z'),
+        running: false,
+        blank: false,
+        cwd: '/w/recent',
+      }] as never[],
+    }))
+
+    await sessionRefresh
+    await flush()
+
+    expect(api.callsOf('session.create')).toEqual([])
+    expect(sessions.list.getSnapshot().current).toBe('s-restored')
+    expect(storage.get('dsh.sessions.current')).toContain('s-restored')
+    stop()
+  })
+
+  it('clears a deleted selection after an authoritative missing baseline and opens the workspace default', async () => {
+    const { SessionRuntime, WorkspaceRuntime } = await loadClientRuntime()
+    const storage = new Map<string, string>([
+      ['dsh.sessions.current', JSON.stringify({ sessionId: 's-deleted' })],
+    ])
+    vi.stubGlobal('localStorage', {
+      getItem: (key: string) => storage.get(key) ?? null,
+      setItem: (key: string, value: string) => { storage.set(key, value) },
+      removeItem: (key: string) => { storage.delete(key) },
+      clear: () => { storage.clear() },
+    })
+
+    const ctx = new Context()
+    const api = new FakeApiClient()
+    const sessions = new SessionRuntime(ctx, api as unknown as IApiClient, fakeRemote())
+    const workspaces = new WorkspaceRuntime(ctx, api as unknown as IApiClient, sessions)
+    const stop = workspaces.startInitialSelection()
+
+    api.onWorkspaceList = () => Promise.resolve(ok({ items: [workspace('recent')] }))
+    api.onList = () => Promise.resolve(ok({ items: [] }))
+    api.onCreate = () => Promise.resolve(ok({ sessionId: sid('s-new') }))
+
+    await Promise.all([workspaces.refresh(), sessions.refresh()])
+    await flush()
+
+    expect(sessions.list.getSnapshot().phase).toBe('ready')
+    expect(storage.get('dsh.sessions.current')).not.toContain('s-deleted')
+    expect(api.callsOf('session.create')).toEqual([{ workspaceId: 'recent' }])
+    expect(sessions.list.getSnapshot().current).toBe('s-new')
+    stop()
+  })
+})

--- a/package.json
+++ b/package.json
@@ -28,6 +28,8 @@
     "@deepseek-ai/dsh-client-ui-workspace@npm:^0.1.1-rc.2": "patch:@deepseek-ai/dsh-client-ui-workspace@npm%3A0.1.1-rc.2#./patches/dsh-client-ui-workspace@0.1.1-rc.2.patch",
     "@deepseek-ai/dsh-client-ui-trajectory@npm:0.1.1-rc.2": "patch:@deepseek-ai/dsh-client-ui-trajectory@npm%3A0.1.1-rc.2#./patches/dsh-client-ui-trajectory@0.1.1-rc.2.patch",
     "@deepseek-ai/dsh-client-ui-trajectory@npm:^0.1.1-rc.2": "patch:@deepseek-ai/dsh-client-ui-trajectory@npm%3A0.1.1-rc.2#./patches/dsh-client-ui-trajectory@0.1.1-rc.2.patch",
+    "@deepseek-ai/dsh-client-runtime@npm:0.1.1-rc.2": "patch:@deepseek-ai/dsh-client-runtime@npm%3A0.1.1-rc.2#./patches/dsh-client-runtime@0.1.1-rc.2.patch",
+    "@deepseek-ai/dsh-client-runtime@npm:^0.1.1-rc.2": "patch:@deepseek-ai/dsh-client-runtime@npm%3A0.1.1-rc.2#./patches/dsh-client-runtime@0.1.1-rc.2.patch",
     "@deepseek-ai/dsh-client-ui-settings-models@npm:0.1.1-rc.2": "patch:@deepseek-ai/dsh-client-ui-settings-models@npm%3A0.1.1-rc.2#./patches/dsh-client-ui-settings-models@0.1.1-rc.2.patch",
     "@deepseek-ai/dsh-client-ui-settings-models@npm:^0.1.1-rc.2": "patch:@deepseek-ai/dsh-client-ui-settings-models@npm%3A0.1.1-rc.2#./patches/dsh-client-ui-settings-models@0.1.1-rc.2.patch",
     "@deepseek-ai/dsh-web-app@npm:0.1.1-rc.2": "patch:@deepseek-ai/dsh-web-app@npm%3A0.1.1-rc.2#./patches/dsh-web-app@0.1.1-rc.2.patch",

--- a/patches/dsh-client-runtime@0.1.1-rc.2.patch
+++ b/patches/dsh-client-runtime@0.1.1-rc.2.patch
@@ -1,0 +1,13 @@
+diff --git a/lib/client.js b/lib/client.js
+index ba3cb21f72..782a387b46 100644
+--- a/lib/client.js
++++ b/lib/client.js
+@@ -9266,7 +9266,7 @@ Set the `cycles` parameter to `"ref"` to resolve cyclical schemas with defs.
+ 				}
+ 				const persisted = this.selection.getSnapshot().sessionId;
+ 				if (current === void 0) {
+-					if (persisted !== void 0) this.selection.set({});
++					if (phase === "ready" && persisted !== void 0) this.selection.set({});
+ 				} else if (byId[current] !== void 0 && (persisted !== current || this.selection.getSnapshot().subagentAddress?.childSessionId !== currentAddress?.childSessionId || this.selection.getSnapshot().subagentAddress?.parentSessionId !== currentAddress?.parentSessionId || this.selection.getSnapshot().subagentAddress?.mode !== currentAddress?.mode)) this.selection.set({
+ 					sessionId: current,
+ 					...currentAddress === void 0 ? {} : { subagentAddress: currentAddress }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1446,7 +1446,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@deepseek-ai/dsh-client-runtime@npm:0.1.1-rc.2, @deepseek-ai/dsh-client-runtime@npm:^0.1.1-rc.2":
+"@deepseek-ai/dsh-client-runtime@npm:0.1.1-rc.2":
   version: 0.1.1-rc.2
   resolution: "@deepseek-ai/dsh-client-runtime@npm:0.1.1-rc.2"
   dependencies:
@@ -1470,6 +1470,33 @@ __metadata:
     "@deepseek-ai/dsh-typert-protocol": ^0.1.1-rc.2
     "@deepseek-ai/dsh-typert-registry": ^0.1.1-rc.2
   checksum: 10c0/4de8d57025f09758f355f30acdcd203b3bec91c03ce034c1f56d87e38c200c02039138d52bec24717d09152fda0a986ffa19b01567f568cf83676e64a13ad4cb
+  languageName: node
+  linkType: hard
+
+"@deepseek-ai/dsh-client-runtime@patch:@deepseek-ai/dsh-client-runtime@npm%3A0.1.1-rc.2#./patches/dsh-client-runtime@0.1.1-rc.2.patch::locator=deepseek-harness-desktop%40workspace%3A.":
+  version: 0.1.1-rc.2
+  resolution: "@deepseek-ai/dsh-client-runtime@patch:@deepseek-ai/dsh-client-runtime@npm%3A0.1.1-rc.2#./patches/dsh-client-runtime@0.1.1-rc.2.patch::version=0.1.1-rc.2&hash=7450aa&locator=deepseek-harness-desktop%40workspace%3A."
+  dependencies:
+    immer: "npm:^10.1.1"
+    zustand: "npm:~4.4.7"
+  peerDependencies:
+    "@deepseek-ai/cordis": ^4.0.1
+    "@deepseek-ai/dsh-agent": ^0.1.1-rc.2
+    "@deepseek-ai/dsh-api-remotes": ^0.1.1-rc.2
+    "@deepseek-ai/dsh-attachment": ^0.1.1-rc.2
+    "@deepseek-ai/dsh-client-connection": ^0.1.1-rc.2
+    "@deepseek-ai/dsh-commands": ^0.1.1-rc.2
+    "@deepseek-ai/dsh-host-apiproxy": ^0.1.1-rc.2
+    "@deepseek-ai/dsh-invariants": ^0.1.1-rc.2
+    "@deepseek-ai/dsh-llm": ^0.1.1-rc.2
+    "@deepseek-ai/dsh-llm-retry": ^0.1.1-rc.2
+    "@deepseek-ai/dsh-session": ^0.1.1-rc.2
+    "@deepseek-ai/dsh-session-projection": ^0.1.1-rc.2
+    "@deepseek-ai/dsh-session-title": ^0.1.1-rc.2
+    "@deepseek-ai/dsh-tools": ^0.1.1-rc.2
+    "@deepseek-ai/dsh-typert-protocol": ^0.1.1-rc.2
+    "@deepseek-ai/dsh-typert-registry": ^0.1.1-rc.2
+  checksum: 10c0/e9acee62003291253f4596138f8d43a09931fb43f2dddd8c3eff9d55cc85a9b06e939e6be740872f397454bf283c45c2bbdb64dc4e1a7952750cd1f7f8859883
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

- keep a persisted session restore target while `session.list` is still pending
- treat the first successful ready baseline as the authority for clearing a stale/deleted target
- retain the existing recent-workspace fallback after an authoritative miss, without timeouts

## Why

On restart the persisted session can be projected before the first session baseline arrives. Clearing it during that temporary gap creates a new empty session. Treating every miss as pending, however, would block startup forever for a deleted session. This uses the existing list phase as the authority boundary.

Closes #408.

## Validation

- `corepack yarn install --immutable`
- full `corepack yarn check`
- Desktop: 810 passed, 4 skipped
- Market: 274 passed
- regression coverage for both delayed baseline restoration and permanently missing/deleted target fallback
- three safety passes covered static/secrets, dependency/runtime closure, and session/workspace/path/IPC boundaries

## Remaining validation

A packaged Windows GUI restart was not manually exercised.