### PR TITLE
feat(desktop): regroup native action menus

### DIFF
--- a/dsh-plugin-desktop/src/client/DesktopNativeActions.tsx
+++ b/dsh-plugin-desktop/src/client/DesktopNativeActions.tsx
@@ -6,16 +6,67 @@ import type { DesktopSettingsApi } from './desktop-settings-api.ts'
 import type { DesktopSettingsLocaleKey } from './desktop-settings-locales.ts'
 
 export interface DesktopNativeActionsProps {
-  readonly api: Pick<DesktopSettingsApi, 'openTerminal' | 'restart'>
-    & Partial<Pick<DesktopSettingsApi, 'restartToRecovery' | 'reloadRenderer' | 'toggleDeveloperTools'>>
+  readonly api: Pick<
+    DesktopSettingsApi,
+    'openTerminal' | 'restart' | 'restartToRecovery' | 'reloadRenderer' | 'toggleDeveloperTools'
+  >
   readonly t: (key: DesktopSettingsLocaleKey) => string
   readonly placement: 'settings' | 'titlebar'
+}
+
+interface DesktopRestartMenuItemsProps {
+  readonly busy: boolean
+  readonly t: DesktopNativeActionsProps['t']
+  readonly onReload: () => void
+  readonly onRestart: () => void
+  readonly onRestartToRecovery: () => void
+}
+
+/** Shared restart-menu order for Settings and the independent Desktop title bar. */
+export function DesktopRestartMenuItems({
+  busy, t, onReload, onRestart, onRestartToRecovery,
+}: DesktopRestartMenuItemsProps) {
+  return (
+    <>
+      <button type="button" className="dshDesktopActionMenuItem" role="menuitem" disabled={busy} onClick={onReload}>
+        <RefreshCw aria-hidden="true" /><span>{t('reloadRenderer')}</span>
+      </button>
+      <button type="button" className="dshDesktopActionMenuItem" role="menuitem" disabled={busy} onClick={onRestart}>
+        <RotateCw aria-hidden="true" /><span>{t('restartDesktop')}</span>
+      </button>
+      <button type="button" className="dshDesktopActionMenuItem" role="menuitem" disabled={busy} onClick={onRestartToRecovery}>
+        <LifeBuoy aria-hidden="true" /><span>{t('restartToRecovery')}</span>
+      </button>
+    </>
+  )
+}
+
+/** Developer menu intentionally owns only the Developer Tools toggle. */
+export function DesktopDeveloperMenuItems({
+  busy, t, onToggleDeveloperTools,
+}: {
+  readonly busy: boolean
+  readonly t: DesktopNativeActionsProps['t']
+  readonly onToggleDeveloperTools: () => void
+}) {
+  return (
+    <button
+      type="button"
+      className="dshDesktopActionMenuItem"
+      role="menuitem"
+      disabled={busy}
+      onClick={onToggleDeveloperTools}
+    >
+      <Bug aria-hidden="true" />
+      <span>{t('toggleDeveloperTools')}</span>
+    </button>
+  )
 }
 
 export function DesktopNativeActions({ api, t, placement }: DesktopNativeActionsProps) {
   const [opening, setOpening] = useState(false)
   const [restarting, setRestarting] = useState(false)
-  const [developerAction, setDeveloperAction] = useState<'reload' | 'devtools'>()
+  const [rendererAction, setRendererAction] = useState<'reload' | 'devtools'>()
   const [restartMenuOpen, setRestartMenuOpen] = useState(false)
   const [developerMenuOpen, setDeveloperMenuOpen] = useState(false)
   const [failed, setFailed] = useState<'terminal' | 'restart' | 'reload' | 'devtools'>()
@@ -42,7 +93,7 @@ export function DesktopNativeActions({ api, t, placement }: DesktopNativeActions
     }
   }, [developerMenuOpen, restartMenuOpen])
 
