### PR TITLE
fix(desktop): autosize desktop dialogs from rendered content

### DIFF
--- a/dsh-plugin-desktop/src/desktop-dialog-window.ts
+++ b/dsh-plugin-desktop/src/desktop-dialog-window.ts
@@ -14,15 +14,10 @@ const DIALOG_SCHEME = 'dsh-desktop-dialog:'
 const DIALOG_DOCUMENT = fileURLToPath(new URL('./native-ui/desktop-dialog.html', import.meta.url))
 const MAX_BUTTONS = 4
 const DIALOG_WIDTH = 480
-const DIALOG_BODY_PADDING = 40
-const DIALOG_CONTENT_COLUMNS = 54
-const DIALOG_MESSAGE_LINE_HEIGHT = 20
-const DIALOG_DETAIL_LINE_HEIGHT = 23
-const DIALOG_FOOTER_GAP = 20
-const DIALOG_BUTTON_HEIGHT = 32
-const DIALOG_BUTTON_GAP = 8
-const DIALOG_MIN_HEIGHT = 160
-const DIALOG_MAX_ESTIMATED_HEIGHT = 360
+const DIALOG_INITIAL_HEIGHT = 300
+const DIALOG_MIN_CONTENT_HEIGHT = 200
+const DIALOG_MAX_HEIGHT = 440
+const DIALOG_REVEAL_FALLBACK_MS = 250
 
 export interface DesktopDialogOptions {
   readonly type?: 'none' | 'info' | 'error' | 'question' | 'warning'
@@ -38,61 +33,6 @@ export interface DesktopDialogOptions {
 
 export interface DesktopDialogResult {
   readonly response: number
-}
-
-function visualColumns(value: string): number {
-  return [...value].reduce((columns, character) => {
-    if (character === '\t') return columns + 4
-    return columns + ((character.codePointAt(0) ?? 0) > 0xff ? 2 : 1)
-  }, 0)
-}
-
-function estimatedWrappedLines(value: string, maximum: number): number {
-  const lines = value.split('\n').reduce((count, line) => (
-    count + Math.max(1, Math.ceil(visualColumns(line) / DIALOG_CONTENT_COLUMNS))
-  ), 0)
-  return Math.min(maximum, Math.max(1, lines))
-}
-
-function estimatedButtonRows(buttons: readonly string[]): number {
-  const availableWidth = DIALOG_WIDTH - DIALOG_BODY_PADDING
-  let rows = 1
-  let rowWidth = 0
-  for (const label of buttons) {
-    const width = Math.min(240, Math.max(52, 24 + visualColumns(label) * 7))
-    const nextWidth = rowWidth === 0 ? width : rowWidth + DIALOG_BUTTON_GAP + width
-    if (nextWidth > availableWidth && rowWidth !== 0) {
-      rows += 1
-      rowWidth = width
-    } else {
-      rowWidth = nextWidth
-    }
-  }
-  return rows
-}
-
-/**
- * Keep short confirmations compact while retaining bounded room for recovery,
- * diagnostic, and multi-action dialogs. The renderer scrolls detail beyond
- * five estimated lines, so a message cannot grow a modal without limit.
- */
-export function desktopDialogWindowHeight(
-  options: DesktopDialogOptions,
-  customFrame = false,
-): number {
-  const messageHeight = estimatedWrappedLines(options.message, 3) * DIALOG_MESSAGE_LINE_HEIGHT
-  const detailHeight = options.detail === undefined
-    ? 0
-    : 8 + estimatedWrappedLines(options.detail, 5) * DIALOG_DETAIL_LINE_HEIGHT
-  const contentHeight = Math.max(24, messageHeight + detailHeight)
-  const buttonRows = estimatedButtonRows(options.buttons)
-  const footerHeight = buttonRows * DIALOG_BUTTON_HEIGHT + (buttonRows - 1) * DIALOG_BUTTON_GAP
-  const frameHeight = customFrame ? DESKTOP_FRAME_HEIGHT : 0
-  const estimated = frameHeight + DIALOG_BODY_PADDING + contentHeight + DIALOG_FOOTER_GAP + footerHeight
-  return Math.min(
-    DIALOG_MAX_ESTIMATED_HEIGHT,
-    Math.max(DIALOG_MIN_HEIGHT + frameHeight, estimated),
-  )
 }
 
 function normalizedIndex(value: number | undefined, fallback: number, length: number): number {
@@ -113,6 +53,20 @@ export function parseDesktopDialogResponse(href: string, buttonCount: number): n
   if (raw === null || !/^(?:0|[1-9]\d*)$/u.test(raw)) return undefined
   const response = Number(raw)
   return Number.isSafeInteger(response) && response >= 0 && response < buttonCount ? response : undefined
+}
+
+/** Accept only a bounded rendered content height from the isolated local UI. */
+export function parseDesktopDialogLayout(href: string): number | undefined {
+  let url: URL
+  try { url = new URL(href) } catch { return undefined }
+  if (url.protocol !== DIALOG_SCHEME || url.hostname !== 'layout'
+    || url.username !== '' || url.password !== '' || url.port !== ''
+    || url.pathname !== '' || url.hash !== ''
+    || [...url.searchParams.keys()].some(key => key !== 'height')) return undefined
+  const raw = url.searchParams.get('height')
+  if (raw === null || !/^[1-9]\d*$/u.test(raw)) return undefined
+  const height = Number(raw)
+  return Number.isSafeInteger(height) && height <= DIALOG_MAX_HEIGHT ? height : undefined
 }
 
 /** One-shot modal Desktop window; closing it always produces the cancel result. */
@@ -143,16 +97,16 @@ export class DesktopDialogWindow {
     // controls; standalone notices keep ordinary close controls.
     const windowControls = this.options.windowControls ?? parent === undefined
     const customFrame = auxiliaryWindowHasCustomFrame(process.platform, windowControls)
-    const height = desktopDialogWindowHeight(this.options, customFrame)
+    const minimumHeight = DIALOG_MIN_CONTENT_HEIGHT + (customFrame ? DESKTOP_FRAME_HEIGHT : 0)
     const window = new BrowserWindow({
       title: this.options.title,
       ...auxiliaryWindowChromeOptions(process.platform, windowControls),
       width: DIALOG_WIDTH,
-      height,
+      height: DIALOG_INITIAL_HEIGHT,
       minWidth: 420,
-      minHeight: height,
+      minHeight: minimumHeight,
       maxWidth: 620,
-      maxHeight: 440,
+      maxHeight: DIALOG_MAX_HEIGHT,
       resizable: windowControls,
       maximizable: false,
       fullscreenable: false,
@@ -178,20 +132,53 @@ export class DesktopDialogWindow {
 
     return await new Promise<DesktopDialogResult>((resolve, reject) => {
       let settled = false
+      let documentReady = false
+      let layoutReady = false
+      let revealed = false
+      let revealTimer: ReturnType<typeof setTimeout> | undefined
+      const reveal = (): void => {
+        if (revealed || !documentReady || window.isDestroyed()) return
+        revealed = true
+        if (revealTimer !== undefined) clearTimeout(revealTimer)
+        revealTimer = undefined
+        revealApplication(window)
+      }
       const finish = (response: number): void => {
         if (settled) return
         settled = true
+        if (revealTimer !== undefined) clearTimeout(revealTimer)
         if (!window.isDestroyed()) window.destroy()
         resolve(Object.freeze({ response }))
       }
       const navigate = (event: Electron.Event, href: string): void => {
         event.preventDefault()
         const response = parseDesktopDialogResponse(href, this.options.buttons.length)
-        if (response !== undefined) finish(response)
+        if (response !== undefined) {
+          finish(response)
+          return
+        }
+        const renderedHeight = parseDesktopDialogLayout(href)
+        if (renderedHeight === undefined || window.isDestroyed()) return
+        const bounds = window.getBounds()
+        const height = Math.max(minimumHeight, renderedHeight)
+        window.setBounds({
+          ...bounds,
+          y: bounds.y + Math.round((bounds.height - height) / 2),
+          height,
+        }, false)
+        layoutReady = true
+        if (documentReady) reveal()
       }
       window.webContents.on('will-navigate', navigate)
       window.webContents.on('will-redirect', navigate)
-      window.once('ready-to-show', () => { revealApplication(window) })
+      window.once('ready-to-show', () => {
+        documentReady = true
+        if (layoutReady) {
+          reveal()
+        } else {
+          revealTimer = setTimeout(reveal, DIALOG_REVEAL_FALLBACK_MS)
+        }
+      })
       window.on('closed', () => { finish(cancelId) })
       void window.loadFile(DIALOG_DOCUMENT, {
         query: {
@@ -202,6 +189,7 @@ export class DesktopDialogWindow {
       }).catch((cause: unknown) => {
         if (settled) return
         settled = true
+        if (revealTimer !== undefined) clearTimeout(revealTimer)
         if (!window.isDestroyed()) window.destroy()
         reject(cause)
       })

--- a/dsh-plugin-desktop/src/native-ui/desktop-dialog/App.tsx
+++ b/dsh-plugin-desktop/src/native-ui/desktop-dialog/App.tsx
@@ -1,5 +1,5 @@
 import { AlertCircle, AlertTriangle, HelpCircle, Info } from 'lucide-react'
-import { useEffect } from 'react'
+import { useEffect, useLayoutEffect, useRef } from 'react'
 import { Button } from '../components/ui/button.tsx'
 import { DesktopFrame } from '../shared/DesktopFrame.tsx'
 
@@ -35,6 +35,12 @@ function respond(response: number): void {
   window.location.assign(url.href)
 }
 
+function reportLayout(height: number): void {
+  const url = new URL(`${SCHEME}//layout`)
+  url.searchParams.set('height', String(height))
+  window.location.assign(url.href)
+}
+
 function ToneIcon({ type }: Pick<DesktopDialogState, 'type'>): JSX.Element {
   const className = type === 'error'
     ? 'text-destructive'
@@ -49,6 +55,7 @@ function ToneIcon({ type }: Pick<DesktopDialogState, 'type'>): JSX.Element {
 
 export function DesktopDialogApp(): JSX.Element {
   const state = decodeState()
+  const contentRef = useRef<HTMLElement>(null)
   useEffect(() => {
     if (state === undefined) return
     const onKeyDown = (event: KeyboardEvent): void => {
@@ -57,10 +64,32 @@ export function DesktopDialogApp(): JSX.Element {
     window.addEventListener('keydown', onKeyDown)
     return () => { window.removeEventListener('keydown', onKeyDown) }
   }, [state])
+  useLayoutEffect(() => {
+    const content = contentRef.current
+    if (content === null) return
+    let frame: number | undefined
+    let lastHeight = 0
+    const measure = (): void => {
+      frame = undefined
+      const height = Math.ceil(content.getBoundingClientRect().height)
+      if (height <= 0 || height === lastHeight) return
+      lastHeight = height
+      reportLayout(height)
+    }
+    const observer = new ResizeObserver(() => {
+      frame ??= requestAnimationFrame(measure)
+    })
+    observer.observe(content)
+    measure()
+    return () => {
+      observer.disconnect()
+      if (frame !== undefined) cancelAnimationFrame(frame)
+    }
+  }, [])
 
-  if (state === undefined) return <><DesktopFrame /><main className="dshNativeContent flex h-screen items-center justify-center p-5"><p className="text-sm text-destructive">Desktop dialog state is unavailable.</p></main></>
-  return <><DesktopFrame /><main className="dshNativeContent flex h-screen flex-col overflow-hidden p-5">
-    <section className="flex min-h-0 flex-1 gap-4" role="dialog" aria-labelledby="desktop-dialog-title" aria-describedby={state.detail === undefined ? undefined : 'desktop-dialog-detail'}>
+  if (state === undefined) return <><DesktopFrame /><main ref={contentRef} className="dshNativeContent flex items-center justify-center p-5"><p className="text-sm text-destructive">Desktop dialog state is unavailable.</p></main></>
+  return <><DesktopFrame /><main ref={contentRef} className="dshNativeContent flex flex-col overflow-hidden p-5">
+    <section className="flex gap-4" role="dialog" aria-labelledby="desktop-dialog-title" aria-describedby={state.detail === undefined ? undefined : 'desktop-dialog-detail'}>
       <div className="mt-0.5 shrink-0"><ToneIcon type={state.type} /></div>
       <div className="min-w-0">
         <h1 className="text-base font-semibold leading-tight" id="desktop-dialog-title">{state.message}</h1>

--- a/dsh-plugin-desktop/tests/desktop-dialog-window.spec.ts
+++ b/dsh-plugin-desktop/tests/desktop-dialog-window.spec.ts
@@ -19,10 +19,21 @@ const electron = vi.hoisted(() => {
     readonly restore = vi.fn()
     readonly removeMenu = vi.fn()
     readonly destroy = vi.fn()
+    private bounds: Electron.Rectangle
+    readonly getBounds = vi.fn(() => ({ ...this.bounds }))
+    readonly setBounds = vi.fn((bounds: Electron.Rectangle) => { this.bounds = { ...bounds } })
     readonly loadFile = vi.fn(async () => {})
     readonly once = vi.fn((event: string, listener: Listener) => { this.onceListeners.set(event, listener) })
     readonly on = vi.fn((event: string, listener: Listener) => { this.listeners.set(event, listener) })
-    constructor(readonly options: Electron.BrowserWindowConstructorOptions) { windows.push(this) }
+    constructor(readonly options: Electron.BrowserWindowConstructorOptions) {
+      this.bounds = {
+        x: 0,
+        y: 0,
+        width: options.width ?? 800,
+        height: options.height ?? 600,
+      }
+      windows.push(this)
+    }
   }
   return {
     app: { isHidden: vi.fn(() => false), show: vi.fn() },
@@ -34,8 +45,8 @@ const electron = vi.hoisted(() => {
 vi.mock('electron', () => ({ app: electron.app, BrowserWindow: electron.BrowserWindow }))
 
 import {
-  desktopDialogWindowHeight,
   DesktopDialogWindow,
+  parseDesktopDialogLayout,
   parseDesktopDialogResponse,
 } from '../src/desktop-dialog-window.ts'
 
@@ -51,25 +62,10 @@ describe('DesktopDialogWindow', () => {
     expect(parseDesktopDialogResponse('dsh-desktop-dialog://response?id=-1', 2)).toBeUndefined()
     expect(parseDesktopDialogResponse('dsh-desktop-dialog://response?id=1&command=bad', 2)).toBeUndefined()
     expect(parseDesktopDialogResponse('https://response/?id=1', 2)).toBeUndefined()
-  })
-
-  it('sizes short confirmations to their content instead of leaving a fixed blank body', () => {
-    const short = desktopDialogWindowHeight({
-      title: 'Restart DSH Desktop',
-      message: '现在重启 DSH Desktop？',
-      detail: '正在运行的操作和未发送的输入可能会中断。如果取消，已保存的设置会继续等待下次重启生效。',
-      buttons: ['重启', '取消'],
-    })
-    const long = desktopDialogWindowHeight({
-      title: 'Plugin Recovery',
-      message: 'DSH Desktop could not load all plugins.',
-      detail: 'Failed plugins:\n- dsh-vision-router\n\nThe client Loader failed while starting the plugin. Open DSH Terminal to update or remove it, then restart DSH Desktop.',
-      buttons: ['Open DSH Terminal', 'Restart DSH Desktop', 'Dismiss'],
-    })
-
-    expect(short).toBeLessThan(210)
-    expect(long).toBeGreaterThan(short)
-    expect(long).toBeLessThanOrEqual(360)
+    expect(parseDesktopDialogLayout('dsh-desktop-dialog://layout?height=236')).toBe(236)
+    expect(parseDesktopDialogLayout('dsh-desktop-dialog://layout?height=0')).toBeUndefined()
+    expect(parseDesktopDialogLayout('dsh-desktop-dialog://layout?height=441')).toBeUndefined()
+    expect(parseDesktopDialogLayout('dsh-desktop-dialog://layout?height=236&width=900')).toBeUndefined()
   })
 
   it('creates a frameless parented modal shadcn window and returns its explicit response', async () => {
@@ -92,15 +88,8 @@ describe('DesktopDialogWindow', () => {
       frame: false,
       closable: false,
       resizable: false,
-      height: desktopDialogWindowHeight({
-        type: 'question',
-        title: 'Restart DSH Desktop',
-        message: 'Restart now?',
-        detail: 'Running operations may be interrupted.',
-        buttons: ['Restart', 'Cancel'],
-        defaultId: 1,
-        cancelId: 1,
-      }),
+      height: 300,
+      minHeight: 200,
     }))
     expect(window?.options).not.toHaveProperty('titleBarStyle')
     expect(window?.loadFile).toHaveBeenCalledWith(
@@ -108,6 +97,13 @@ describe('DesktopDialogWindow', () => {
       expect.objectContaining({ query: expect.objectContaining({ platform: process.platform, frame: 'false' }) }),
     )
     const navigate = window?.webListeners.get('will-navigate')
+    window?.onceListeners.get('ready-to-show')?.()
+    expect(window?.show).not.toHaveBeenCalled()
+    const layoutEvent = { preventDefault: vi.fn() }
+    navigate?.(layoutEvent, 'dsh-desktop-dialog://layout?height=236')
+    expect(layoutEvent.preventDefault).toHaveBeenCalledOnce()
+    expect(window?.setBounds).toHaveBeenCalledWith({ x: 0, y: 32, width: 480, height: 236 }, false)
+    expect(window?.show).toHaveBeenCalledOnce()
     const event = { preventDefault: vi.fn() }
     navigate?.(event, 'dsh-desktop-dialog://response?id=0')
 
@@ -128,6 +124,7 @@ describe('DesktopDialogWindow', () => {
     expect(electron.windows[0]?.options).toEqual(expect.objectContaining({
       titleBarStyle: 'hiddenInset',
       trafficLightPosition: { x: 16, y: 12 },
+      minHeight: 236,
     }))
     expect(electron.windows[0]?.loadFile).toHaveBeenCalledWith(
       expect.any(String),


### PR DESCRIPTION
## Summary
- remove character-count height estimation from Desktop dialogs
- let the shadcn content flow naturally and measure its rendered height
- resize the isolated BrowserWindow before reveal, preserving a comfortable 200px minimum
- keep multi-line recovery text and wrapped action rows from overlapping

## Local verification
- `corepack yarn workspace dsh-plugin-desktop check`
- 82 test files passed; 810 tests passed, 4 skipped
- versions remain 2.0.3