### PR TITLE
feat(models): discover models from explicit endpoint overrides

### DIFF
--- a/dsh-plugin-desktop/tests/model-discovery.spec.ts
+++ b/dsh-plugin-desktop/tests/model-discovery.spec.ts
@@ -1,0 +1,108 @@
+import { createServer } from 'node:http'
+import type { IncomingMessage, Server, ServerResponse } from 'node:http'
+import { createRequire } from 'node:module'
+import { afterEach, describe, expect, it } from 'vitest'
+import { Context } from '@deepseek-ai/cordis'
+import LlmRuntime from '@deepseek-ai/dsh-llm'
+const require = createRequire(import.meta.url)
+const LlmPiAi = require('@deepseek-ai/dsh-llm-pi-ai') as any
+
+const servers: Server[] = []
+
+afterEach(async () => {
+  await Promise.all(servers.splice(0).map(server => new Promise(resolve => server.close(resolve))))
+})
+
+interface ListingServer {
+  url: string
+  paths: string[]
+  headers: IncomingMessage['headers'][]
+}
+
+async function listingServer(body: string): Promise<ListingServer> {
+  const paths: string[] = []
+  const headers: IncomingMessage['headers'][] = []
+  const server = createServer((request: IncomingMessage, response: ServerResponse) => {
+    paths.push(request.url ?? '')
+    headers.push(request.headers)
+    response.writeHead(200, {
+      'content-type': 'application/json',
+      'content-length': String(Buffer.byteLength(body)),
+    })
+    response.end(body)
+  })
+  servers.push(server)
+  await new Promise<void>(resolve => server.listen(0, '127.0.0.1', resolve))
+  const address = server.address()
+  if (address === null || typeof address === 'string') throw new Error('no port')
+  return { url: `http://127.0.0.1:${address.port}`, paths, headers }
+}
+
+async function harness(): Promise<Context> {
+  const ctx = new Context()
+  await ctx.plugin(LlmRuntime)
+  await ctx.plugin(LlmPiAi, {})
+  return ctx
+}
+
+describe('Desktop pi-ai model discovery patch', () => {
+  it('keeps built-in providers offline when no endpoint override is present', async () => {
+    const server = await listingServer(JSON.stringify({ data: [{ id: 'from-endpoint-only' }] }))
+    const ctx = await harness()
+
+    const models = await ctx.llm.discoverModels('llm-pi-ai', { provider: 'deepseek' })
+
+    expect(models.length).toBeGreaterThan(0)
+    expect(server.paths).toEqual([])
+  })
+
+  it('probes a built-in provider live when baseURL is explicitly overridden with a listable protocol', async () => {
+    const ctx = await harness()
+    const catalog = await ctx.llm.discoverModels('llm-pi-ai', { provider: 'deepseek' })
+    const known = catalog.find(model =>
+      typeof model.name === 'string'
+      && typeof model.contextWindow === 'number'
+      && typeof model.maxTokens === 'number')
+    if (known === undefined) throw new Error('deepseek catalog did not expose an enrichable model')
+    const server = await listingServer(JSON.stringify({
+      data: [
+        { id: known.id, display_name: 'Live Name' },
+        { id: 'fresh-from-endpoint' },
+      ],
+    }))
+
+    const models = await ctx.llm.discoverModels('llm-pi-ai', {
+      provider: 'deepseek',
+      baseURL: `${server.url}/v1`,
+      api: 'openai-completions',
+    })
+
+    expect(server.paths).toEqual(['/v1/models'])
+    expect(server.headers[0]?.authorization).toBeUndefined()
+    expect(models).toEqual([
+      {
+        id: known.id,
+        name: 'Live Name',
+        contextWindow: known.contextWindow,
+        maxTokens: known.maxTokens,
+      },
+      { id: 'fresh-from-endpoint' },
+    ])
+  })
+
+  it('keeps the offline catalog for built-in providers when the override protocol is not listable', async () => {
+    const server = await listingServer(JSON.stringify({ data: [{ id: 'from-endpoint-only' }] }))
+    const ctx = await harness()
+    const catalog = await ctx.llm.discoverModels('llm-pi-ai', { provider: 'deepseek' })
+
+    const models = await ctx.llm.discoverModels('llm-pi-ai', {
+      provider: 'deepseek',
+      baseURL: server.url,
+      api: 'anthropic-messages',
+    })
+
+    expect(models.map(model => model.id).sort())
+      .toEqual(catalog.map(model => model.id).sort())
+    expect(server.paths).toEqual([])
+  })
+})

