### PR TITLE
fix(desktop): size dialogs by content area

### DIFF
--- a/dsh-plugin-desktop/src/desktop-dialog-window.ts
+++ b/dsh-plugin-desktop/src/desktop-dialog-window.ts
@@ -155,11 +155,16 @@ export class DesktopDialogWindow {
         }
         const renderedHeight = parseDesktopDialogLayout(href)
         if (renderedHeight === undefined || window.isDestroyed()) return
-        const bounds = window.getBounds()
+        const previousBounds = window.getBounds()
+        // The renderer reports web-content height. setBounds() consumes the
+        // outer window height and clips the footer wherever native chrome or
+        // invisible window borders consume part of that space.
+        window.setContentSize(DIALOG_WIDTH, renderedHeight, false)
+        const sizedBounds = window.getBounds()
         window.setBounds({
-          ...bounds,
-          y: bounds.y + Math.round((bounds.height - renderedHeight) / 2),
-          height: renderedHeight,
+          ...sizedBounds,
+          x: previousBounds.x + Math.round((previousBounds.width - sizedBounds.width) / 2),
+          y: previousBounds.y + Math.round((previousBounds.height - sizedBounds.height) / 2),
         }, false)
         layoutReady = true
         if (documentReady) reveal()

--- a/dsh-plugin-desktop/tests/desktop-dialog-window.spec.ts
+++ b/dsh-plugin-desktop/tests/desktop-dialog-window.spec.ts
@@ -22,6 +22,11 @@ const electron = vi.hoisted(() => {
     private bounds: Electron.Rectangle
     readonly getBounds = vi.fn(() => ({ ...this.bounds }))
     readonly setBounds = vi.fn((bounds: Electron.Rectangle) => { this.bounds = { ...bounds } })
+    readonly setContentSize = vi.fn((width: number, height: number) => {
+      // Model native/invisible chrome so the test distinguishes content size
+      // from outer bounds instead of accidentally treating them as identical.
+      this.bounds = { ...this.bounds, width: width + 8, height: height + 12 }
+    })
     readonly loadFile = vi.fn(async () => {})
     readonly once = vi.fn((event: string, listener: Listener) => { this.onceListeners.set(event, listener) })
     readonly on = vi.fn((event: string, listener: Listener) => { this.listeners.set(event, listener) })
@@ -102,7 +107,8 @@ describe('DesktopDialogWindow', () => {
     const layoutEvent = { preventDefault: vi.fn() }
     navigate?.(layoutEvent, 'dsh-desktop-dialog://layout?height=236')
     expect(layoutEvent.preventDefault).toHaveBeenCalledOnce()
-    expect(window?.setBounds).toHaveBeenCalledWith({ x: 0, y: 32, width: 480, height: 236 }, false)
+    expect(window?.setContentSize).toHaveBeenCalledWith(480, 236, false)
+    expect(window?.setBounds).toHaveBeenCalledWith({ x: -4, y: 26, width: 488, height: 248 }, false)
     expect(window?.show).toHaveBeenCalledOnce()
     const event = { preventDefault: vi.fn() }
     navigate?.(event, 'dsh-desktop-dialog://response?id=0')


### PR DESCRIPTION
## Summary
- apply renderer measurements with `BrowserWindow.setContentSize` instead of outer bounds
- preserve the dialog center after Electron adds native and invisible window chrome
- keep natural sizing with no minimum-height constraint

## Local verification
- `corepack yarn workspace dsh-plugin-desktop typecheck`
- `corepack yarn workspace dsh-plugin-desktop test`
- 82 test files passed; 810 tests passed, 4 skipped
- versions remain 2.0.3