### PR TITLE
fix(desktop): remove trailing blank line in desktop-port.ts

### DIFF
--- a/dsh-plugin-desktop/src/desktop-port.ts
+++ b/dsh-plugin-desktop/src/desktop-port.ts
@@ -5,4 +5,3 @@ export const DESKTOP_DEFAULT_WEB_PORT = 43_120
 
 /** Maximum number of sequential ports tried after a real bind collision. */
 export const DESKTOP_WEB_PORT_RETRY_LIMIT = 32
-


### PR DESCRIPTION
﻿## Summary

- remove the trailing blank line at the end of `desktop-port.ts`

## Problem

`desktop-port.ts` ends with an extra blank line (`\n\n` at EOF). This is a `git diff --check` violation: any fork that syncs to a commit at or after `808b350fb4` fails its CI `changes` job with `dsh-plugin-desktop/src/desktop-port.ts:8: new blank line at EOF.` The upstream CI does not catch it because it only checks incremental diffs.

## Fix

Remove the single trailing blank line so the file ends with one newline.

## Verification

- `git diff --check` — passed
- `corepack yarn workspace dsh-plugin-desktop typecheck` — passed
- fork CI (MyGO-Mujica/deepseek-harness-desktop @ 872b4309fa) — all 5 jobs passed (changes, check, desktop-windows, desktop-macos, upstream-command-windows)
