### PR TITLE
fix(desktop): style settings restart menu independently

### DIFF
--- a/dsh-plugin-desktop/src/client/desktop-settings-styles.ts
+++ b/dsh-plugin-desktop/src/client/desktop-settings-styles.ts
@@ -162,7 +162,44 @@ const CSS = `
   align-items: center;
   gap: 8px;
 }
-.dshDesktopNativeActions[data-placement="settings"] .dshDesktopActionMenu { right: 0; }
+.dshDesktopNativeActions[data-placement="settings"] .dshDesktopNativeActionMenuAnchor { position: relative; }
+.dshDesktopNativeActions[data-placement="settings"] .dshDesktopActionMenu {
+  position: absolute;
+  z-index: 2147483001;
+  top: calc(100% + 5px);
+  right: 0;
+  display: grid;
+  grid-auto-flow: row;
+  grid-template-columns: minmax(0, 1fr);
+  min-width: 220px;
+  padding: 5px;
+  border: 1px solid var(--dsw-alias-border-l1);
+  border-radius: 10px;
+  background: var(--dsw-alias-bg-layer-1);
+  box-shadow: 0 12px 32px color-mix(in srgb, #000 28%, transparent);
+  -webkit-app-region: no-drag;
+}
+.dshDesktopNativeActions[data-placement="settings"] .dshDesktopActionMenuItem {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  width: 100%;
+  min-height: 32px;
+  padding: 5px 9px;
+  border: 0;
+  border-radius: 7px;
+  background: transparent;
+  color: var(--dsw-alias-label-primary);
+  cursor: pointer;
+  font: inherit;
+  font-size: 12px;
+  text-align: start;
+  white-space: nowrap;
+}
+.dshDesktopNativeActions[data-placement="settings"] .dshDesktopActionMenuItem:hover:not(:disabled) { background: var(--dsw-alias-interactive-bg-hover); }
+.dshDesktopNativeActions[data-placement="settings"] .dshDesktopActionMenuItem:disabled { cursor: default; opacity: .45; }
+.dshDesktopNativeActions[data-placement="settings"] .dshDesktopActionMenuItem svg { width: 14px; height: 14px; stroke-width: 1.8; }
+.dshDesktopNativeActions[data-placement="settings"] .dshDesktopActionMenuItem span { flex: 1; }
 .dshDesktopSettingsHeaderButton {
   display: inline-flex;
   align-items: center;

--- a/dsh-plugin-desktop/tests/client-desktop-settings.spec.ts
+++ b/dsh-plugin-desktop/tests/client-desktop-settings.spec.ts
@@ -20,6 +20,7 @@ import {
   DESKTOP_SHELL_SETTINGS_NAMESPACE,
 } from '../src/client/desktop-settings.ts'
 import { en, type DesktopSettingsLocaleKey } from '../src/client/desktop-settings-locales.ts'
+import { installDesktopSettingsStyles } from '../src/client/desktop-settings-styles.ts'
 
 const VIEW: DesktopSettingsView = {
   current: 'desktop',
@@ -169,6 +170,34 @@ describe('Desktop native action presentation', () => {
     expect(markup).toContain('Restart Desktop')
     expect(markup).toContain('aria-haspopup="menu"')
     expect(markup).not.toContain('Developer options')
+  })
+
+  it('installs a self-contained vertical settings menu in every presentation mode', () => {
+    let css = ''
+    const remove = vi.fn()
+    const style = {
+      id: '',
+      get textContent() { return css },
+      set textContent(value: string) { css = value },
+      remove,
+    }
+    const appendChild = vi.fn()
+    vi.stubGlobal('document', {
+      getElementById: () => null,
+      createElement: () => style,
+      head: { appendChild },
+    })
+
+    try {
+      const dispose = installDesktopSettingsStyles()
+      expect(css).toMatch(/data-placement="settings"\] \.dshDesktopActionMenu \{[^}]*position: absolute;[^}]*display: grid;[^}]*grid-auto-flow: row;[^}]*grid-template-columns: minmax\(0, 1fr\);[^}]*min-width: 220px;/)
+      expect(css).toMatch(/data-placement="settings"\] \.dshDesktopActionMenuItem \{[^}]*display: flex;[^}]*width: 100%;[^}]*white-space: nowrap;/)
+      expect(appendChild).toHaveBeenCalledWith(style)
+      dispose()
+      expect(remove).toHaveBeenCalledOnce()
+    } finally {
+      vi.unstubAllGlobals()
+    }
   })
 })
 


### PR DESCRIPTION
## Summary
- make the Settings restart dropdown self-contained instead of depending on framed-shell styles
- force a single vertical menu column with full-width restart actions
- preserve native confirmation for ordinary and recovery restarts
- keep version 2.0.3

## Local verification
- corepack yarn workspace dsh-plugin-desktop test client-desktop-settings.spec.ts
- corepack yarn workspace dsh-plugin-desktop check