### PR TITLE
fix(market): search beyond the 1024Store local prefix

### DIFF
--- a/dsh-community-market/src/adapters/dsh-1024store.ts
+++ b/dsh-community-market/src/adapters/dsh-1024store.ts
@@ -297,6 +297,12 @@ function compareCandidates(left: RegistryCandidate, right: RegistryCandidate, qu
   return right.stars - left.stars || left.item.displayName.localeCompare(right.item.displayName, 'en', { sensitivity: 'base' })
 }
 
+function fetchUrl(query: CatalogQuery): string {
+  const url = new URL(DSH_1024STORE_ENDPOINT)
+  if (query.q !== undefined) url.searchParams.set('q', query.q)
+  return url.href
+}
+
 function buildSnapshot(value: unknown, context: CatalogFetchContext, finalUrl: string, query: CatalogQuery): CatalogSnapshot {
   if (value === null || typeof value !== 'object' || Array.isArray(value)) throw new Error('1024Store response is not an object')
   const raw = value as Dsh1024StoreCatalog
@@ -453,7 +459,7 @@ export const dsh1024StoreAdapter: CatalogAdapter = {
     const query = { ...queryValue, limit: Math.min(queryValue.limit ?? 50, 50) }
     const expectedOrigin = new URL(DSH_1024STORE_ENDPOINT).origin
     const response = await context.http.getJson(
-      DSH_1024STORE_ENDPOINT,
+      fetchUrl(query),
       context.signal,
       { allowedOrigin: expectedOrigin },
     )

--- a/dsh-community-market/src/catalog/service.ts
+++ b/dsh-community-market/src/catalog/service.ts
@@ -87,6 +87,10 @@ function catalogScanKey(sourceRecordId: string, locale: string | undefined): str
   return `${sourceRecordId}\0${locale ?? ''}`
 }
 
+function prefersProviderSearch(source: LocalSourceRecord, query: CatalogQuery): boolean {
+  return source.adapterId === DSH_1024STORE_ADAPTER_ID && query.q !== undefined
+}
+
 function cachedScanView(entry: CatalogFullIndexCacheEntry, cacheStatus: 'fresh' | 'cached'): CatalogFullIndex {
   return {
     source: entry.source,
@@ -695,6 +699,55 @@ export class DefaultCatalogService implements CatalogService {
     }]
   }
 
+  private async fetchProviderSearch(
+    query: CatalogQuery,
+    signal: AbortSignal,
+    scope?: CatalogFetchScope,
+  ): Promise<readonly MarketCatalogSourceResult[] | undefined> {
+    if (query.q === undefined) return undefined
+    const sourceGenerationsAtLoadStart = new Map(this.sourceGenerations)
+    const records = [...await this.store.load()].sort((left, right) => left.order - right.order)
+    signal.throwIfAborted()
+    const source = records.find(record => record.enabled)
+    if (scope !== undefined && source?.sourceRecordId !== scope.sourceRecordId) {
+      throw new Error('catalog source is not active')
+    }
+    if (source === undefined) return []
+    if (!prefersProviderSearch(source, query)) return undefined
+    const sourceGeneration = sourceGenerationsAtLoadStart.get(source.sourceRecordId) ?? 0
+    if ((this.sourceGenerations.get(source.sourceRecordId) ?? 0) !== sourceGeneration) {
+      throw new Error('catalog source changed during scan setup')
+    }
+    const adapter = adapters.get(source.adapterId)
+    if (adapter === undefined) throw new Error('catalog adapter unavailable')
+
+    return await this.sourceConcurrency.run(signal, async () => {
+      signal.throwIfAborted()
+      if ((this.sourceGenerations.get(source.sourceRecordId) ?? 0) !== sourceGeneration) {
+        throw new Error('catalog source changed while waiting to scan')
+      }
+      const delegate = this.adapterHttpClients.get(source.adapterId) ?? this.http
+      const effectiveQuery = scope?.cursor === undefined
+        ? query
+        : this.applyCursor(scope.cursor, scope.sourceRecordId, query, sourceGeneration)
+      const snapshot = parseCatalogSnapshot(await adapter.fetch(effectiveQuery, {
+        signal,
+        source,
+        http: delegate,
+        media: this.media,
+      }))
+      signal.throwIfAborted()
+      if ((this.sourceGenerations.get(source.sourceRecordId) ?? 0) !== sourceGeneration) {
+        throw new Error('catalog source changed during scan')
+      }
+      return [{
+        source: sourceView(source),
+        snapshot: this.exposeSnapshot(snapshot, source.sourceRecordId, query, sourceGeneration),
+        stale: false,
+      }]
+    })
+  }
+
   async fetch(
     value: unknown,
     signal: AbortSignal,
@@ -702,6 +755,8 @@ export class DefaultCatalogService implements CatalogService {
   ): Promise<readonly MarketCatalogSourceResult[]> {
     const query = normalizeCatalogQuery(value)
     if (query.cursor !== undefined) throw new Error('catalog cursor requires an explicit source scope')
+    const providerSearch = await this.fetchProviderSearch(query, signal, scope)
+    if (providerSearch !== undefined) return providerSearch
     const index = await this.scanCatalog(signal, {
       ...(query.locale === undefined ? {} : { locale: query.locale }),
       ...(scope === undefined ? {} : { expectedSourceRecordId: scope.sourceRecordId }),

--- a/dsh-community-market/src/host/routes.ts
+++ b/dsh-community-market/src/host/routes.ts
@@ -12,6 +12,7 @@ import type {
   MarketCatalogErrorCode,
   MarketCatalogMetadata,
   MarketCatalogResponse,
+  MarketCatalogSourceResult,
   MarketInstallationView,
   MarketInstallReceipt,
   MarketManualInstallHint,
@@ -816,8 +817,9 @@ export function registerMarketRoutes(
     index: CatalogFullIndex | undefined,
     query: Record<string, unknown>,
     fetchScope: CatalogFetchScope | undefined,
+    resultsOverride?: readonly MarketCatalogSourceResult[],
   ): MarketCatalogResponse => {
-    const results = index === undefined ? [] : service.queryCatalog(index, query, fetchScope)
+    const results = resultsOverride ?? (index === undefined ? [] : service.queryCatalog(index, query, fetchScope))
     const responseQuery = fetchScope === undefined
       ? query
       : {
@@ -909,12 +911,13 @@ export function registerMarketRoutes(
               sourceRecordId: sourceRecordIds[0]!,
               ...(cursors.length === 0 ? {} : { cursor: cursors[0]! }),
             }
-        const activeSource = scope === undefined
-          ? undefined
-          : (await service.listSources()).find(source => (
+        const listedSources = await service.listSources()
+        const selectedSource = scope === undefined
+          ? listedSources.find(source => source.enabled)
+          : listedSources.find(source => (
               source.enabled && source.sourceRecordId === scope.sourceRecordId
             ))
-        if (scope !== undefined && activeSource === undefined) throw new Error('catalog source is not active')
+        if (scope !== undefined && selectedSource === undefined) throw new Error('catalog source is not active')
         const localeKey = locale ?? ''
         const previewSourceRecordId = q === undefined
           && categories.length === 0
@@ -929,14 +932,37 @@ export function registerMarketRoutes(
           : catalogPreviewKey(previewSourceRecordId, localeKey)
         if (force) refreshPreviewKey = previewKey
         if (!force && previewKey !== undefined && !servedCatalogPreviews.has(previewKey)) {
-          const cached = activeSource === undefined
+          const cached = selectedSource === undefined
             ? undefined
-            : cachedCatalogResponse(settingsScope.get().catalogCache, activeSource, localeKey)
+            : cachedCatalogResponse(settingsScope.get().catalogCache, selectedSource, localeKey)
           if (cached !== undefined) {
             servedCatalogPreviews.add(previewKey)
             if (!signal.aborted && !res.destroyed) sendJson(res, 200, cached)
             return
           }
+        }
+        if (q !== undefined && selectedSource?.adapterId === DSH_1024STORE_ADAPTER_ID) {
+          let results: readonly MarketCatalogSourceResult[]
+          try {
+            results = await service.fetch(query, signal, scope)
+          } catch (cause) {
+            if (!signal.aborted && !res.destroyed) sendCatalogFailure(res, cause)
+            return
+          }
+          let index: CatalogFullIndex | undefined
+          try {
+            index = await service.scanCatalog(signal, {
+              force,
+              ...(locale === null || locale === '' ? {} : { locale }),
+              ...(scope === undefined ? {} : { expectedSourceRecordId: scope.sourceRecordId }),
+            })
+          } catch {
+            index = undefined
+          }
+          signal.throwIfAborted()
+          const response = buildCatalogResponse(index, query, scope, results)
+          if (!signal.aborted && !res.destroyed) sendJson(res, 200, response)
+          return
         }
         let index: CatalogFullIndex | undefined
         try {

--- a/dsh-community-market/tests/market-runtime.spec.ts
+++ b/dsh-community-market/tests/market-runtime.spec.ts
@@ -395,6 +395,34 @@ describe('1024Store adapter', () => {
     )).rejects.toThrow(/provider total/u)
   })
 
+  it('forwards 1024Store search terms to the reviewed provider endpoint', async () => {
+    const appshot = {
+      ...rawCatalog.packages[0]!,
+      id: 'TaurusWood/dsh-plugin-appshot',
+      name: 'dsh-plugin-appshot',
+      owner: 'TaurusWood',
+      url: 'https://github.com/TaurusWood/dsh-plugin-appshot',
+    }
+    const getJson = vi.fn(async () => ({
+      value: { ...rawCatalog, meta: { ...rawCatalog.meta, total: 1 }, packages: [appshot] },
+      finalUrl: 'https://deepseek1024.com/api/v1/plugins?q=appshot',
+    }))
+    const http: CatalogHttpClient = { getJson }
+
+    const snapshot = await dsh1024StoreAdapter.fetch(
+      { q: 'appshot', limit: 50 },
+      { source: source(), signal: new AbortController().signal, http, media: { register: () => fixtureAssetRef } },
+    )
+
+    const requestedCall = getJson.mock.calls[0] as unknown as [string, ...unknown[]] | undefined
+    const requestedUrl = requestedCall?.[0]
+    if (requestedUrl === undefined) throw new Error('expected the 1024Store adapter to issue one provider request')
+    expect(requestedUrl).toEqual(expect.any(String))
+    expect(new URL(requestedUrl).searchParams.get('q')).toBe('appshot')
+    expect(snapshot.items.map(item => item.id)).toEqual(['TaurusWood/dsh-plugin-appshot'])
+    expect(snapshot.page).toEqual({ total: 1 })
+  })
+
   it('keeps the reviewed 1024Store adapter page size fixed at 50', async () => {
     const packages = Array.from({ length: 51 }, (_, index) => ({
       ...rawCatalog.packages[0]!,
@@ -1020,6 +1048,84 @@ describe('catalog active-source reads', () => {
     expect(getJson).toHaveBeenCalledOnce()
     expect(results).toHaveLength(1)
     expect(results[0]?.snapshot?.items).toHaveLength(1)
+  })
+
+  it('routes 1024Store searches through provider fetch instead of the incomplete local scan', async () => {
+    const store = new MemoryCatalogSourceStore()
+    await store.save([source()])
+    const appshot = {
+      ...rawCatalog.packages[0]!,
+      id: 'TaurusWood/dsh-plugin-appshot',
+      name: 'dsh-plugin-appshot',
+      owner: 'TaurusWood',
+      url: 'https://github.com/TaurusWood/dsh-plugin-appshot',
+    }
+    const getJson = vi.fn(async (url: string) => ({
+      value: url.includes('q=appshot')
+        ? { ...rawCatalog, meta: { ...rawCatalog.meta, total: 1 }, packages: [appshot] }
+        : rawCatalog,
+      finalUrl: url,
+    }))
+    const scanCatalog = vi.spyOn(dsh1024StoreAdapter, 'scanCatalog')
+    const service = new DefaultCatalogService(store, { getJson })
+
+    try {
+      const results = await service.fetch({ q: 'appshot' }, new AbortController().signal)
+
+      expect(scanCatalog).not.toHaveBeenCalled()
+      const requestedCall = getJson.mock.calls[0] as unknown as [string, ...unknown[]] | undefined
+      const requestedUrl = requestedCall?.[0]
+      if (requestedUrl === undefined) throw new Error('expected the service to issue one 1024Store provider request')
+      expect(requestedUrl).toEqual(expect.any(String))
+      expect(new URL(requestedUrl).searchParams.get('q')).toBe('appshot')
+      expect(results).toHaveLength(1)
+      expect(results[0]?.snapshot?.items.map(item => item.id)).toEqual(['TaurusWood/dsh-plugin-appshot'])
+    } finally {
+      scanCatalog.mockRestore()
+    }
+  })
+
+  it('returns provider-backed 1024Store search results even when the full local scan is incomplete', async () => {
+    const fetch = vi.spyOn(dsh1024StoreAdapter, 'fetch').mockResolvedValue({
+      schemaVersion: '1.0.0',
+      source: {
+        sourceRecordId: source().sourceRecordId,
+        providerId: source().providerId,
+        adapterId: source().adapterId,
+        registrationKind: source().registrationKind,
+        fetchedAt: '2026-08-24T16:10:00.000Z',
+        finalUrl: 'https://deepseek1024.com/api/v1/plugins?q=appshot',
+      },
+      items: [{
+        id: 'TaurusWood/dsh-plugin-appshot',
+        name: 'dsh-plugin-appshot',
+        displayName: 'dsh-plugin-appshot',
+        summary: 'Appshot',
+        repository: { url: 'https://github.com/TaurusWood/dsh-plugin-appshot' },
+        provenance: {
+          sourceRecordId: source().sourceRecordId,
+          providerId: source().providerId,
+          itemId: 'TaurusWood/dsh-plugin-appshot',
+        },
+      }],
+      page: { total: 1 },
+    })
+    const scanCatalog = vi.spyOn(dsh1024StoreAdapter, 'scanCatalog')
+      .mockRejectedValue(new Error('1024Store scan did not reach the provider total'))
+
+    try {
+      const response = await requestMarketCatalog([source()], `${marketRoutes.catalog}?q=appshot`)
+
+      expect(response.statusCode).toBe(200)
+      expect(fetch).toHaveBeenCalledOnce()
+      expect(response.body.results[0]?.snapshot?.items.map((item: { id: string }) => item.id))
+        .toEqual(['TaurusWood/dsh-plugin-appshot'])
+      expect(response.body.categories).toEqual([])
+      expect(response.body.metadata).toBeUndefined()
+    } finally {
+      fetch.mockRestore()
+      scanCatalog.mockRestore()
+    }
   })
 
   it('reuses only an unexpired complete index and reports explicit cache status', async () => {


### PR DESCRIPTION
## Summary

- forward the reviewed `q` parameter to the 1024Store v1 provider endpoint
- route active-source 1024Store searches through provider fetch while leaving browse on the scanned local index
- serve provider-backed matches even when the best-effort complete scan remains truncated

## Why

The Market currently searches only its locally scanned prefix. A package outside that prefix is invisible even though 1024Store already supports server-side `q` search.

Closes #558.

## Validation

- rebased onto current `upstream/master`
- `corepack yarn install --immutable`
- focused Market runtime tests: 86/86
- full `corepack yarn check`
- Market: 277/277
- Desktop: 808 passed, 4 skipped
- three safety passes covered the remote query surface, cursor/cache boundaries, and debug/residue scan

## Scope

Only `q` is forwarded. This does not relax the separate full-scan completeness guard and does not invent an unverified remote pagination contract.