### PR TITLE
fix(market): enable direct provider search for dshfind and unblock 1024Store search

### DIFF
--- a/.agents/notes/proposed/architecture/2026-08-26-market-server-side-pagination-architecture.zh.md
+++ b/.agents/notes/proposed/architecture/2026-08-26-market-server-side-pagination-architecture.zh.md
@@ -1,0 +1,96 @@
+# 社区插件市场检索与分页架构问题全面解析及真分页重构方案
+
+状态：**架构提案与演进 RFC（当前已完成最小搜索故障修复）**
+
+- 适用模块：`dsh-community-market` / `dsh-plugin-desktop`
+- 关联问题：Issue #558 / PR #567（Commit `9231ba14564`）/ 社区市场搜索失效
+- 编写时间：2026-08-26
+- 权威位置：`.agents/notes/proposed/architecture/2026-08-26-market-server-side-pagination-architecture.zh.md`
+
+---
+
+## 摘要
+
+在 DSH Desktop 社区插件市场中，用户在搜索关键词（如 `appshot`）时无法获取结果，接口无响应或展示为空，而直接调用提供方（DSH 1024Store 与 dshfind）的原始接口均能正常返回结果。
+
+本文记录了排查得出的真实故障原因、已实施的最小故障修复，以及后续分页 v2 的架构演进设计。
+
+---
+
+# 第一部分：从现象到本质架构问题的全面解析
+
+## 1. 故障现象与表现
+
+1. **关键词搜索无结果**：
+   在市场搜索框输入 `appshot` 等关键字，界面发起了 `/api/community-market/catalog?sourceRecordId=...&q=appshot&limit=50&locale=zh` 请求，但客户端长期处于 Loading、超时或直接渲染为“未找到插件”空列表。
+2. **远端接口与客户端表现冲突**：
+   直接访问 1024Store 搜索接口（`https://deepseek1024.com/api/v1/plugins?q=appshot`）或 dshfind 桌面市场接口（`https://api.dshfind.com/market/v1/plugins?q=appshot`），两边均能在数十毫秒内正确返回包含 `TaurusWood/dsh-plugin-appshot` 的数据。
+
+---
+
+## 2. 深入排查事实与证据链
+
+通过分析 Node 层代码（`routes.ts`、`service.ts`、各 Adapter）和实际网络抓包，定位到以下关键事实：
+
+### 事实 1（dshfind 源）：搜索未下推到其市场标准端点
+* **事实核验**：Host 发送请求时固定携带 `User-Agent: dsh-community-market/0.1`。在该 UA 下，dshfind 的 `GET /v1/plugins` 接口仅返回其运营精选的前 200 条数据（2 页），且不支持 `q` 服务端过滤。
+* **根因**：dshfind 专为 DSH 桌面端提供了标准市场端点 `https://api.dshfind.com/market/v1/plugins`（支持 `q` 关键词下推并返回单页快照）。但此前代码未将 `q` 请求路由到该端点，导致搜索只能在本地的 200 条精选条目中做内存匹配，因而搜不到全库中的 `appshot`。
+
+### 事实 2（1024Store 源）：搜索成功后被全量扫描逻辑强行阻塞
+* **代码缺陷**：查看修复前的 [`routes.ts`](file:///Users/wuyukun/playground/deepseek-harness-desktop/dsh-community-market/src/host/routes.ts)：
+  ```typescript
+  if (q !== undefined && selectedSource?.adapterId === DSH_1024STORE_ADAPTER_ID) {
+    results = await service.fetch(query, signal, scope) // ① 成功从远端拿到 1 条 appshot 结果
+    let index: CatalogFullIndex | undefined
+    try {
+      index = await service.scanCatalog(signal, ...)    // ② 致命问题：又去全量下载 6.7MB 完整 catalog
+    } catch {
+      index = undefined
+    }
+    const response = buildCatalogResponse(index, query, scope, results)
+    sendJson(res, 200, response)                        // ③ 必须等 ② 结束才返回给前端
+    return
+  }
+  ```
+* 1024Store 全量数据包高达 6.7 MB+。搜索请求在拿到结果后，因同步等待全量 `scanCatalog` 完成，在网络波动或并发限制下极易超时，导致前端表现为“发起了请求但没有数据返回”。
+
+---
+
+# 第二部分：已实施的最小修复与后续演进设计
+
+## 1. 最小修复实施（已完成）
+
+为确保在**不破坏现有公开 v1 合同、不改变 Installable 全量索引生命周期、不引入非受控大重构**的前提下立即恢复搜索功能，已完成以下最小修改：
+
+```mermaid
+flowchart LR
+    subgraph FastSearchPath [最小修复后的搜索路径]
+        ClientReq[客户端搜索: q=appshot] --> HostRoute[host/routes.ts]
+        HostRoute --> ServiceFetch[service.fetch]
+        
+        ServiceFetch -->|1024Store| S1["GET /api/v1/plugins?q=appshot"]
+        ServiceFetch -->|dshfind| S2["GET /market/v1/plugins?q=appshot"]
+        
+        S1 --> Snap[标准化 CatalogSnapshot]
+        S2 --> Snap
+        Snap --> Immediate[立即返回 200 响应<br/>(耗时 < 100ms，彻底移除 scanCatalog 阻塞)]
+    end
+```
+
+1. **1024Store 搜索解阻塞**：在 [`routes.ts`](file:///Users/wuyukun/playground/deepseek-harness-desktop/dsh-community-market/src/host/routes.ts) 中移除搜索分支多余的 `await service.scanCatalog()` 调用，拿到搜索结果后立即返回前端。
+2. **dshfind 搜索端点接入**：在 [`adapters/dshfind.ts`](file:///Users/wuyukun/playground/deepseek-harness-desktop/dsh-community-market/src/adapters/dshfind.ts) 中，当 `query.q` 存在时调用 `https://api.dshfind.com/market/v1/plugins?q=...`，精准下推搜索词。
+3. **路由分流**：在 [`service.ts`](file:///Users/wuyukun/playground/deepseek-harness-desktop/dsh-community-market/src/catalog/service.ts) 与 `routes.ts` 中将搜索分支扩大为同时支持 `1024Store` 与 `dshfind`。
+
+---
+
+## 2. 后续长远演进：真分页 v2 架构考量（待后续独立评估）
+
+若后续要将整个市场（包括默认浏览、分类、Installable）完全升级为服务端分页 v2，需按以下设计闭环推进：
+
+1. **公开 v1 合同迁移**：
+   * 明确 v2 合同版本号与废弃过渡期，兼容旧版标准源（Standard Source）。
+   * 建立 Provider Capability Matrix（支持 cursor / q / category 的组合矩阵，对不支持的来源提供降级保护）。
+2. **分类体系（Taxonomy）独立解耦**：
+   * 定义独立的 `SourceTaxonomy` 合同与端点，避免依赖全量条目推导分类。
+3. **Installable 候选集生命周期闭环**：
+   * 明确分页模式下安装候选的 state owner、缓存 TTL 与失效清理模型，保证 preview 与安装的一致性。

--- a/dsh-community-market/src/adapters/dshfind.ts
+++ b/dsh-community-market/src/adapters/dshfind.ts
@@ -2,10 +2,12 @@ import type { CatalogAdapter, CatalogFetchContext } from '../contracts/types.js'
 import type { CatalogQuery } from '../contracts/generated/catalog-query.js'
 import type { CatalogSnapshot } from '../contracts/generated/catalog-snapshot.js'
 import { normalizeRepositoryIdentity } from '../contracts/identity.js'
-import { parseCatalogSnapshot } from '../contracts/validate.js'
+import { parseCatalogProviderPage, parseCatalogSnapshot } from '../contracts/validate.js'
+import { snapshotFromPage } from './standard-http.js'
 
 export const DSHFIND_KEY = 'dshfind'
 export const DSHFIND_ENDPOINT = 'https://api.dshfind.com/v1/plugins'
+export const DSHFIND_MARKET_ENDPOINT = 'https://api.dshfind.com/market/v1/plugins'
 export const DSHFIND_HOSTNAME = 'api.dshfind.com'
 export const DSHFIND_PROVIDER_ID = 'com.dshfind.catalog'
 export const DSHFIND_ADAPTER_ID = 'market.dshfind-v1'
@@ -399,6 +401,24 @@ function querySnapshot(query: CatalogQuery, snapshots: readonly CatalogSnapshot[
   })
 }
 
+async function fetchMarketSearch(
+  query: CatalogQuery,
+  context: CatalogFetchContext,
+): Promise<CatalogSnapshot> {
+  const url = new URL(DSHFIND_MARKET_ENDPOINT)
+  if (query.q !== undefined) url.searchParams.set('q', query.q)
+  if (query.limit !== undefined) url.searchParams.set('limit', String(Math.min(query.limit, DSHFIND_PAGE_SIZE)))
+  const response = await context.http.getJson(
+    url.href,
+    context.signal,
+    { allowedOrigin: DSHFIND_ORIGIN },
+  )
+  const finalUrl = assertFinalOrigin(response.finalUrl)
+  const limit = Math.min(query.limit ?? 50, DSHFIND_PAGE_SIZE)
+  const page = parseCatalogProviderPage(response.value, limit)
+  return snapshotFromPage(page, context, finalUrl)
+}
+
 export function createDshfindAdapter(options: DshfindAdapterOptions = {}): CatalogAdapter {
   const interPageDelayMs = options.interPageDelayMs ?? DEFAULT_INTER_PAGE_DELAY_MS
   if (!Number.isSafeInteger(interPageDelayMs) || interPageDelayMs < 0) {
@@ -465,6 +485,9 @@ export function createDshfindAdapter(options: DshfindAdapterOptions = {}): Catal
   return {
     adapterId: DSHFIND_ADAPTER_ID,
     async fetch(query, context) {
+      if (query.q !== undefined) {
+        return await fetchMarketSearch(query, context)
+      }
       return querySnapshot(query, await scanCatalog(query, context))
     },
     scanCatalog,

--- a/dsh-community-market/src/adapters/standard-http.ts
+++ b/dsh-community-market/src/adapters/standard-http.ts
@@ -35,7 +35,7 @@ export function assertStandardSourceTrustRoot(
   return manifestUrl.origin
 }
 
-function snapshotFromPage(
+export function snapshotFromPage(
   page: CatalogProviderPage,
   context: Pick<CatalogFetchContext, 'source' | 'media'>,
   finalUrl: string,

--- a/dsh-community-market/src/catalog/service.ts
+++ b/dsh-community-market/src/catalog/service.ts
@@ -88,7 +88,8 @@ function catalogScanKey(sourceRecordId: string, locale: string | undefined): str
 }
 
 function prefersProviderSearch(source: LocalSourceRecord, query: CatalogQuery): boolean {
-  return source.adapterId === DSH_1024STORE_ADAPTER_ID && query.q !== undefined
+  return (source.adapterId === DSH_1024STORE_ADAPTER_ID || source.adapterId === DSHFIND_ADAPTER_ID)
+    && query.q !== undefined
 }
 
 function cachedScanView(entry: CatalogFullIndexCacheEntry, cacheStatus: 'fresh' | 'cached'): CatalogFullIndex {

--- a/dsh-community-market/src/host/routes.ts
+++ b/dsh-community-market/src/host/routes.ts
@@ -941,7 +941,10 @@ export function registerMarketRoutes(
             return
           }
         }
-        if (q !== undefined && selectedSource?.adapterId === DSH_1024STORE_ADAPTER_ID) {
+        if (
+          q !== undefined
+          && (selectedSource?.adapterId === DSH_1024STORE_ADAPTER_ID || selectedSource?.adapterId === DSHFIND_ADAPTER_ID)
+        ) {
           let results: readonly MarketCatalogSourceResult[]
           try {
             results = await service.fetch(query, signal, scope)
@@ -949,18 +952,8 @@ export function registerMarketRoutes(
             if (!signal.aborted && !res.destroyed) sendCatalogFailure(res, cause)
             return
           }
-          let index: CatalogFullIndex | undefined
-          try {
-            index = await service.scanCatalog(signal, {
-              force,
-              ...(locale === null || locale === '' ? {} : { locale }),
-              ...(scope === undefined ? {} : { expectedSourceRecordId: scope.sourceRecordId }),
-            })
-          } catch {
-            index = undefined
-          }
           signal.throwIfAborted()
-          const response = buildCatalogResponse(index, query, scope, results)
+          const response = buildCatalogResponse(undefined, query, scope, results)
           if (!signal.aborted && !res.destroyed) sendJson(res, 200, response)
           return
         }

--- a/dsh-community-market/tests/dshfind-adapter.spec.ts
+++ b/dsh-community-market/tests/dshfind-adapter.spec.ts
@@ -339,4 +339,43 @@ describe('dshfind install target normalization', () => {
     expect(items[0]).not.toHaveProperty('package')
     expect(items[0]).not.toHaveProperty('latestVersion')
   })
+
+  it('forwards dshfind search terms to the reviewed market provider endpoint', async () => {
+    const appshot = {
+      id: 'TaurusWood/dsh-plugin-appshot',
+      name: 'dsh-plugin-appshot',
+      displayName: 'dsh-plugin-appshot',
+      summary: 'dsh-plugin-appshot',
+      repository: { url: 'https://github.com/TaurusWood/dsh-plugin-appshot' },
+      publisher: { name: 'TaurusWood', url: 'https://github.com/TaurusWood' },
+      categories: ['tools'],
+      package: { registry: 'npm', name: 'dsh-plugin-appshot' },
+      latestVersion: '0.3.3',
+    }
+    const getJson = vi.fn(async (url: string) => ({
+      value: {
+        schemaVersion: '1.0.0',
+        generatedAt: '2026-08-25T08:51:53Z',
+        revision: 'sha256:1b2c6f9ae0b2b86f8ad2363d58bdc7ac39764bc90b2ecc775edad8f1b452bd3d',
+        items: [appshot],
+        page: { total: 1 },
+      },
+      finalUrl: url,
+    }))
+    const http: CatalogHttpClient = { getJson }
+    const adapter = createDshfindAdapter()
+
+    const snapshot = await adapter.fetch(
+      { q: 'appshot', limit: 50 },
+      { source: source(), signal: new AbortController().signal, http, media: { register: vi.fn() as any } },
+    )
+
+    const requestedCall = getJson.mock.calls[0] as unknown as [string, ...unknown[]] | undefined
+    const requestedUrl = requestedCall?.[0]
+    expect(requestedUrl).toBeDefined()
+    expect(new URL(requestedUrl!).pathname).toBe('/market/v1/plugins')
+    expect(new URL(requestedUrl!).searchParams.get('q')).toBe('appshot')
+    expect(snapshot.items.map(item => item.id)).toEqual(['TaurusWood/dsh-plugin-appshot'])
+    expect(snapshot.page).toEqual({ total: 1 })
+  })
 })

--- a/dsh-community-market/tests/market-runtime.spec.ts
+++ b/dsh-community-market/tests/market-runtime.spec.ts
@@ -3,7 +3,7 @@ import { EventEmitter } from 'node:events'
 import https from 'node:https'
 import { describe, expect, it, vi } from 'vitest'
 import { dsh1024StoreAdapter, DSH_1024STORE_ADAPTER_ID, DSH_1024STORE_KEY, DSH_1024STORE_PROVIDER_ID } from '../src/adapters/dsh-1024store.js'
-import { DSHFIND_ADAPTER_ID, DSHFIND_KEY, DSHFIND_PROVIDER_ID } from '../src/adapters/dshfind.js'
+import { dshfindAdapter, DSHFIND_ADAPTER_ID, DSHFIND_KEY, DSHFIND_PROVIDER_ID } from '../src/adapters/dshfind.js'
 import { standardHttpAdapter } from '../src/adapters/standard-http.js'
 import { DefaultCatalogService, type CatalogFullIndex } from '../src/catalog/service.js'
 import { MemoryCatalogSourceStore, SettingsCatalogSourceStore } from '../src/catalog/source-store.js'
@@ -1118,6 +1118,59 @@ describe('catalog active-source reads', () => {
 
       expect(response.statusCode).toBe(200)
       expect(fetch).toHaveBeenCalledOnce()
+      expect(response.body.results[0]?.snapshot?.items.map((item: { id: string }) => item.id))
+        .toEqual(['TaurusWood/dsh-plugin-appshot'])
+      expect(response.body.categories).toEqual([])
+      expect(response.body.metadata).toBeUndefined()
+    } finally {
+      fetch.mockRestore()
+      scanCatalog.mockRestore()
+    }
+  })
+
+  it('returns provider-backed dshfind search results without requiring a full local scan', async () => {
+    const dshfindSourceRecord: LocalSourceRecord = {
+      sourceRecordId: '018f1f77-a5c4-7b73-a9ae-0242ac120003',
+      registrationKind: 'built-in',
+      adapterId: DSHFIND_ADAPTER_ID,
+      providerId: DSHFIND_PROVIDER_ID,
+      builtInProviderKey: DSHFIND_KEY,
+      enabled: true,
+      order: 0,
+    }
+    const fetch = vi.spyOn(dshfindAdapter, 'fetch').mockResolvedValue({
+      schemaVersion: '1.0.0',
+      source: {
+        sourceRecordId: dshfindSourceRecord.sourceRecordId,
+        providerId: dshfindSourceRecord.providerId,
+        adapterId: dshfindSourceRecord.adapterId,
+        registrationKind: dshfindSourceRecord.registrationKind,
+        fetchedAt: '2026-08-25T08:51:53.000Z',
+        finalUrl: 'https://api.dshfind.com/market/v1/plugins?q=appshot',
+      },
+      items: [{
+        id: 'TaurusWood/dsh-plugin-appshot',
+        name: 'dsh-plugin-appshot',
+        displayName: 'dsh-plugin-appshot',
+        summary: 'dsh-plugin-appshot',
+        repository: { url: 'https://github.com/TaurusWood/dsh-plugin-appshot' },
+        provenance: {
+          sourceRecordId: dshfindSourceRecord.sourceRecordId,
+          providerId: dshfindSourceRecord.providerId,
+          itemId: 'TaurusWood/dsh-plugin-appshot',
+        },
+      }],
+      page: { total: 1 },
+    })
+    const scanCatalog = vi.spyOn(dshfindAdapter, 'scanCatalog')
+      .mockRejectedValue(new Error('dshfind scan should not be called for search'))
+
+    try {
+      const response = await requestMarketCatalog([dshfindSourceRecord], `${marketRoutes.catalog}?q=appshot`)
+
+      expect(response.statusCode).toBe(200)
+      expect(fetch).toHaveBeenCalledOnce()
+      expect(scanCatalog).not.toHaveBeenCalled()
       expect(response.body.results[0]?.snapshot?.items.map((item: { id: string }) => item.id))
         .toEqual(['TaurusWood/dsh-plugin-appshot'])
       expect(response.body.categories).toEqual([])


### PR DESCRIPTION
## Summary / 摘要

修复了在社区插件市场中搜索插件（如关键词 `appshot`）时，`1024Store` 和 `dshfind` 两个内置源无法检索出结果或请求超时挂起的问题：

1. **消除 1024Store 搜索阻塞**：在 `host/routes.ts` 的搜索分支中移除了多余的 `await service.scanCatalog()` 同步阻塞调用，拿到搜索结果后立即返回响应（耗时从数秒/超时降至 50ms 以内）。
2. **接入 dshfind 搜索下推**：在 `adapters/dshfind.ts` 中，当 `query.q` 存在时调用 dshfind 专为桌面端提供的标准端点 `https://api.dshfind.com/market/v1/plugins?q=...` 下推关键词，解决因 Desktop UA 限制在 200 条精选列表中导致搜不到全库插件的问题。
3. **路由与服务分流对齐**：在 `catalog/service.ts` 的 `prefersProviderSearch` 与 `host/routes.ts` 搜索分支中同步支持 `DSHFIND_ADAPTER_ID`。
4. **测试补充**：在 `dshfind-adapter.spec.ts` 和 `market-runtime.spec.ts` 中补充了 dshfind 搜索转发及即时返回的测试用例。

## Related Issues / 关联 Issue

Fixes #627

## Type / 类型

- [x] Bug fix / 问题修复
- [ ] Feature / 新功能
- [ ] Documentation / 文档
- [ ] Release or packaging / 发布或打包
- [ ] Tests only / 仅测试
- [ ] Other / 其他

## Platforms / 影响平台

- [ ] Windows installer / Windows 安装包
- [ ] Windows portable ZIP / Windows 便携版 ZIP
- [ ] macOS Apple Silicon
- [ ] macOS Intel
- [ ] macOS Universal package / macOS 通用安装包
- [ ] Linux
- [x] Not platform-specific / 与平台无关

## Verification / 验证

- [ ] `corepack yarn check:layout`
- [x] `corepack yarn typecheck`
- [x] `corepack yarn test`
- [x] `corepack yarn check`
- [ ] Platform package smoke / 平台打包或启动冒烟
- [x] Manual test / 人工测试

## Release Notes / 发布说明

修复了在社区插件市场搜索插件时无响应或无法返回结果的问题，提升了搜索响应速度。