### PR TITLE
fix(market): forward 1024Store search queries to provider

### DIFF
--- a/dsh-community-market/src/adapters/dsh-1024store.ts
+++ b/dsh-community-market/src/adapters/dsh-1024store.ts
@@ -451,9 +451,11 @@ export const dsh1024StoreAdapter: CatalogAdapter = {
   adapterId: DSH_1024STORE_ADAPTER_ID,
   async fetch(queryValue, context) {
     const query = { ...queryValue, limit: Math.min(queryValue.limit ?? 50, 50) }
-    const expectedOrigin = new URL(DSH_1024STORE_ENDPOINT).origin
+    const endpoint = new URL(DSH_1024STORE_ENDPOINT)
+    if (query.q !== undefined) endpoint.searchParams.set('q', query.q)
+    const expectedOrigin = endpoint.origin
     const response = await context.http.getJson(
-      DSH_1024STORE_ENDPOINT,
+      endpoint.href,
       context.signal,
       { allowedOrigin: expectedOrigin },
     )

--- a/dsh-community-market/tests/dsh-1024store-query.spec.ts
+++ b/dsh-community-market/tests/dsh-1024store-query.spec.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it, vi } from 'vitest'
+import {
+  dsh1024StoreAdapter,
+  DSH_1024STORE_ADAPTER_ID,
+  DSH_1024STORE_ENDPOINT,
+  DSH_1024STORE_KEY,
+  DSH_1024STORE_PROVIDER_ID,
+} from '../src/adapters/dsh-1024store.js'
+import type { CatalogHttpClient, LocalSourceRecord } from '../src/contracts/index.js'
+
+const source = (): LocalSourceRecord => ({
+  sourceRecordId: '018f1f77-a5c4-7b73-a9ae-0242ac120002',
+  registrationKind: 'built-in',
+  adapterId: DSH_1024STORE_ADAPTER_ID,
+  providerId: DSH_1024STORE_PROVIDER_ID,
+  builtInProviderKey: DSH_1024STORE_KEY,
+  enabled: true,
+  order: 0,
+})
+
+const appshotCatalog = {
+  meta: { total: 1 },
+  packages: [{
+    id: 'TaurusWood/dsh-plugin-appshot',
+    name: 'dsh-plugin-appshot',
+    owner: 'TaurusWood',
+    url: 'https://github.com/TaurusWood/dsh-plugin-appshot',
+    category: 'tools',
+    description: { en: 'Context screenshot capture for DeepSeek Harness', zh: 'DeepSeek Harness 上下文截图插件' },
+    stars: 0,
+  }],
+}
+
+const media = { register: () => 'mktimg_QQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQ' }
+
+describe('1024Store provider search', () => {
+  it('forwards the keyword to the provider before applying local filtering', async () => {
+    const getJson = vi.fn(async (url: string) => ({ value: appshotCatalog, finalUrl: url }))
+    const http: CatalogHttpClient = { getJson }
+
+    const snapshot = await dsh1024StoreAdapter.fetch(
+      { q: 'appshot', locale: 'en-US' },
+      { source: source(), signal: new AbortController().signal, http, media },
+    )
+
+    expect(getJson.mock.calls[0]?.[0]).toBe(`${DSH_1024STORE_ENDPOINT}?q=appshot`)
+    expect(snapshot.items.map(item => item.id)).toEqual(['TaurusWood/dsh-plugin-appshot'])
+  })
+
+  it('keeps complete catalog scans on the unfiltered provider endpoint', async () => {
+    const getJson = vi.fn(async (url: string) => ({ value: appshotCatalog, finalUrl: url }))
+    const http: CatalogHttpClient = { getJson }
+
+    await dsh1024StoreAdapter.scanCatalog!(
+      { q: 'appshot', locale: 'en-US' },
+      { source: source(), signal: new AbortController().signal, http, media },
+    )
+
+    expect(getJson.mock.calls[0]?.[0]).toBe(DSH_1024STORE_ENDPOINT)
+  })
+})


### PR DESCRIPTION
## Summary / 摘要

Fix DSH 1024Store search so that keyword queries are forwarded to the provider instead of being applied only to the provider's default truncated response.

The 1024Store adapter previously always requested:

```text
https://deepseek1024.com/api/v1/plugins
```

and then applied `query.q` locally to the returned packages.

However, `/api/v1/plugins` returns a truncated result set. This means plugins outside the provider's default response cannot be discovered from DSH Desktop search even though they exist in the 1024Store catalog.

This change forwards the search keyword through the existing v1 API:

```text
/api/v1/plugins?q=<query>
```

The v1 response contract remains unchanged (`packages` / `meta`), so the existing normalization, origin validation, local secondary filtering, and sorting logic are preserved.

`scanCatalog` continues to use the unfiltered endpoint and is not affected by interactive search queries.

A regression test is added to verify both:

- Search queries are forwarded to the 1024Store provider.
- Full catalog scans continue to use the unfiltered endpoint.

修复 DSH 1024Store 的搜索行为：将关键词查询传递给数据源，而不是仅在数据源默认返回的截断结果中进行本地过滤。

此前 1024Store adapter 始终请求：

```text
https://deepseek1024.com/api/v1/plugins
```

之后才在 Desktop 侧使用 `query.q` 进行本地过滤。

由于 `/api/v1/plugins` 返回的是截断结果，因此未包含在默认返回结果中的插件，即使已经存在于 1024Store，也无法通过 DSH Desktop 搜索发现。

本次修改仍使用现有 v1 API，仅在搜索请求中增加：

```text
/api/v1/plugins?q=<query>
```

v1 接口返回结构仍保持为 `packages` / `meta`，因此现有的数据标准化、Origin 校验、本地二次过滤和排序逻辑均保持不变。

`scanCatalog` 仍然请求无过滤参数的 endpoint，不受交互式搜索影响。

同时新增回归测试，验证：

- 搜索关键词会正确传递给 1024Store provider。
- 全量 catalog scan 仍然使用无过滤 endpoint。

## Related Issues / 关联 Issue

Fixes #558

## Type / 类型

- [x] Bug fix / 问题修复
- [ ] Feature / 新功能
- [ ] Documentation / 文档
- [ ] Release or packaging / 发布或打包
- [ ] Tests only / 仅测试
- [ ] Other / 其他

## Platforms / 影响平台

- [ ] Windows installer / Windows 安装包
- [ ] Windows portable ZIP / Windows 便携版 ZIP
- [ ] macOS Apple Silicon
- [ ] macOS Intel
- [ ] macOS Universal package / macOS 通用安装包
- [ ] Linux
- [x] Not platform-specific / 与平台无关

## Verification / 验证

The change was verified locally against the current repository workspace.

本次修改已在当前仓库 workspace 中完成本地验证。

- [ ] `corepack yarn check:layout`
- [x] `corepack yarn typecheck`
- [x] `corepack yarn test`
- [x] `corepack yarn check`
- [ ] Platform package smoke / 平台打包或启动冒烟
- [ ] Manual test / 人工测试

Additional verification / 其他验证：

- `corepack yarn typecheck`
  - ✅ 0 errors
- `corepack yarn test`
  - ✅ 1083 / 1083 tests passed
  - Desktop: 807 passed
  - Community Market: 276 passed
- `yarn workspace dsh-community-market test`
  - ✅ Passed
- `yarn workspace dsh-community-market check`
  - ✅ Passed
- `corepack yarn build`
  - ✅ Production build completed successfully
- `corepack yarn check`
  - ✅ Full headless gate passed
- Confirmed that `scanCatalog` continues to request the unfiltered 1024Store endpoint.
- Confirmed that interactive `fetch` adds `?q=<query>` only when a search query is present.
- Confirmed that the existing `allowedOrigin` and `finalOrigin` validation remains unchanged.

## Release Notes / 发布说明

DSH Desktop can now discover 1024Store plugins through keyword search even when they are not included in the provider's default truncated catalog response.

DSH Desktop 现在可以通过关键词搜索发现未包含在 1024Store 默认截断目录结果中的插件。