### PR TITLE
fix(market): index the capped 1024Store listing and retry transient failures

### DIFF
--- a/dsh-community-market/src/adapters/dsh-1024store.ts
+++ b/dsh-community-market/src/adapters/dsh-1024store.ts
@@ -3,12 +3,14 @@ import type { CatalogQuery } from '../contracts/generated/catalog-query.js'
 import type { CatalogSnapshot } from '../contracts/generated/catalog-snapshot.js'
 import { parseCatalogSnapshot } from '../contracts/validate.js'
 import { normalizeRepositoryIdentity } from '../contracts/identity.js'
+import { CatalogNetworkError } from '../network/restricted-http.js'
 
 export const DSH_1024STORE_KEY = 'dsh-1024store'
 export const DSH_1024STORE_ENDPOINT = 'https://deepseek1024.com/api/v1/plugins'
 export const DSH_1024STORE_HOSTNAME = 'deepseek1024.com'
 export const DSH_1024STORE_PROVIDER_ID = 'com.deepseek1024.catalog'
 export const DSH_1024STORE_ADAPTER_ID = 'market.dsh-1024store-v1'
+const DSH_1024STORE_ORIGIN = new URL(DSH_1024STORE_ENDPOINT).origin
 
 export interface Dsh1024StoreRawItem {
   readonly id?: unknown
@@ -406,8 +408,12 @@ function buildCatalogScanSnapshots(
     ? new Date(generatedAt).toISOString()
     : undefined
   const providerRevision = plainText(meta.revision, 160, '') || undefined
-  const total = providerTotal(meta, raw.packages.length) ?? items.length
-  if (total !== items.length) throw new Error('1024Store scan did not reach the provider total')
+  // The frozen v1 endpoint caps `packages` at the first 500 entries while
+  // meta.total counts every matching installable plugin, so a scan may
+  // legitimately receive less than the provider total. The scan indexes what
+  // actually arrived instead of failing closed, and snapshot page totals
+  // report the normalized item count.
+  const total = items.length
   const fetchedAt = new Date().toISOString()
   const snapshots: CatalogSnapshot[] = []
   for (let offset = 0; offset < items.length; offset += 100) {
@@ -447,34 +453,100 @@ function buildCatalogScanSnapshots(
   return snapshots
 }
 
-export const dsh1024StoreAdapter: CatalogAdapter = {
-  adapterId: DSH_1024STORE_ADAPTER_ID,
-  async fetch(queryValue, context) {
-    const query = { ...queryValue, limit: Math.min(queryValue.limit ?? 50, 50) }
-    const expectedOrigin = new URL(DSH_1024STORE_ENDPOINT).origin
-    const response = await context.http.getJson(
-      DSH_1024STORE_ENDPOINT,
-      context.signal,
-      { allowedOrigin: expectedOrigin },
-    )
-    let finalOrigin: string
-    try { finalOrigin = new URL(response.finalUrl).origin }
-    catch { throw new Error('1024Store final URL is invalid') }
-    if (finalOrigin !== expectedOrigin) throw new Error('1024Store response changed the reviewed provider origin')
-    return buildSnapshot(response.value, context, response.finalUrl, query)
-  },
-  async scanCatalog(query, context) {
-    const expectedOrigin = new URL(DSH_1024STORE_ENDPOINT).origin
-    const response = await context.http.getJson(
-      DSH_1024STORE_ENDPOINT,
-      context.signal,
-      { allowedOrigin: expectedOrigin },
-    )
-    context.signal.throwIfAborted()
-    let finalOrigin: string
-    try { finalOrigin = new URL(response.finalUrl).origin }
-    catch { throw new Error('1024Store final URL is invalid') }
-    if (finalOrigin !== expectedOrigin) throw new Error('1024Store response changed the reviewed provider origin')
-    return buildCatalogScanSnapshots(response.value, context, response.finalUrl, query.locale)
-  },
+export interface Dsh1024StoreAdapterOptions {
+  /** Base delay for transient-failure retries; doubles per attempt with full jitter. */
+  readonly retryBaseDelayMs?: number
+  /** Injectable for tests; the default sleeps while staying abort-aware. */
+  readonly sleep?: (delayMs: number, signal: AbortSignal) => Promise<void>
+  /** Injectable full-jitter source for tests. */
+  readonly random?: () => number
 }
+
+const DEFAULT_RETRY_BASE_DELAY_MS = 600
+const MAX_1024STORE_ATTEMPTS = 3
+const RETRYABLE_NETWORK_CODES: ReadonlySet<string> = new Set(['timeout', 'http', 'response'])
+
+function defaultSleep(delayMs: number, signal: AbortSignal): Promise<void> {
+  signal.throwIfAborted()
+  if (delayMs === 0) return Promise.resolve()
+  return new Promise((resolve, reject) => {
+    const onAbort = () => {
+      clearTimeout(timer)
+      signal.removeEventListener('abort', onAbort)
+      reject(signal.reason ?? new DOMException('The operation was aborted', 'AbortError'))
+    }
+    const timer = setTimeout(() => {
+      signal.removeEventListener('abort', onAbort)
+      resolve()
+    }, delayMs)
+    signal.addEventListener('abort', onAbort, { once: true })
+    if (signal.aborted) onAbort()
+  })
+}
+
+function retryDelayMs(attempt: number, baseDelayMs: number, random: () => number): number {
+  return Math.floor(random() * baseDelayMs * 2 ** (attempt - 1))
+}
+
+async function getJsonWithRetry(
+  context: CatalogFetchContext,
+  sleep: (delayMs: number, signal: AbortSignal) => Promise<void>,
+  baseDelayMs: number,
+  random: () => number,
+): Promise<Awaited<ReturnType<CatalogFetchContext['http']['getJson']>>> {
+  let lastError: unknown
+  for (let attempt = 1; attempt <= MAX_1024STORE_ATTEMPTS; attempt += 1) {
+    try {
+      return await context.http.getJson(
+        DSH_1024STORE_ENDPOINT,
+        context.signal,
+        { allowedOrigin: DSH_1024STORE_ORIGIN },
+      )
+    } catch (cause) {
+      // Deterministic refusals (invalid URL, blocked address, origin-changing
+      // redirect) must surface immediately; only jitter-class transport
+      // failures are worth another attempt.
+      if (!(cause instanceof CatalogNetworkError) || !RETRYABLE_NETWORK_CODES.has(cause.code)) throw cause
+      lastError = cause
+      if (attempt < MAX_1024STORE_ATTEMPTS) {
+        await sleep(retryDelayMs(attempt, baseDelayMs, random), context.signal)
+      }
+    }
+  }
+  throw lastError
+}
+
+function assertReviewedOrigin(finalUrl: string): string {
+  let finalOrigin: string
+  try { finalOrigin = new URL(finalUrl).origin }
+  catch { throw new Error('1024Store final URL is invalid') }
+  if (finalOrigin !== DSH_1024STORE_ORIGIN) throw new Error('1024Store response changed the reviewed provider origin')
+  return finalUrl
+}
+
+export function createDsh1024StoreAdapter(options: Dsh1024StoreAdapterOptions = {}): CatalogAdapter {
+  const retryBaseDelayMs = options.retryBaseDelayMs ?? DEFAULT_RETRY_BASE_DELAY_MS
+  if (!Number.isSafeInteger(retryBaseDelayMs) || retryBaseDelayMs < 0) {
+    throw new TypeError('invalid 1024Store retry base delay')
+  }
+  const sleep = options.sleep ?? defaultSleep
+  const random = options.random ?? Math.random
+
+  return {
+    adapterId: DSH_1024STORE_ADAPTER_ID,
+    async fetch(queryValue, context) {
+      const query = { ...queryValue, limit: Math.min(queryValue.limit ?? 50, 50) }
+      const response = await getJsonWithRetry(context, sleep, retryBaseDelayMs, random)
+      const finalUrl = assertReviewedOrigin(response.finalUrl)
+      return buildSnapshot(response.value, context, finalUrl, query)
+    },
+    async scanCatalog(query, context) {
+      const response = await getJsonWithRetry(context, sleep, retryBaseDelayMs, random)
+      context.signal.throwIfAborted()
+      const finalUrl = assertReviewedOrigin(response.finalUrl)
+      return buildCatalogScanSnapshots(response.value, context, finalUrl, query.locale)
+    },
+  }
+}
+
+export const dsh1024StoreAdapter: CatalogAdapter = createDsh1024StoreAdapter()

--- a/dsh-community-market/tests/dsh-1024store-adapter.spec.ts
+++ b/dsh-community-market/tests/dsh-1024store-adapter.spec.ts
@@ -1,0 +1,173 @@
+import { describe, expect, it, vi } from 'vitest'
+import {
+  createDsh1024StoreAdapter,
+  DSH_1024STORE_ADAPTER_ID,
+  DSH_1024STORE_ENDPOINT,
+  DSH_1024STORE_KEY,
+  DSH_1024STORE_PROVIDER_ID,
+} from '../src/adapters/dsh-1024store.js'
+import { CatalogNetworkError } from '../src/network/restricted-http.js'
+import type { CatalogHttpClient, CatalogFetchContext, LocalSourceRecord } from '../src/contracts/index.js'
+
+const source: LocalSourceRecord = {
+  sourceRecordId: '018f1f77-a5c4-7b73-a9ae-0242ac120002',
+  registrationKind: 'built-in',
+  adapterId: DSH_1024STORE_ADAPTER_ID,
+  providerId: DSH_1024STORE_PROVIDER_ID,
+  builtInProviderKey: DSH_1024STORE_KEY,
+  enabled: true,
+  order: 0,
+}
+
+function rawItem(index: number): Record<string, unknown> {
+  const suffix = String(index).padStart(3, '0')
+  return {
+    id: `example/plugin-${suffix}`,
+    name: `Plugin ${suffix}`,
+    owner: 'example',
+    url: `https://github.com/example/plugin-${suffix}`,
+    category: index % 2 === 0 ? 'tools' : 'ui',
+    description: { en: `Plugin ${suffix} summary.`, zh: `插件 ${suffix} 摘要。` },
+    stars: 10 - index,
+    installMethods: [{
+      kind: 'npm',
+      spec: `dsh-plugin-${suffix}`,
+      verification: 'verified',
+      code: 'repository_backlink',
+      requiresBuildAllowance: false,
+      revision: `1.0.${index}`,
+    }],
+  }
+}
+
+function catalogResponse(packages: readonly unknown[], meta: Record<string, unknown> = {}): {
+  value: unknown
+  finalUrl: string
+} {
+  return {
+    value: { meta: { generatedAt: '2026-08-18T00:00:00.000Z', ...meta }, packages },
+    finalUrl: DSH_1024STORE_ENDPOINT,
+  }
+}
+
+function context(getJson: CatalogHttpClient['getJson']): CatalogFetchContext {
+  const controller = new AbortController()
+  return {
+    source,
+    signal: controller.signal,
+    http: { getJson },
+    media: { register: vi.fn(() => 'mktimg_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA') },
+  }
+}
+
+function noSleep(): (delayMs: number, signal: AbortSignal) => Promise<void> {
+  return vi.fn(async () => {})
+}
+
+function adapter() {
+  return createDsh1024StoreAdapter({
+    retryBaseDelayMs: 0,
+    sleep: noSleep(),
+    random: () => 0,
+  })
+}
+
+describe('1024Store adapter against the capped v1 listing', () => {
+  it('scans a partial catalog whose provider total exceeds the capped packages array', async () => {
+    const packages = [rawItem(0), rawItem(1)]
+    const getJson = vi.fn(async () => catalogResponse(packages, { total: 7 }))
+
+    const snapshots = await adapter().scanCatalog!({}, context(getJson))
+
+    const items = snapshots.flatMap(snapshot => snapshot.items)
+    expect(items).toHaveLength(2)
+    expect(snapshots.every(snapshot => snapshot.page.total === 2)).toBe(true)
+  })
+
+  it('tolerates a provider total below the received count by distrusting the metadata', async () => {
+    const getJson = vi.fn(async () => catalogResponse([rawItem(0), rawItem(1), rawItem(2)], { total: 2 }))
+
+    const snapshots = await adapter().scanCatalog!({}, context(getJson))
+
+    const items = snapshots.flatMap(snapshot => snapshot.items)
+    expect(items).toHaveLength(3)
+    expect(snapshots.every(snapshot => snapshot.page.total === 3)).toBe(true)
+    expect(getJson).toHaveBeenCalledOnce()
+  })
+
+  it('keeps advertising the provider total on complete fetch queries with locally bounded cursors', async () => {
+    const packages = [rawItem(0), rawItem(1), rawItem(2)]
+    const getJson = vi.fn(async () => catalogResponse(packages, { total: 4120 }))
+    const ctx = context(getJson)
+
+    const first = await adapter().fetch({ limit: 2 }, ctx)
+    expect(first.items).toHaveLength(2)
+    expect(first.page).toEqual({ total: 4120, nextCursor: '2' })
+
+    const second = await adapter().fetch({ limit: 2, cursor: '2' }, ctx)
+    expect(second.items).toHaveLength(1)
+    expect(second.page).toEqual({ total: 4120 })
+
+    const scoped = await adapter().fetch({ limit: 2, q: 'plugin' }, ctx)
+    expect(scoped.page.total).toBe(3)
+  })
+
+  it('retries transient transport failures and succeeds on a later attempt', async () => {
+    const ok = catalogResponse([rawItem(0)])
+    const getJson = vi.fn(async () => {
+      if (getJson.mock.calls.length === 1) throw new CatalogNetworkError('timeout')
+      return ok
+    })
+    const sleep = noSleep()
+
+    const snapshots = await createDsh1024StoreAdapter({
+      retryBaseDelayMs: 100,
+      sleep,
+      random: () => 1,
+    }).scanCatalog!({}, context(getJson))
+
+    expect(snapshots.flatMap(snapshot => snapshot.items)).toHaveLength(1)
+    expect(getJson).toHaveBeenCalledTimes(2)
+    expect(sleep).toHaveBeenCalledWith(100, expect.any(AbortSignal))
+  })
+
+  it('gives up after the attempt budget and surfaces the last transport failure', async () => {
+    const getJson = vi.fn(async () => {
+      throw new CatalogNetworkError('http')
+    })
+
+    await expect(adapter().fetch({}, context(getJson))).rejects.toThrow('catalog request failed: http')
+    expect(getJson).toHaveBeenCalledTimes(3)
+  })
+
+  it('does not retry deterministic refusals such as an origin-changing redirect', async () => {
+    const getJson = vi.fn(async () => {
+      throw new CatalogNetworkError('redirect')
+    })
+
+    await expect(adapter().fetch({}, context(getJson))).rejects.toThrow('catalog request failed: redirect')
+    expect(getJson).toHaveBeenCalledOnce()
+  })
+
+  it('propagates an abort raised while waiting between retries', async () => {
+    const getJson = vi.fn(async () => {
+      throw new CatalogNetworkError('timeout')
+    })
+    const sleep = vi.fn(async (_delayMs: number, signal: AbortSignal) => {
+      signal.throwIfAborted()
+      throw new Error('sleep must reject when the scan is aborted')
+    })
+
+    await expect(createDsh1024StoreAdapter({ sleep }).fetch({}, context(getJson)))
+      .rejects.toThrow()
+    expect(getJson).toHaveBeenCalledOnce()
+  })
+
+  it('still rejects duplicate item ids during a scan', async () => {
+    const packages = [rawItem(0), rawItem(0)]
+    const getJson = vi.fn(async () => catalogResponse(packages))
+
+    await expect(adapter().scanCatalog!({}, context(getJson)))
+      .rejects.toThrow('1024Store catalog contains duplicate item IDs')
+  })
+})

--- a/dsh-community-market/tests/market-runtime.spec.ts
+++ b/dsh-community-market/tests/market-runtime.spec.ts
@@ -375,7 +375,12 @@ describe('1024Store adapter', () => {
     expect(snapshot.page).toEqual({ nextCursor: '50', total: 7635 })
   })
 
-  it('fails a complete 1024Store scan when provider metadata says more items exist', async () => {
+  it('indexes the capped 1024Store listing when provider metadata says more items exist', async () => {
+    // The frozen v1 endpoint caps `packages` at the first 500 entries while
+    // meta.total counts every matching installable plugin, so truncation is
+    // the steady state, not a transient failure mode. The scan now indexes
+    // what arrived instead of failing the whole market; page totals report
+    // the normalized item count.
     const packages = Array.from({ length: 51 }, (_, index) => ({
       ...rawCatalog.packages[0]!,
       id: `anywhere-labs/plugin-${index}`,
@@ -389,10 +394,14 @@ describe('1024Store adapter', () => {
       })),
     }
 
-    await expect(dsh1024StoreAdapter.scanCatalog!(
+    const snapshots = await dsh1024StoreAdapter.scanCatalog!(
       { limit: 100 },
       { source: source(), signal: new AbortController().signal, http, media: { register: () => fixtureAssetRef } },
-    )).rejects.toThrow(/provider total/u)
+    )
+
+    const items = snapshots.flatMap(snapshot => snapshot.items)
+    expect(items).toHaveLength(51)
+    expect(snapshots.every(snapshot => snapshot.page.total === 51)).toBe(true)
   })
 
   it('keeps the reviewed 1024Store adapter page size fixed at 50', async () => {


### PR DESCRIPTION
Fixes #588.

## Why

The provider's frozen v1 `/api/v1/plugins` has **no pagination parameters** — its published API reference ([docs/api.md](https://github.com/imsai-sh/awesome-deepseek-harness-plugins/blob/main/docs/api.md)) states that `packages` contains *at most the first 500 entries after filtering and sorting*, while `meta.total` reports the number of matching installable plugins. Truncation is the steady state, not a transient failure:

- `scanCatalog` treated `meta.total !== items.length` as an incomplete scan and threw, so **every real response failed the scan and took the market route down** (the 502 in #588).
- Cursor pagination — the shape suggested in #588 — cannot be implemented against this endpoint, so the honest fix is to index what actually arrived.
- `restricted-http` has no retry, so a single jitter-class failure (timeout, 5xx, truncated body) also killed a scan with no second attempt.

One existing spec (`fails a complete 1024Store scan when provider metadata says more items exist`) pinned the fail-closed behavior deliberately. This PR reverses that one direction on purpose, with the upstream API reference quoted in the rewritten test: when the provider itself documents a 500-entry cap, failing closed rejects 100% of production responses. The opposite inconsistency (meta.total below the received count) keeps the existing distrust-the-metadata semantics, and `fetch` is unchanged (complete queries still advertise the provider total; cursors terminate at the local end).

## What users will see

The 1024Store market source loads again: the scan indexes the capped installable listing (up to 500 entries) instead of erroring the whole route, page totals reflect the normalized items served, and a transient network hiccup during a fetch or scan is retried up to 3 times with exponential backoff and full jitter instead of failing immediately. Deterministic refusals (blocked address, origin-changing redirect) still fail on the first attempt.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys
- [ ] **New top-level dependency** — none
- [x] **Default behavior change** — the 1024Store scan no longer fails on a provider-documented capped listing; it indexes the partial catalog and reports local page totals
- [ ] **None**

## Validation

- new `dsh-community-market/tests/dsh-1024store-adapter.spec.ts` — 8 tests: partial-scan acceptance (the #588 regression), undercount tolerance, provider-total advertisement with locally bounded cursors, retry-then-succeed, attempt-budget exhaustion, non-retryable refusal, abort during backoff, duplicate-id rejection
- market vitest — 282/282 across 20 files (includes the rewritten capped-listing spec case)
- desktop vitest — 812 passed / 4 skipped
- market + desktop `tsc` typecheck — clean (generated contract types current)
- root gates: bilingual-docs, market-dependency-direction, verify-layout — green