### PR TITLE
fix(windows): preserve Unicode workspace picker paths

### DIFF
--- a/dsh-plugin-desktop/src/electron-runtime.ts
+++ b/dsh-plugin-desktop/src/electron-runtime.ts
@@ -58,6 +58,7 @@ import {
   type WindowsVolumeQuery,
 } from './windows-volume-diagnostics.ts'
 import { ElectronWorkspaceAdmission } from './workspace-admission.ts'
+import { pickWindowsUnicodeDirectory } from './windows-unicode-directory-picker.ts'
 import { ProfileCreateWindow, type ProfileCreateWindowOptions } from './profile-create-window.ts'
 import { windowsBuildNumber } from './window-material.ts'
 import { desktopNativeCopy } from './native-dialog-copy.ts'
@@ -142,6 +143,7 @@ export class ElectronDesktopRuntime implements DesktopRuntime {
       showOpenDialog: async options => this.generation === undefined
         ? await dialog.showOpenDialog(options)
         : await this.generation.showOpenDialog(options),
+      pickWindowsUnicodeDirectory: async title => await pickWindowsUnicodeDirectory(title),
       showMessageBox: async options => await this.showDesktopMessageBox(options),
       logError: message => { this.logError(message) },
       ...(workspaceVolumeQuery === undefined ? {} : { volumeQuery: workspaceVolumeQuery }),

--- a/dsh-plugin-desktop/src/windows-unicode-directory-picker.ts
+++ b/dsh-plugin-desktop/src/windows-unicode-directory-picker.ts
@@ -1,0 +1,109 @@
+/** Unicode-safe Windows directory picker isolated from Electron's path conversion. */
+
+import { execFile } from 'node:child_process'
+import { Buffer } from 'node:buffer'
+import { desktopWindowsPwshPath } from './windows-pwsh-sandbox.ts'
+
+const RUN_AS_NODE = 'ELECTRON_RUN_AS_NODE'
+const DIALOG_TITLE = 'DSH_DIALOG_TITLE'
+
+const PICK_DIRECTORY_SCRIPT = String.raw`
+Add-Type -AssemblyName System.Windows.Forms
+$dialog = [System.Windows.Forms.FolderBrowserDialog]::new()
+$dialog.Description = $env:DSH_DIALOG_TITLE
+$dialog.ShowNewFolderButton = $true
+$dialog.AutoUpgradeEnabled = $true
+if ($dialog.ShowDialog() -eq [System.Windows.Forms.DialogResult]::OK) {
+  $bytes = [System.Text.Encoding]::Unicode.GetBytes($dialog.SelectedPath)
+  [Console]::Out.Write([System.Convert]::ToBase64String($bytes))
+}
+`
+
+interface PickerProcessOptions {
+  readonly env: NodeJS.ProcessEnv
+  readonly windowsHide: boolean
+}
+
+interface PickerProcessResult {
+  readonly stdout: string
+  readonly stderr: string
+}
+
+type RunPickerProcess = (
+  executable: string,
+  args: readonly string[],
+  options: PickerProcessOptions,
+) => Promise<PickerProcessResult>
+
+function defaultPowerShellPath(): string {
+  const executable = desktopWindowsPwshPath(process.env, 'win32')
+  if (executable === undefined) throw new Error('Windows Unicode directory picker could not find PowerShell')
+  return executable
+}
+
+async function runPickerProcess(
+  executable: string,
+  args: readonly string[],
+  options: PickerProcessOptions,
+): Promise<PickerProcessResult> {
+  return await new Promise((resolve, reject) => {
+    execFile(executable, [...args], {
+      ...options,
+      encoding: 'utf8',
+      maxBuffer: 1024 * 1024,
+    }, (error, stdout, stderr) => {
+      if (error !== null) {
+        const detail = stderr.trim()
+        reject(new Error(`Windows Unicode directory picker failed: ${detail === '' ? error.message : detail}`))
+        return
+      }
+      resolve({ stdout, stderr })
+    })
+  })
+}
+
+/** Remove Electron Node mode and pass the localized title through the Unicode Windows environment block. */
+export function windowsUnicodePickerEnvironment(
+  source: NodeJS.ProcessEnv,
+  title: string,
+): NodeJS.ProcessEnv {
+  const env = { ...source }
+  for (const key of Object.keys(env)) {
+    if (key.toUpperCase() === RUN_AS_NODE) delete env[key]
+  }
+  env[DIALOG_TITLE] = title
+  return env
+}
+
+/**
+ * Open a WinForms folder chooser and return its path through an ASCII-only carrier.
+ * PowerShell encodes the UTF-16 path as Base64 so the active console code page is irrelevant.
+ */
+export async function pickWindowsUnicodeDirectory(
+  title: string,
+  executable: string = defaultPowerShellPath(),
+  run: RunPickerProcess = runPickerProcess,
+): Promise<string | null> {
+  const encodedCommand = Buffer.from(PICK_DIRECTORY_SCRIPT, 'utf16le').toString('base64')
+  const result = await run(executable, [
+    '-NoLogo',
+    '-NoProfile',
+    '-NonInteractive',
+    '-STA',
+    '-EncodedCommand',
+    encodedCommand,
+  ], {
+    env: windowsUnicodePickerEnvironment(process.env, title),
+    windowsHide: true,
+  })
+  const encodedPath = result.stdout.trim()
+  if (encodedPath === '') return null
+  if (!/^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$/u.test(encodedPath)) {
+    throw new Error('Windows Unicode directory picker returned an invalid Base64 path')
+  }
+  const bytes = Buffer.from(encodedPath, 'base64')
+  if (bytes.length % 2 !== 0) throw new Error('Windows Unicode directory picker returned an invalid UTF-16 path')
+  const path = bytes.toString('utf16le')
+  if (path.length === 0) throw new Error('Windows Unicode directory picker returned an empty path')
+  return path
+}

--- a/dsh-plugin-desktop/src/workspace-admission.ts
+++ b/dsh-plugin-desktop/src/workspace-admission.ts
@@ -4,6 +4,7 @@ import type {
   MessageBoxOptions,
   MessageBoxReturnValue,
 } from 'electron'
+import { existsSync } from 'node:fs'
 import type { DesktopLocale, DesktopPlatform } from './runtime.ts'
 import {
   evaluateWindowsWorkspaceVolume,
@@ -16,6 +17,8 @@ export interface ElectronWorkspaceAdmissionOptions {
   readonly canPickDirectory: boolean
   readonly locale: () => DesktopLocale
   readonly showOpenDialog: (options: OpenDialogOptions) => Promise<OpenDialogReturnValue>
+  readonly pickWindowsUnicodeDirectory?: (title: string) => Promise<string | null>
+  readonly pathExists?: (path: string) => boolean
   readonly showMessageBox: (options: MessageBoxOptions) => Promise<MessageBoxReturnValue>
   readonly logError: (message: string) => void
   readonly volumeQuery?: WindowsVolumeQuery
@@ -24,6 +27,7 @@ export interface ElectronWorkspaceAdmissionOptions {
 /** Own native workspace selection and every Desktop policy decision before persistence. */
 export class ElectronWorkspaceAdmission {
   private pickTask: Promise<string | null> | undefined
+  private preferUnicodeWindowsPicker = false
 
   constructor(private readonly options: ElectronWorkspaceAdmissionOptions) {}
 
@@ -88,10 +92,26 @@ export class ElectronWorkspaceAdmission {
   }
 
   private async showDirectoryPicker(): Promise<string | null> {
+    const title = this.options.locale() === 'zh' ? '选择工作区目录' : 'Select Workspace Directory'
+    if (this.preferUnicodeWindowsPicker && this.options.pickWindowsUnicodeDirectory !== undefined) {
+      return await this.options.pickWindowsUnicodeDirectory(title)
+    }
     const result = await this.options.showOpenDialog({
-      title: this.options.locale() === 'zh' ? '选择工作区目录' : 'Select Workspace Directory',
+      title,
       properties: ['openDirectory', 'dontAddToRecent'],
     })
-    return result.canceled ? null : result.filePaths[0] ?? null
+    const path = result.canceled ? null : result.filePaths[0] ?? null
+    if (this.options.platform !== 'win32'
+      || path === null
+      || this.options.pickWindowsUnicodeDirectory === undefined
+      || !/[^\u0000-\u007f]/u.test(path)
+      || (this.options.pathExists ?? existsSync)(path)) {
+      return path
+    }
+
+    this.options.logError('dsh-plugin-desktop: native workspace picker returned an inaccessible non-ASCII path; retrying with the UTF-16 Windows picker')
+    const fallback = await this.options.pickWindowsUnicodeDirectory(title)
+    this.preferUnicodeWindowsPicker = true
+    return fallback
   }
 }

--- a/dsh-plugin-desktop/tests/windows-unicode-directory-picker.spec.ts
+++ b/dsh-plugin-desktop/tests/windows-unicode-directory-picker.spec.ts
@@ -1,0 +1,72 @@
+import { Buffer } from 'node:buffer'
+import { describe, expect, it, vi } from 'vitest'
+import {
+  pickWindowsUnicodeDirectory,
+  windowsUnicodePickerEnvironment,
+} from '../src/windows-unicode-directory-picker.ts'
+
+describe('Windows Unicode directory picker', () => {
+  it('removes inherited Electron Node mode and preserves the Unicode dialog title', () => {
+    const environment = windowsUnicodePickerEnvironment({
+      Path: 'C:\\Windows',
+      electron_run_as_node: 'inherited',
+    }, '选择工作区目录')
+
+    expect(environment).toMatchObject({
+      Path: 'C:\\Windows',
+      DSH_DIALOG_TITLE: '选择工作区目录',
+    })
+    expect(environment).not.toHaveProperty('electron_run_as_node')
+    expect(environment).not.toHaveProperty('ELECTRON_RUN_AS_NODE')
+  })
+
+  it('preserves a Chinese path through the UTF-16LE Base64 carrier', async () => {
+    const path = 'D:\\测试\\迅雷下载'
+    let captured: {
+      executable: string
+      args: readonly string[]
+      env: NodeJS.ProcessEnv
+      windowsHide: boolean
+    } | undefined
+    const run = vi.fn(async (executable, args, options) => {
+      captured = { executable, args, ...options }
+      return {
+        stdout: Buffer.from(path, 'utf16le').toString('base64'),
+        stderr: '',
+      }
+    })
+
+    await expect(pickWindowsUnicodeDirectory(
+      '选择工作区目录',
+      'C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe',
+      run,
+    )).resolves.toBe(path)
+    expect(captured).toMatchObject({
+      executable: 'C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe',
+      args: [
+        '-NoLogo',
+        '-NoProfile',
+        '-NonInteractive',
+        '-STA',
+        '-EncodedCommand',
+        expect.any(String),
+      ],
+      env: { DSH_DIALOG_TITLE: '选择工作区目录' },
+      windowsHide: true,
+    })
+  })
+
+  it('maps cancellation onto null and rejects malformed output', async () => {
+    await expect(pickWindowsUnicodeDirectory(
+      'Select Workspace Directory',
+      'powershell.exe',
+      async () => ({ stdout: '', stderr: '' }),
+    )).resolves.toBeNull()
+
+    await expect(pickWindowsUnicodeDirectory(
+      'Select Workspace Directory',
+      'powershell.exe',
+      async () => ({ stdout: 'not base64!', stderr: '' }),
+    )).rejects.toThrow('invalid Base64 path')
+  })
+})

--- a/dsh-plugin-desktop/tests/workspace-admission.spec.ts
+++ b/dsh-plugin-desktop/tests/workspace-admission.spec.ts
@@ -49,6 +49,39 @@ describe('Electron workspace admission', () => {
     expect(showOpenDialog).not.toHaveBeenCalled()
   })
 
+  it('retries an inaccessible non-ASCII Windows result through the UTF-16 picker and keeps using it', async () => {
+    const showOpenDialog = vi.fn(async () => ({
+      canceled: false,
+      filePaths: ['D:\\Ѹ������'],
+    }))
+    const pickWindowsUnicodeDirectory = vi.fn(async () => 'D:\\迅雷下载')
+    const { admission: subject, options } = admission({
+      locale: () => 'zh',
+      showOpenDialog,
+      pickWindowsUnicodeDirectory,
+      pathExists: () => false,
+    })
+
+    await expect(subject.pickDirectory()).resolves.toBe('D:\\迅雷下载')
+    await expect(subject.pickDirectory()).resolves.toBe('D:\\迅雷下载')
+    expect(showOpenDialog).toHaveBeenCalledOnce()
+    expect(pickWindowsUnicodeDirectory).toHaveBeenCalledTimes(2)
+    expect(pickWindowsUnicodeDirectory).toHaveBeenCalledWith('选择工作区目录')
+    expect(options.logError).toHaveBeenCalledWith(expect.stringContaining('inaccessible non-ASCII path'))
+  })
+
+  it('keeps an existing Unicode path returned by Electron without opening the fallback picker', async () => {
+    const pickWindowsUnicodeDirectory = vi.fn(async () => 'D:\\其他目录')
+    const { admission: subject } = admission({
+      showOpenDialog: vi.fn(async () => ({ canceled: false, filePaths: ['D:\\迅雷下载'] })),
+      pickWindowsUnicodeDirectory,
+      pathExists: path => path === 'D:\\迅雷下载',
+    })
+
+    await expect(subject.pickDirectory()).resolves.toBe('D:\\迅雷下载')
+    expect(pickWindowsUnicodeDirectory).not.toHaveBeenCalled()
+  })
+
   it('allows a fixed NTFS workspace without prompting or logging', async () => {
     const { admission: subject, options } = admission()
 


### PR DESCRIPTION
Fixes #522.

## Summary

- keep Electron `dialog.showOpenDialog` as the normal Windows workspace picker
- detect the affected boundary when Electron returns a non-ASCII path that does not exist
- retry through an isolated PowerShell/WinForms folder picker
- carry the selected path as UTF-16LE Base64 so the active Windows console code page cannot corrupt it
- keep using the Unicode-safe picker for later selections in the same Desktop runtime

No upstream submodule files are changed, and the fix does not attempt to guess or reverse mojibake.

## Flow

```mermaid
flowchart LR
  Electron[Electron folder picker] --> Check{Selected path exists?}
  Check -->|yes| Workspace[Workspace admission]
  Check -->|no, non-ASCII| Fallback[PowerShell / WinForms picker]
  Fallback --> Carrier[UTF-16LE Base64 carrier]
  Carrier --> Workspace
```

## Reproduction evidence

The screenshots from #522 show `迅雷下载` becoming `Ѹ������` before workspace `realpath` and then failing with `ENOENT`:

![Windows folder picker selecting the Chinese directory](https://github.com/user-attachments/assets/2756a199-abec-463a-a58d-25dcdf9d06f3)

![Workspace create failure with the corrupted path](https://github.com/user-attachments/assets/269ed0ca-1dc8-45b6-a60b-f0862f8de8a3)

The fallback was manually verified on Windows with both PowerShell 7 and the built-in Windows PowerShell 5.1. Both returned the exact path:

```text
C:\测试\迅雷下载
```

## Verification

- `corepack yarn workspace dsh-plugin-desktop test tests/workspace-admission.spec.ts tests/windows-unicode-directory-picker.spec.ts tests/electron-runtime.spec.ts` — 72 passed
- `corepack yarn workspace dsh-plugin-desktop typecheck` — passed
- `corepack yarn workspace dsh-plugin-desktop build` — passed
- `corepack yarn workspace dsh-plugin-desktop verify:closure` — 201-node runtime graph passed
- manual Unicode selection with PowerShell 7 — passed
- manual Unicode selection with Windows PowerShell 5.1 — passed

A local full-suite run completed with 777 passed and 9 skipped. Seven existing symlink-fixture cases could not run because this Windows session lacks the `CreateSymbolicLink` privilege; the focused and Electron runtime suites pass.
