### PR TITLE
test(desktop): cover whitespace-only machine patches

### DIFF
--- a/dsh-plugin-desktop/tests/profile.spec.ts
+++ b/dsh-plugin-desktop/tests/profile.spec.ts
@@ -704,8 +704,8 @@ virtualStoreDirMaxLength: 60
     expect(() => readDesktopShellMode({ path })).toThrow('invalid settings document')
   })
 
-  it('treats an empty machine-wide patch file as no desktop patches', () => {
-    for (const content of ['', '# no machine-wide patches\n']) {
+  it('treats a semantically empty machine-wide patch file as no desktop patches', () => {
+    for (const content of ['', '  \r\n  \r\n', '# no machine-wide patches\n']) {
       const home = temporaryHome()
       writeFileSync(join(home, 'cordis.patch.yml'), content)
 


### PR DESCRIPTION
## Summary / 摘要

<!-- What changed and why? / 说明改了什么，以及为什么改。 -->

- 将机器级 patch 回归测试从 0 字节和仅注释 YAML 扩展到仅空白 YAML。
- 继续通过现有负向测试拒绝格式错误的 mapping。

历史故障机制已经复现：当前 `js-yaml` 对 0 字节内容返回 `undefined`，对仅空白和仅注释内容返回 `null`，三者都不能通过旧逻辑的 `Array.isArray(parsed)` 检查；显式 `[]` 才能通过。生产解析器修复 `695ca61e6f` 已经把 `undefined` 和 `null` 转为空 patch list，v2.0.2 源码标签也包含该修复。本 PR 不重复修改生产解析器，只补齐 whitespace-only 回归边界。

## Related Issues / 关联 Issue

Related to #289. 本 PR 不关闭 #289，因为尚未执行 v2.0.2 Windows 安装包启动复测。

<!-- Example: Fixes #123, Closes #456, or N/A / 例如：Fixes #123、Closes #456，或 N/A。 -->

## Type / 类型

- [ ] Bug fix / 问题修复
- [ ] Feature / 新功能
- [ ] Documentation / 文档
- [ ] Release or packaging / 发布或打包
- [x] Tests only / 仅测试
- [ ] Other / 其他

## Platforms / 影响平台

- [x] Windows installer / Windows 安装包
- [x] Windows portable ZIP / Windows 便携版 ZIP
- [ ] macOS Apple Silicon
- [ ] macOS Intel
- [ ] macOS Universal package / macOS 通用安装包
- [ ] Linux
- [ ] Not platform-specific / 与平台无关

## Verification / 验证

<!-- List commands actually run and any manual checks. Do not claim unrun checks passed. / 列出实际运行过的命令和人工验证。不要声称未运行的检查已经通过。 -->

- [ ] `corepack yarn check:layout`
- [ ] `corepack yarn typecheck`
- [ ] `corepack yarn test`
- [ ] `corepack yarn check`
- [ ] Platform package smoke / 平台打包或启动冒烟
- [ ] Manual test / 人工测试

实际执行命令：

```powershell
corepack yarn workspace dsh-plugin-desktop node -e "const yaml=require('js-yaml'); for(const [label,text] of [['zero-byte',''],['whitespace','  \r\n  \r\n'],['comment-only','# no patches\n'],['explicit-empty-list','[]\n'],['mapping','not: a list\n']]){const parsed=yaml.load(text); console.log(label+': value='+String(parsed)+', type='+(parsed===null?'null':typeof parsed)+', array='+Array.isArray(parsed))}"
corepack yarn workspace dsh-plugin-desktop vitest run tests/profile.spec.ts tests/package.spec.ts
corepack yarn workspace dsh-plugin-desktop typecheck
git diff --check upstream/master...HEAD
```
执行结果：
```powershell
zero-byte: value=undefined, type=undefined, array=false
whitespace: value=null, type=null, array=false
comment-only: value=null, type=null, array=false
explicit-empty-list: value=, type=object, array=true
mapping: value=[object Object], type=object, array=false
Test Files  2 passed (2)
Tests       66 passed (66)
Desktop workspace typecheck: exit code 0
git diff --check: exit code 0
```

模板中的根 `typecheck`、根 `test`、根 `check`、平台 package smoke 和人工安装包复测均未作为本 PR 的通过证据。

## Release Notes / 发布说明

<!-- User-visible changes, migration notes, new release assets, or N/A. / 用户可见变化、迁移说明、新增发布资产，或 N/A。 -->

N/A。仅增加测试覆盖，没有新的生产修复、迁移要求或发布资产。