--- a/dsh-plugin-desktop/tests/package.spec.ts
+++ b/dsh-plugin-desktop/tests/package.spec.ts
@@ -256,6 +256,27 @@ describe('published package surface', () => {
     }
   })
 
+  it('patches pi-ai discovery so explicit built-in endpoint overrides can probe live /models', () => {
+    const patchPath = './patches/dsh-llm-pi-ai@0.1.1-rc.2.patch'
+    expect(workspaceManifest.resolutions).toMatchObject({
+      '@deepseek-ai/dsh-llm-pi-ai@npm:0.1.1-rc.2': expect.stringContaining(patchPath),
+      '@deepseek-ai/dsh-llm-pi-ai@npm:^0.1.1-rc.2': expect.stringContaining(patchPath),
+    })
+    const patch = readFileSync(new URL(patchPath, workspaceRoot), 'utf8')
+    const installedProvider = readFileSync(new URL(
+      'node_modules/@deepseek-ai/dsh-llm-pi-ai/lib/index.js',
+      packageRoot,
+    ), 'utf8')
+    for (const marker of [
+      'const catalogRows = catalog !== void 0 && catalog.size > 0 ? [...catalog.values()].map((model) => ({',
+      'const probeCatalogRoute = catalogRows !== void 0 && hasBaseURL && LISTABLE_PROTOCOLS.has(api);',
+      'if (catalog === void 0) return discovered;',
+    ]) {
+      expect(patch).toContain(marker)
+      expect(installedProvider).toContain(marker)
+    }
+  })
+
   it('localizes Trajectory toolbar labels in Simplified Chinese', () => {
     const patchPath = './patches/dsh-client-ui-trajectory@0.1.1-rc.2.patch'
     expect(workspaceManifest.resolutions).toMatchObject({

--- a/package.json
+++ b/package.json
@@ -18,6 +18,8 @@
     "@deepseek-ai/dsh-app-boot@npm:0.1.1-rc.2": "patch:@deepseek-ai/dsh-app-boot@npm%3A0.1.1-rc.2#./patches/dsh-app-boot@0.1.1-rc.2.patch",
     "@deepseek-ai/dsh-app-boot@npm:^0.1.1-rc.2": "patch:@deepseek-ai/dsh-app-boot@npm%3A0.1.1-rc.2#./patches/dsh-app-boot@0.1.1-rc.2.patch",
     "@deepseek-ai/dsh-llm-deepseek@npm:^0.1.1-rc.2": "patch:@deepseek-ai/dsh-llm-deepseek@npm%3A0.1.1-rc.2#./patches/dsh-llm-deepseek@0.1.1-rc.2.patch",
+    "@deepseek-ai/dsh-llm-pi-ai@npm:0.1.1-rc.2": "patch:@deepseek-ai/dsh-llm-pi-ai@npm%3A0.1.1-rc.2#./patches/dsh-llm-pi-ai@0.1.1-rc.2.patch",
+    "@deepseek-ai/dsh-llm-pi-ai@npm:^0.1.1-rc.2": "patch:@deepseek-ai/dsh-llm-pi-ai@npm%3A0.1.1-rc.2#./patches/dsh-llm-pi-ai@0.1.1-rc.2.patch",
     "@deepseek-ai/dsh-sandbox-windows-acl@npm:0.1.1-rc.2": "patch:@deepseek-ai/dsh-sandbox-windows-acl@npm%3A0.1.1-rc.2#./patches/dsh-sandbox-windows-acl@0.1.1-rc.2.patch",
     "@deepseek-ai/dsh-sandbox-windows-acl@npm:^0.1.1-rc.2": "patch:@deepseek-ai/dsh-sandbox-windows-acl@npm%3A0.1.1-rc.2#./patches/dsh-sandbox-windows-acl@0.1.1-rc.2.patch",
     "@deepseek-ai/dsh-client-ui-directory-picker-browse@npm:0.1.1-rc.2": "patch:@deepseek-ai/dsh-client-ui-directory-picker-browse@npm%3A0.1.1-rc.2#./patches/dsh-client-ui-directory-picker-browse@0.1.1-rc.2.patch",

--- a/patches/dsh-llm-pi-ai@0.1.1-rc.2.patch
+++ b/patches/dsh-llm-pi-ai@0.1.1-rc.2.patch
@@ -1,0 +1,96 @@
+diff --git a/lib/index.js b/lib/index.js
+--- a/lib/index.js
++++ b/lib/index.js
+@@ -1945,10 +1945,12 @@
+ * Answering "which models can this provider serve?" for the configuration
+ * surface's "fetch available models" action.
+ *
+-* A route the installed pi-ai catalog ships is answered **from that catalog**,
+-* with no network call at all: pi-ai's registry is the authoritative list for
+-* its own providers, and it carries the capacities a listing endpoint would
+-* not disclose. Only a route the catalog does not describe — a gateway, a
++* A route the installed pi-ai catalog ships is answered **from that catalog**
++* unless the draft also names a `baseURL` whose protocol this build can list;
++* that explicit endpoint override is probed live, then enriched from the
++* catalog by id where the listing omits capacities. pi-ai's registry remains
++* the authoritative offline answer for its own providers. Only a route the
++* catalog does not describe — a gateway, a
+ * self-hosted server — is interrogated over the wire.
+ *
+ * Neither path is a catalog refresh. Nothing here is stored: the request
+@@ -2087,17 +2089,22 @@
+ *   refuses or fails the request, or the reply is not a model listing.
+ */
+ async function discoverModels(request, storedApiKey) {
+-	if (request.provider !== void 0) {
+-		const installed = catalogModels(request.provider);
+-		if (installed.size > 0) return [...installed.values()].map((model) => ({
+-			id: model.id,
+-			name: model.name,
+-			contextWindow: model.contextWindow,
+-			maxTokens: model.maxTokens
+-		}));
+-	}
++	const catalog = request.provider === void 0 ? void 0 : catalogModels(request.provider);
++	const catalogRows = catalog !== void 0 && catalog.size > 0 ? [...catalog.values()].map((model) => ({
++		id: model.id,
++		name: model.name,
++		contextWindow: model.contextWindow,
++		maxTokens: model.maxTokens
++	})) : void 0;
++	const hasBaseURL = request.baseURL !== void 0 && request.baseURL.length > 0;
++	const api = request.api ?? "openai-completions";
++	const probeCatalogRoute = catalogRows !== void 0 && hasBaseURL && LISTABLE_PROTOCOLS.has(api);
++	// A named catalog route keeps its offline answer unless the draft also names
++	// an explicit listable endpoint override. That narrower live path preserves
++	// the current no-network behavior for ordinary built-ins while letting a
++	// gateway-backed override surface new ids immediately.
++	if (catalogRows !== void 0 && !probeCatalogRoute) return catalogRows;
+ 	if (request.baseURL === void 0 || request.baseURL.length === 0) throw new LlmError(`pi-ai ships no catalog for provider "${request.provider ?? ""}", so its models can only come from its endpoint; set a baseURL, or enter this provider's models by hand`, "DISCOVERY_FAILED");
+-	const api = request.api ?? "openai-completions";
+ 	if (!LISTABLE_PROTOCOLS.has(api)) throw new LlmError(`pi-ai protocol "${api}" has no model listing this build can read; enter this provider's models by hand`, "DISCOVERY_UNSUPPORTED");
+ 	const url = listingUrl(request.baseURL);
+ 	const supplied = request.apiKey ?? await storedApiKey?.();
+@@ -2131,7 +2138,21 @@
+ 	} catch (error) {
+ 		throw new LlmError(`${url} did not answer with JSON`, "DISCOVERY_FAILED", { cause: error });
+ 	}
+-	return readListing(body);
++	const discovered = readListing(body);
++	if (catalog === void 0) return discovered;
++	return discovered.map((model) => {
++		const installed = catalog.get(model.id);
++		if (installed === void 0) return model;
++		const name = model.name ?? installed.name;
++		const contextWindow = model.contextWindow ?? installed.contextWindow;
++		const maxTokens = model.maxTokens ?? installed.maxTokens;
++		return {
++			id: model.id,
++			...name === void 0 ? {} : { name },
++			...contextWindow === void 0 ? {} : { contextWindow },
++			...maxTokens === void 0 ? {} : { maxTokens }
++		};
++	});
+ }
+ //#endregion
+ //#region lib/types/login.js
+diff --git a/lib/types/discovery.d.ts b/lib/types/discovery.d.ts
+--- a/lib/types/discovery.d.ts
++++ b/lib/types/discovery.d.ts
+@@ -2,10 +2,12 @@
+  * Answering "which models can this provider serve?" for the configuration
+  * surface's "fetch available models" action.
+  *
+- * A route the installed pi-ai catalog ships is answered **from that catalog**,
+- * with no network call at all: pi-ai's registry is the authoritative list for
+- * its own providers, and it carries the capacities a listing endpoint would
+- * not disclose. Only a route the catalog does not describe — a gateway, a
++ * A route the installed pi-ai catalog ships is answered **from that catalog**
++ * unless the draft also names a `baseURL` whose protocol this build can list;
++ * that explicit endpoint override is probed live, then enriched from the
++ * catalog by id where the listing omits capacities. pi-ai's registry remains
++ * the authoritative offline answer for its own providers. Only a route the
++ * catalog does not describe — a gateway, a
+  * self-hosted server — is interrogated over the wire.
+  *
+  * Neither path is a catalog refresh. Nothing here is stored: the request

--- a/yarn.lock
+++ b/yarn.lock
@@ -2727,7 +2727,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@deepseek-ai/dsh-llm-pi-ai@npm:^0.1.1-rc.2":
+"@deepseek-ai/dsh-llm-pi-ai@npm:0.1.1-rc.2":
   version: 0.1.1-rc.2
   resolution: "@deepseek-ai/dsh-llm-pi-ai@npm:0.1.1-rc.2"
   dependencies:
@@ -2744,6 +2744,26 @@ __metadata:
     "@deepseek-ai/dsh-settings": ^0.1.1-rc.2
     "@deepseek-ai/dsh-timeout": ^0.1.1-rc.2
   checksum: 10c0/bbac1d7eca4c38e3c3e40e4cb297971e0174fad223484871351a602040ae03d1e91d28d30af3b13c8e756849d115a4fd9063438ba4a741aeb745e212613a9cb4
+  languageName: node
+  linkType: hard
+
+"@deepseek-ai/dsh-llm-pi-ai@patch:@deepseek-ai/dsh-llm-pi-ai@npm%3A0.1.1-rc.2#./patches/dsh-llm-pi-ai@0.1.1-rc.2.patch::locator=deepseek-harness-desktop%40workspace%3A.":
+  version: 0.1.1-rc.2
+  resolution: "@deepseek-ai/dsh-llm-pi-ai@patch:@deepseek-ai/dsh-llm-pi-ai@npm%3A0.1.1-rc.2#./patches/dsh-llm-pi-ai@0.1.1-rc.2.patch::version=0.1.1-rc.2&hash=e1ea1c&locator=deepseek-harness-desktop%40workspace%3A."
+  dependencies:
+    "@deepseek-ai/schemastery": "npm:^3.18.1"
+    "@earendil-works/pi-ai": "npm:^0.82.1"
+  peerDependencies:
+    "@deepseek-ai/cordis": ^4.0.1
+    "@deepseek-ai/dsh-attachment": ^0.1.1-rc.2
+    "@deepseek-ai/dsh-authorization": ^0.1.1-rc.2
+    "@deepseek-ai/dsh-credentials": ^0.1.1-rc.2
+    "@deepseek-ai/dsh-invariants": ^0.1.1-rc.2
+    "@deepseek-ai/dsh-launch-environment": ^0.1.1-rc.2
+    "@deepseek-ai/dsh-llm": ^0.1.1-rc.2
+    "@deepseek-ai/dsh-settings": ^0.1.1-rc.2
+    "@deepseek-ai/dsh-timeout": ^0.1.1-rc.2
+  checksum: 10c0/6d71cfe87e2c4a8a4b8ba994e9d13f88152b80052e8a519dae4f37020614a72066ac65a991224e28f5414a0eaa1bedd4f1ccccf1b7634a288acda1edebcd13ae
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary
- keep built-in providers on the offline catalog by default
- query /models only when a built-in provider has an explicit listable base URL override
- enrich live rows with known catalog capacities without persisting discovery results
- retain offline fallback for unsupported override protocols

## Validation
- focused model-discovery and package tests: 35 passed, 1 skipped
- dsh-plugin-desktop typecheck
- full corepack yarn check
- network-boundary, credential handling, and offline-fallback reviews completed

Closes #467