-  const busy = opening || restarting || developerAction !== undefined
+  const busy = opening || restarting || rendererAction !== undefined
 
   const open = (): void => {
     if (busy) return
@@ -59,27 +110,22 @@ export function DesktopNativeActions({ api, t, placement }: DesktopNativeActions
     setRestartMenuOpen(false)
     setFailed(undefined)
     const operation = recovery ? api.restartToRecovery : api.restart
-    if (operation === undefined) {
-      setFailed('restart')
-      setRestarting(false)
-      return
-    }
     void operation()
       .catch(() => { setFailed('restart') })
       .finally(() => { setRestarting(false) })
   }
 
-  const runDeveloperAction = (action: 'reload' | 'devtools'): void => {
+  const runRendererAction = (action: 'reload' | 'devtools'): void => {
     if (busy) return
     const operation = action === 'reload' ? api.reloadRenderer : api.toggleDeveloperTools
-    if (operation === undefined) return
-    setDeveloperAction(action)
+    setRendererAction(action)
     setDeveloperMenuOpen(false)
+    setRestartMenuOpen(false)
     setFailed(undefined)
     void operation().catch(() => {
       setFailed(action)
     }).finally(() => {
-      setDeveloperAction(undefined)
+      setRendererAction(undefined)
     })
   }
 
@@ -119,12 +165,13 @@ export function DesktopNativeActions({ api, t, placement }: DesktopNativeActions
           </button>
           {restartMenuOpen && (
             <div className="dshDesktopActionMenu" role="menu">
-              <button type="button" className="dshDesktopActionMenuItem" role="menuitem" disabled={busy} onClick={() => { restart() }}>
-                <RotateCw aria-hidden="true" /><span>{t('restartDesktop')}</span>
-              </button>
-              <button type="button" className="dshDesktopActionMenuItem" role="menuitem" disabled={busy} onClick={() => { restart(true) }}>
-                <LifeBuoy aria-hidden="true" /><span>{t('restartToRecovery')}</span>
-              </button>
+              <DesktopRestartMenuItems
+                busy={busy}
+                t={t}
+                onReload={() => { runRendererAction('reload') }}
+                onRestart={() => { restart() }}
+                onRestartToRecovery={() => { restart(true) }}
+              />
             </div>
           )}
         </div>
@@ -165,12 +212,13 @@ export function DesktopNativeActions({ api, t, placement }: DesktopNativeActions
         </button>
         {restartMenuOpen && (
           <div className="dshDesktopActionMenu" role="menu">
-            <button type="button" className="dshDesktopActionMenuItem" role="menuitem" disabled={busy} onClick={() => { restart() }}>
-              <RotateCw aria-hidden="true" /><span>{t('restartDesktop')}</span>
-            </button>
-            <button type="button" className="dshDesktopActionMenuItem" role="menuitem" disabled={busy} onClick={() => { restart(true) }}>
-              <LifeBuoy aria-hidden="true" /><span>{t('restartToRecovery')}</span>
-            </button>
+            <DesktopRestartMenuItems
+              busy={busy}
+              t={t}
+              onReload={() => { runRendererAction('reload') }}
+              onRestart={() => { restart() }}
+              onRestartToRecovery={() => { restart(true) }}
+            />
           </div>
         )}
       </div>
@@ -192,26 +240,11 @@ export function DesktopNativeActions({ api, t, placement }: DesktopNativeActions
         </button>
         {developerMenuOpen && (
           <div className="dshDesktopActionMenu" role="menu">
-            <button
-              type="button"
-              className="dshDesktopActionMenuItem"
-              role="menuitem"
-              disabled={busy}
-              onClick={() => { runDeveloperAction('reload') }}
-            >
-              <RefreshCw aria-hidden="true" />
-              <span>{t('reloadRenderer')}</span>
-            </button>
-            <button
-              type="button"
-              className="dshDesktopActionMenuItem"
-              role="menuitem"
-              disabled={busy}
-              onClick={() => { runDeveloperAction('devtools') }}
-            >
-              <Bug aria-hidden="true" />
-              <span>{t('toggleDeveloperTools')}</span>
-            </button>
+            <DesktopDeveloperMenuItems
+              busy={busy}
+              t={t}
+              onToggleDeveloperTools={() => { runRendererAction('devtools') }}
+            />
           </div>
         )}
       </div>

--- a/dsh-plugin-desktop/src/client/DesktopTerminalSettingsAction.tsx
+++ b/dsh-plugin-desktop/src/client/DesktopTerminalSettingsAction.tsx
@@ -6,7 +6,10 @@ import { DesktopNativeActions } from './DesktopNativeActions.tsx'
 
 /** Registration-side capabilities for native Desktop actions. */
 export interface DesktopTerminalSettingsActionInjected {
-  readonly api: Pick<DesktopSettingsApi, 'openTerminal' | 'restart'>
+  readonly api: Pick<
+    DesktopSettingsApi,
+    'openTerminal' | 'restart' | 'restartToRecovery' | 'reloadRenderer' | 'toggleDeveloperTools'
+  >
 }
 
 /** Renderer-composed terminal action props. */

--- a/dsh-plugin-desktop/tests/client-desktop-settings.spec.ts
+++ b/dsh-plugin-desktop/tests/client-desktop-settings.spec.ts
@@ -2,7 +2,11 @@ import { describe, expect, it, vi } from 'vitest'
 import { createElement } from 'react'
 import { renderToStaticMarkup } from 'react-dom/server'
 import type { ClientContext, SettingsScope } from '@deepseek-ai/dsh-client-runtime/client'
-import { DesktopNativeActions } from '../src/client/DesktopNativeActions.tsx'
+import {
+  DesktopDeveloperMenuItems,
+  DesktopNativeActions,
+  DesktopRestartMenuItems,
+} from '../src/client/DesktopNativeActions.tsx'
 import { DesktopSettingsSection } from '../src/client/DesktopSettingsSection.tsx'
 import { DesktopTerminalSettingsAction } from '../src/client/DesktopTerminalSettingsAction.tsx'
 import {
@@ -170,6 +174,29 @@ describe('Desktop native action presentation', () => {
     expect(markup).toContain('Restart Desktop')
     expect(markup).toContain('aria-haspopup="menu"')
     expect(markup).not.toContain('Developer options')
+  })
+
+  it('groups reload with both restart actions and leaves only Developer Tools in its menu', () => {
+    const restartMarkup = renderToStaticMarkup(createElement(DesktopRestartMenuItems, {
+      busy: false,
+      t,
+      onReload: vi.fn(),
+      onRestart: vi.fn(),
+      onRestartToRecovery: vi.fn(),
+    }))
+    const developerMarkup = renderToStaticMarkup(createElement(DesktopDeveloperMenuItems, {
+      busy: false,
+      t,
+      onToggleDeveloperTools: vi.fn(),
+    }))
+
+    expect(restartMarkup.match(/role="menuitem"/g)).toHaveLength(3)
+    expect(restartMarkup.indexOf('Reload renderer')).toBeLessThan(restartMarkup.indexOf('Restart Desktop'))
+    expect(restartMarkup.indexOf('Restart Desktop')).toBeLessThan(restartMarkup.indexOf('Restart in Recovery Mode'))
+    expect(restartMarkup).not.toContain('Toggle Developer Tools')
+    expect(developerMarkup.match(/role="menuitem"/g)).toHaveLength(1)
+    expect(developerMarkup).toContain('Toggle Developer Tools')
+    expect(developerMarkup).not.toContain('Reload renderer')
   })
 
   it('installs a self-contained vertical settings menu in every presentation mode', () => {


### PR DESCRIPTION
## Summary
- add renderer reload to the restart dropdown before the two restart commands
- use the same restart menu in Settings and the independent Desktop title bar
- leave only the Developer Tools toggle in the developer dropdown
- preserve native confirmation for both actual restart operations
- keep version 2.0.3

## Local verification
- corepack yarn workspace dsh-plugin-desktop test client-desktop-settings.spec.ts
- corepack yarn workspace dsh-plugin-desktop typecheck
- corepack yarn workspace dsh-plugin-desktop check