### PR TITLE
feat(models): search large provider catalogs

### DIFF
--- a/dsh-plugin-desktop/tests/package.spec.ts
+++ b/dsh-plugin-desktop/tests/package.spec.ts
@@ -256,6 +256,72 @@ describe('published package surface', () => {
     }
   })
 
+  it('adds bilingual search copy to the fetched-model picker', () => {
+    const patch = readFileSync(new URL(
+      '../patches/dsh-client-ui-settings-models@0.1.1-rc.2.patch',
+      packageRoot,
+    ), 'utf8')
+    const installedClient = readFileSync(new URL(
+      'node_modules/@deepseek-ai/dsh-client-ui-settings-models/lib/client.js',
+      packageRoot,
+    ), 'utf8')
+    for (const marker of [
+      'fetchSearch: "Search models"',
+      'fetchSearchPlaceholder: "Search by model ID or name"',
+      'fetchNoMatches: "No models match the current search."',
+      'fetchSearch: "搜索模型"',
+      'fetchSearchPlaceholder: "按模型 ID 或名称搜索"',
+      'fetchNoMatches: "当前搜索没有匹配的模型。"',
+    ]) {
+      expect(patch).toContain(marker)
+      expect(installedClient).toContain(marker)
+    }
+  })
+
+  it('filters fetched-model candidates before rendering and bulk selection', () => {
+    const patch = readFileSync(new URL(
+      '../patches/dsh-client-ui-settings-models@0.1.1-rc.2.patch',
+      packageRoot,
+    ), 'utf8')
+    const installedClient = readFileSync(new URL(
+      'node_modules/@deepseek-ai/dsh-client-ui-settings-models/lib/client.js',
+      packageRoot,
+    ), 'utf8')
+    for (const marker of [
+      'const [candidateQuery, setCandidateQuery] = (0, react.useState)("")',
+      'const normalizedCandidateQuery = candidateQuery.trim().toLowerCase();',
+      'const filteredCandidates = normalizedCandidateQuery.length === 0 ? activeCandidates : activeCandidates.filter((candidate) => {',
+      'const haystacks = [candidate.id, candidate.name].filter((value) => typeof value === "string");',
+      'filteredCandidates.length === 0 ? (0, react_jsx_runtime.jsx)("p", {',
+      'children: t("fetchNoMatches")',
+      'children: filteredCandidates.map((candidate) => (0, react_jsx_runtime.jsx)("li", {',
+    ]) {
+      expect(patch).toContain(marker)
+      expect(installedClient).toContain(marker)
+    }
+  })
+
+  it('preserves picked models outside the active filter when bulk-clearing matches', () => {
+    const patch = readFileSync(new URL(
+      '../patches/dsh-client-ui-settings-models@0.1.1-rc.2.patch',
+      packageRoot,
+    ), 'utf8')
+    const installedClient = readFileSync(new URL(
+      'node_modules/@deepseek-ai/dsh-client-ui-settings-models/lib/client.js',
+      packageRoot,
+    ), 'utf8')
+    for (const marker of [
+      'const allFilteredCandidatesPicked = filteredCandidates.length > 0 && filteredCandidates.every((candidate) => picked.has(candidate.id));',
+      'for (const candidate of filteredCandidates) next.delete(candidate.id);',
+      'for (const candidate of filteredCandidates) next.add(candidate.id);',
+      'disabled: filteredCandidates.length === 0',
+      'children: t(allFilteredCandidatesPicked ? "fetchDeselectAll" : "fetchSelectAll")',
+    ]) {
+      expect(patch).toContain(marker)
+      expect(installedClient).toContain(marker)
+    }
+  })
+
   it('localizes Trajectory toolbar labels in Simplified Chinese', () => {
     const patchPath = './patches/dsh-client-ui-trajectory@0.1.1-rc.2.patch'
     expect(workspaceManifest.resolutions).toMatchObject({

--- a/patches/dsh-client-ui-settings-models@0.1.1-rc.2.patch
+++ b/patches/dsh-client-ui-settings-models@0.1.1-rc.2.patch
@@ -2,6 +2,95 @@ diff --git a/lib/client.js b/lib/client.js
 index fff5f43..b10f8d7 100644
 --- a/lib/client.js
 +++ b/lib/client.js
+@@ -756,6 +756,7 @@ window.__ModuleLoader__.load({
+ 			const [busy, setBusy] = (0, react.useState)(false);
+ 			const [failure, setFailure] = (0, react.useState)(void 0);
+ 			const [candidates, setCandidates] = (0, react.useState)(void 0);
++			const [candidateQuery, setCandidateQuery] = (0, react.useState)("");
+ 			const [picked, setPicked] = (0, react.useState)(/* @__PURE__ */ new Set());
+ 			const [expanded, setExpanded] = (0, react.useState)(/* @__PURE__ */ new Set());
+ 			const [editing, setEditing] = (0, react.useState)(/* @__PURE__ */ new Map());
+@@ -816,6 +817,7 @@ window.__ModuleLoader__.load({
+ 					}
+ 					const known = new Set(models.map((model) => textOf(model, "id")));
+ 					setCandidates(found);
++					setCandidateQuery("");
+ 					setPicked(new Set(found.filter((model) => !known.has(model.id)).map((model) => model.id)));
+ 				} catch (error) {
+ 					setFailure(messageOf(error));
+@@ -825,6 +827,7 @@ window.__ModuleLoader__.load({
+ 			};
+ 			const closePicker = () => {
+ 				setCandidates(void 0);
++				setCandidateQuery("");
+ 				setPicked(/* @__PURE__ */ new Set());
+ 			};
+ 			const adoptPicked = () => {
+@@ -846,10 +849,21 @@ window.__ModuleLoader__.load({
+ 				});
+ 			};
+ 			const activeCandidates = candidates ?? [];
+-			const allCandidatesPicked = activeCandidates.length > 0 && activeCandidates.every((candidate) => picked.has(candidate.id));
++			const normalizedCandidateQuery = candidateQuery.trim().toLowerCase();
++			const filteredCandidates = normalizedCandidateQuery.length === 0 ? activeCandidates : activeCandidates.filter((candidate) => {
++				const haystacks = [candidate.id, candidate.name].filter((value) => typeof value === "string");
++				return haystacks.some((value) => value.toLowerCase().includes(normalizedCandidateQuery));
++			});
++			const allFilteredCandidatesPicked = filteredCandidates.length > 0 && filteredCandidates.every((candidate) => picked.has(candidate.id));
+ 			const toggleAllCandidates = () => {
+ 				setPicked((current) => {
+-					return activeCandidates.every((candidate) => current.has(candidate.id)) ? /* @__PURE__ */ new Set() : new Set(activeCandidates.map((candidate) => candidate.id));
++					const next = new Set(current);
++					if (filteredCandidates.every((candidate) => current.has(candidate.id))) {
++						for (const candidate of filteredCandidates) next.delete(candidate.id);
++					} else {
++						for (const candidate of filteredCandidates) next.add(candidate.id);
++					}
++					return next;
+ 				});
+ 			};
+ 			const askable = probe.provider !== void 0 || probe.baseURL !== void 0 && probe.baseURL.length > 0;
+@@ -1018,17 +1032,36 @@ window.__ModuleLoader__.load({
+ 							onClick: adoptPicked,
+ 							children: t("fetchAdopt")
+ 						})] }),
+-						children: [(0, react_jsx_runtime.jsx)("div", {
++						children: [(0, react_jsx_runtime.jsxs)("div", {
++							className: ModelsSection_module_css_default["field"],
++							children: [(0, react_jsx_runtime.jsx)("label", {
++								className: ModelsSection_module_css_default["hiddenLabel"],
++								children: t("fetchSearch")
++							}), (0, react_jsx_runtime.jsx)("input", {
++								className: ModelsSection_module_css_default["input"],
++								type: "search",
++								value: candidateQuery,
++								placeholder: t("fetchSearchPlaceholder"),
++								"aria-label": t("fetchSearch"),
++								onChange: (event) => {
++									setCandidateQuery(event.target.value);
++								}
++							})]
++						}), (0, react_jsx_runtime.jsx)("div", {
+ 							className: ModelsSection_module_css_default["candidateActions"],
+ 							children: (0, react_jsx_runtime.jsx)(_deepseek_ai_dsh_client_ui_primitives.Button, {
+ 								variant: "ghost",
+ 								size: "sm",
++								disabled: filteredCandidates.length === 0,
+ 								onClick: toggleAllCandidates,
+-								children: t(allCandidatesPicked ? "fetchDeselectAll" : "fetchSelectAll")
++								children: t(allFilteredCandidatesPicked ? "fetchDeselectAll" : "fetchSelectAll")
+ 							})
+-						}), (0, react_jsx_runtime.jsx)("ul", {
++						}), filteredCandidates.length === 0 ? (0, react_jsx_runtime.jsx)("p", {
++							className: ModelsSection_module_css_default["modelEmpty"],
++							children: t("fetchNoMatches")
++						}) : null, (0, react_jsx_runtime.jsx)("ul", {
+ 							className: ModelsSection_module_css_default["candidateList"],
+-							children: (candidates ?? []).map((candidate) => (0, react_jsx_runtime.jsx)("li", {
++							children: filteredCandidates.map((candidate) => (0, react_jsx_runtime.jsx)("li", {
+ 								className: ModelsSection_module_css_default["candidate"],
+ 								children: (0, react_jsx_runtime.jsxs)("label", {
+ 									className: ModelsSection_module_css_default["candidateLabel"],
 @@ -1529,6 +1529,8 @@ window.__ModuleLoader__.load({
  			*/
  			const curatedFields = (family) => {
@@ -20,3 +109,23 @@ index fff5f43..b10f8d7 100644
  								className: ModelsSection_module_css_default["field"],
  								children: [(0, react_jsx_runtime.jsx)("span", {
  									className: ModelsSection_module_css_default["fieldLabel"],
+@@ -2576,6 +2609,9 @@ window.__ModuleLoader__.load({
+ 			fetchEmpty: "The provider listed no models. Add them by hand.",
+ 			fetchTitle: "Choose models to add",
+ 			fetchDescription: "These are the models this provider has available. Choose the ones to add.",
++			fetchSearch: "Search models",
++			fetchSearchPlaceholder: "Search by model ID or name",
++			fetchNoMatches: "No models match the current search.",
+ 			fetchSelectAll: "Select all",
+ 			fetchDeselectAll: "Deselect all",
+ 			fetchAdopt: "Add selected",
+@@ -2674,6 +2710,9 @@ window.__ModuleLoader__.load({
+ 			fetchEmpty: "该提供方没有列出任何模型，请手动添加。",
+ 			fetchTitle: "选择要添加的模型",
+ 			fetchDescription: "以下是模型提供方的可用模型，勾选要添加的模型。",
++			fetchSearch: "搜索模型",
++			fetchSearchPlaceholder: "按模型 ID 或名称搜索",
++			fetchNoMatches: "当前搜索没有匹配的模型。",
+ 			fetchSelectAll: "全选",
+ 			fetchDeselectAll: "取消全选",
+ 			fetchAdopt: "添加所选",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1869,7 +1869,7 @@ __metadata:
 
 "@deepseek-ai/dsh-client-ui-settings-models@patch:@deepseek-ai/dsh-client-ui-settings-models@npm%3A0.1.1-rc.2#./patches/dsh-client-ui-settings-models@0.1.1-rc.2.patch::locator=deepseek-harness-desktop%40workspace%3A.":
   version: 0.1.1-rc.2
-  resolution: "@deepseek-ai/dsh-client-ui-settings-models@patch:@deepseek-ai/dsh-client-ui-settings-models@npm%3A0.1.1-rc.2#./patches/dsh-client-ui-settings-models@0.1.1-rc.2.patch::version=0.1.1-rc.2&hash=c5beaa&locator=deepseek-harness-desktop%40workspace%3A."
+  resolution: "@deepseek-ai/dsh-client-ui-settings-models@patch:@deepseek-ai/dsh-client-ui-settings-models@npm%3A0.1.1-rc.2#./patches/dsh-client-ui-settings-models@0.1.1-rc.2.patch::version=0.1.1-rc.2&hash=6667b1&locator=deepseek-harness-desktop%40workspace%3A."
   peerDependencies:
     "@deepseek-ai/cordis": ^4.0.1
     "@deepseek-ai/dsh-api-remotes": ^0.1.1-rc.2
@@ -1878,7 +1878,7 @@ __metadata:
     "@deepseek-ai/dsh-client-runtime": ^0.1.1-rc.2
     "@deepseek-ai/dsh-client-ui-settings": ^0.1.1-rc.2
     "@deepseek-ai/dsh-invariants": ^0.1.1-rc.2
-  checksum: 10c0/5de09b119b082c86129b9cc8f00efc856dadeb8aab2ab1d758b6d46d570377802082a789592ec89456354a83c5bb3e09c48eda2845a2407ba7b60996911ecfcc
+  checksum: 10c0/cdcd4a67c6b845e579975d4f25a2118b8f9cb7f7ca443d30dab9337621dbe8114230b7254fd6c0b397ba9f8d229b7c152467dd966dfd44cd6c1e4805b55fe2bb
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary
- add bilingual search by model ID or name to fetched provider catalogs
- scope bulk select/deselect to visible results
- preserve selected models outside the active filter

## Validation
- corepack yarn workspace dsh-plugin-desktop vitest run tests/package.spec.ts
- corepack yarn install --immutable
- corepack yarn check (Market 274; Desktop 813, 4 skipped)
- accessibility, local-only filtering, and selection-state reviews completed

Closes #453