### PR TITLE
fix(desktop): keep Windows caption draggable after scrolling

### DIFF
--- a/dsh-plugin-desktop/src/client/AdvancedFrame.tsx
+++ b/dsh-plugin-desktop/src/client/AdvancedFrame.tsx
@@ -114,7 +114,6 @@ export function DesktopOwnedFrame({ layout, mode, platform, renderSlot, useSessi
       style={{ gridTemplateColumns: `${columns.sidebar}px minmax(0, 1fr) ${columns.details}px` }}
     >
       {mode === 'advanced' && platform === 'darwin' && <div className="dshDesktopMacCaptionRow" aria-hidden="true" />}
-      {mode === 'advanced' && platform === 'win32' && <div className="dshDesktopWindowsCaptionRow" aria-hidden="true" />}
       <aside className="dshDesktopSidebarSurface">
         <div className="dshDesktopUpstreamSidebar">
           {renderSlot('sidebar', { collapsed, width: sidebarOwnerWidth })}
@@ -122,6 +121,8 @@ export function DesktopOwnedFrame({ layout, mode, platform, renderSlot, useSessi
       </aside>
       <main className="dshDesktopConversationSurface">{renderSlot('conversation', {})}</main>
       <aside className="dshDesktopDetailsSurface">{renderSlot('details', {})}</aside>
+      {/* Electron resolves app regions in DOM order; Desktop overlays must remain later. */}
+      {mode === 'advanced' && platform === 'win32' && <div className="dshDesktopWindowsCaptionRow" aria-hidden="true" />}
       <div className="dshDesktopOverlay" data-shell-overlay>
         {renderSlot('shell.overlay', {})}
       </div>

--- a/dsh-plugin-desktop/tests/client-environment.spec.ts
+++ b/dsh-plugin-desktop/tests/client-environment.spec.ts
@@ -1,3 +1,4 @@
+import { readFileSync } from 'node:fs'
 import { describe, expect, it, vi } from 'vitest'
 import type { ClientContext } from '@deepseek-ai/dsh-client-runtime/client'
 import { apply } from '../src/client/index.ts'
@@ -61,6 +62,19 @@ describe('desktop client environment', () => {
 })
 
 describe('advanced desktop layout', () => {
+  it('orders the Windows drag region after scrollable content and before overlays', () => {
+    const frame = readFileSync(new URL('../src/client/AdvancedFrame.tsx', import.meta.url), 'utf8')
+    const conversation = frame.indexOf('className="dshDesktopConversationSurface"')
+    const details = frame.indexOf('className="dshDesktopDetailsSurface"')
+    const caption = frame.indexOf('className="dshDesktopWindowsCaptionRow"')
+    const overlay = frame.indexOf('className="dshDesktopOverlay"')
+
+    expect([conversation, details, caption, overlay]).not.toContain(-1)
+    expect(caption).toBeGreaterThan(conversation)
+    expect(caption).toBeGreaterThan(details)
+    expect(caption).toBeLessThan(overlay)
+  })
+
   it('owns native caption geometry with one fixed macOS drag strip above page content', () => {
     expect(ADVANCED_MACOS_CONTENT_INSET).toBe(20)
     expect(ADVANCED_MACOS_DRAG_REGION_HEIGHT).toBe(32)


### PR DESCRIPTION
## Summary / 摘要

### English

- Move the enhanced-mode Windows caption drag region after the scrollable conversation and details surfaces. This prevents their later `no-drag` descendants from overriding the caption when Electron collects app regions in DOM order.
- Keep the caption before Desktop overlays and resize handles, preserving modal, overlay, resize, and native caption-control interaction priority.
- Add a regression contract for the required order: `conversation/details < Windows caption < overlay`.

### 中文

- 将增强模式的 Windows caption 拖动区域移到可滚动的会话区和详情区之后，防止 Electron 按 DOM 顺序收集 app region 时，后出现的 `no-drag` 后代覆盖 caption。
- caption 仍位于 Desktop overlay 和 resize handle 之前，保留弹窗、覆盖层、缩放区域和原生标题栏按钮的交互优先级。
- 增加 DOM 顺序回归约束：`conversation/details < Windows caption < overlay`。

## Related Issues / 关联 Issue

Fixes #495

Closes #474

Supersedes #505, which has the same code change but currently conflicts with `master`; this PR adds exact native reproduction, mode controls, and the merged #474 scope.

本 PR 以 #495 为主，并合并处理 #474 中“长会话、多轮推理后上下文仍能滚动，但窗口不能移动”的同一症状。#474 另一条评论提到“页面本身无法滚动，只能按 Tab”，该现象不能由本根因解释；若仍可复现，应另建 Issue 跟踪。

本 PR 取代已有但与 `master` 冲突的 #505，并补充了精确原生复现、模式对照和 #474 的合并范围说明。

## Type / 类型

- [x] Bug fix / 问题修复
- [ ] Feature / 新功能
- [ ] Documentation / 文档
- [ ] Release or packaging / 发布或打包
- [ ] Tests only / 仅测试
- [ ] Other / 其他

## Platforms / 影响平台

- [x] Windows installer / Windows 安装包
- [x] Windows portable ZIP / Windows 便携版 ZIP
- [ ] macOS Apple Silicon
- [ ] macOS Intel
- [ ] macOS Universal package / macOS 通用安装包
- [ ] Linux
- [ ] Not platform-specific / 与平台无关

## Exact Reproduction / 精确复现

### Environment / 环境

- Windows 11 Pro x64, build 26200
- Electron 43.4.0
- Window / 窗口：1280 x 840, DPR 1
- Enhanced mode / 增强模式
- Real long session / 真实长会话：2 rounds, 16 steps, about 427K input tokens / 2 轮、16 步、约 42.7 万输入 tokens
- Native probe / 原生探针：Windows cursor events + `GetWindowRect`

### Steps / 步骤

1. Open the real long session in enhanced mode. / 在增强模式中打开上述真实长会话。
2. Set the conversation scroller to `scrollTop=0`. / 将会话滚动体设为 `scrollTop=0`。
3. Reset the window to screen position `(320,96)`. / 将窗口恢复到屏幕坐标 `(320,96)`。
4. Drag natively from client point `(900,16)` by requested delta `(120,80)`, then compare `GetWindowRect`. / 从客户区坐标 `(900,16)` 原生拖动 `(120,80)`，比较拖动前后的 `GetWindowRect`。
5. Scroll the same conversation to the bottom and repeat from the same window position and client point. / 将同一会话滚动到底部，再从相同窗口位置和客户区坐标重复测试。

### Result / 结果

| State / 状态 | `scrollTop` | Actual window delta / 窗口实际位移 |
|---|---:|---:|
| Baseline before scroll / 修复前、滚动前 | 0 | `(110,73)` |
| Baseline after scroll / 修复前、滚动后 | 2798 | `(0,0)` |
| Fixed before scroll / 修复后、滚动前 | 0 | `(110,73)` |
| Fixed after scroll / 修复后、滚动后 | 2760 | `(110,73)` |
| Compatibility control / 兼容模式对照 | 2802 | `(110,73)` |
| Extended-window control / 扩展窗口对照 | 2803 | `(110,73)` |

After scrolling, a baseline horizontal scan moved only at `x=320`; `x=450,600,750,900,1050` all returned `(0,0)`. With the fix, all six sampled points moved `(55,37)`.

滚动到底部后，修复前的横向扫描仅 `x=320` 能移动窗口，`x=450,600,750,900,1050` 均为 `(0,0)`；修复后六个采样点均移动 `(55,37)`。

![#495 marked failing drag area / #495 标注的失效拖动区域](https://github.com/user-attachments/assets/6a55a524-0205-4172-85a4-8234398279ce)

## Root Cause / 根因

Electron/Chromium resolves overlapping `-webkit-app-region` declarations in DOM collection order. The enhanced-mode Windows caption was emitted before the scrollable conversation and details surfaces. Their later `no-drag` descendants could therefore override the earlier caption drag region after scrolling, even though visual clipping and `z-index` suggested that the caption was on top.

Electron/Chromium 按 DOM 收集顺序解析重叠的 `-webkit-app-region`。增强模式的 Windows caption 原本位于可滚动会话区和详情区之前，因此滚动内容中后出现的 `no-drag` 后代会覆盖较早的 caption 拖动区域；视觉裁剪和 `z-index` 看似仍让 caption 位于上层，但不能改变 app region 的命中顺序。

The original direct-child order was:

```text
macOS caption / Windows caption
sidebar
conversation
details
Desktop overlay
resize handles
```

The fixed order is:

```text
macOS caption
sidebar
conversation
details
Windows caption
Desktop overlay
resize handles
```

## Mode Scope / 模式范围

- The bug is specific to enhanced mode on Windows, which uses the internal 32 px caption in `AdvancedFrame`. / 问题仅影响 Windows 增强模式，该模式使用 `AdvancedFrame` 内部的 32 px caption。
- Compatibility mode and the extended window use an independent 36 px Desktop frame and do not traverse this caption node; both passed native drag controls after scrolling. / 兼容模式和扩展窗口使用独立的 36 px Desktop frame，不经过该 caption 节点；两者在滚动后均通过原生拖动对照。
- The macOS caption path is unchanged. / macOS caption 路径未改动。

## Verification / 验证

- [x] `corepack yarn workspace dsh-plugin-desktop vitest run tests/client-environment.spec.ts` (20 passed)
- [x] `corepack yarn typecheck`
- [x] Real Windows/Electron enhanced-mode reproduction before the change / 修复前真实 Windows/Electron 增强模式复现
- [x] Real Windows/Electron enhanced-mode verification after the change / 修复后真实 Windows/Electron 增强模式验证
- [x] Compatibility and extended-window native-drag controls / 兼容模式与扩展窗口原生拖动对照
- [x] `git diff --check`
- [x] Separately run / 单独补跑：`verify:closure`, `verify:cli`, `verify:loader`, `verify:profile`, `verify:licenses`, `verify:operations`
- [ ] `corepack yarn check` clean exit / 完整命令零退出

`corepack yarn check` passed bilingual docs, architecture, layout, Fabric, Market (273/273), Desktop build, and Desktop typecheck. Desktop Vitest reported 773 passed, 9 skipped, and 7 failures because this Windows account cannot create test symlinks (`EPERM`). All seven failures occur at existing fixture `symlinkSync` calls and are unrelated to this two-file change. The six gates skipped by the early exit were run separately and passed.

`corepack yarn check` 已通过双语文档、架构、layout、Fabric、Market（273/273）、Desktop build 和 Desktop typecheck。Desktop Vitest 结果为 773 passed、9 skipped、7 failed；7 项失败均因当前 Windows 账户无权创建测试符号链接（`EPERM`），发生在既有 fixture 的 `symlinkSync`，与本次两个文件的改动无关。因提前退出而跳过的 6 个 gate 已单独补跑并通过。

## Risk / 风险

- This reorders one enhanced-mode Windows node; caption geometry, native-control inset, styles, and services are unchanged. / 仅调整一个增强模式 Windows 节点的顺序；caption 几何、原生按钮预留宽度、样式和服务均未改变。
- Modal and Desktop-owned overlay `no-drag` behavior remains later in DOM order. / modal 和 Desktop 自有 overlay 的 `no-drag` 仍位于其后，交互优先级不变。
- Compatibility mode, extended-window mode, and macOS layout are unchanged. / 兼容模式、扩展窗口和 macOS 布局均未修改。

## Release Notes / 发布说明

The Windows title-bar drag area remains draggable after scrolling a long conversation in enhanced mode.

Windows 增强模式下，滚动长会话后标题栏区域仍可正常拖动窗口。
