### PR TITLE
docs(contributing): fix stale friendly-links anchor in English guide

### DIFF
--- a/CONTRIBUTING.en.md
+++ b/CONTRIBUTING.en.md
@@ -8,7 +8,7 @@ Thank you for wanting to contribute to DSH Desktop. This is a community project 
 - Feature ideas and improvement suggestions are welcome as issues too.
 - Join the [community channels](README.en.md#community) (WeChat group, QQ group, Discord) and help other users.
 - Write tutorials or experience posts, or help improve and translate the documentation.
-- Suggest ecosystem projects for the [related links](README.en.md#friendly-links) section.
+- Suggest ecosystem projects for the [related links](README.en.md#related-links) section.
 
 ## Plugin authors: extend the ecosystem
 


### PR DESCRIPTION
## What

`CONTRIBUTING.en.md` links the *related links* bullet to `README.en.md#friendly-links`, but the English README heading is "Related Links" (`README.en.md:189`), so the anchor has never resolved — GitHub just lands the reader at the top of the page. The Chinese guide correctly links `README.md#友情链接` (`README.md:189`); this PR points the English link at `#related-links` to match the actual heading.

Found with a repository-wide markdown link/anchor audit (relative link targets + cross-file anchors). It is the only stale cross-file anchor in the repo: the other two findings from the audit resolve inside the pinned `deepseek-harness` submodule and are false positives without the submodule initialized.

## Verification

- `node --test scripts/bilingual-docs.test.mjs` — 0 fail
- `node scripts/verify-bilingual-docs.mjs` — 42 records / 84 documents consistent
- `node --test scripts/market-dependency-direction.test.mjs` — 0 fail
- `node scripts/verify-layout.mjs` — consistent (with `deepseek-harness` submodule initialized at the pinned commit)

Docs-only change; no runtime code touched.