### PR TITLE
feat(market): carry pinned GitHub install sources

### DIFF
--- a/dsh-community-market/docs/schemas/catalog-provider-page.schema.json
+++ b/dsh-community-market/docs/schemas/catalog-provider-page.schema.json
@@ -126,6 +126,23 @@
         }
       }
     },
+    "installSource": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "kind",
+        "commit"
+      ],
+      "properties": {
+        "kind": {
+          "const": "github"
+        },
+        "commit": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{40}$"
+        }
+      }
+    },
     "package": {
       "type": "object",
       "additionalProperties": false,
@@ -312,6 +329,9 @@
         },
         "repository": {
           "$ref": "#/$defs/repository"
+        },
+        "installSource": {
+          "$ref": "#/$defs/installSource"
         },
         "package": {
           "$ref": "#/$defs/package"

--- a/dsh-community-market/docs/schemas/catalog-snapshot.schema.json
+++ b/dsh-community-market/docs/schemas/catalog-snapshot.schema.json
@@ -213,6 +213,23 @@
         }
       }
     },
+    "installSource": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "kind",
+        "commit"
+      ],
+      "properties": {
+        "kind": {
+          "const": "github"
+        },
+        "commit": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{40}$"
+        }
+      }
+    },
     "package": {
       "type": "object",
       "additionalProperties": false,
@@ -400,6 +417,9 @@
         },
         "repository": {
           "$ref": "#/$defs/repository"
+        },
+        "installSource": {
+          "$ref": "#/$defs/installSource"
         },
         "package": {
           "$ref": "#/$defs/package"

--- a/dsh-community-market/src/contracts/generated/catalog-provider-page.ts
+++ b/dsh-community-market/src/contracts/generated/catalog-provider-page.ts
@@ -18,6 +18,7 @@ export type Item = Item1 & {
    */
   keywords?: string[]
   repository?: Repository
+  installSource?: InstallSource
   package?: Package
   publisher?: Publisher
   media?: Media
@@ -60,6 +61,10 @@ export interface CatalogProviderPage {
 export interface Repository {
   url: HttpsUri
   subdirectory?: string
+}
+export interface InstallSource {
+  kind: 'github'
+  commit: string
 }
 export interface Package {
   registry: 'npm'

--- a/dsh-community-market/src/contracts/generated/catalog-snapshot.ts
+++ b/dsh-community-market/src/contracts/generated/catalog-snapshot.ts
@@ -24,6 +24,7 @@ export type Item = Item1 & {
    */
   keywords?: string[]
   repository?: Repository
+  installSource?: InstallSource
   package?: Package
   publisher?: Publisher
   media?: Media
@@ -79,6 +80,10 @@ export interface Source {
 export interface Repository {
   url: HttpsUri
   subdirectory?: string
+}
+export interface InstallSource {
+  kind: 'github'
+  commit: string
 }
 export interface Package {
   registry: 'npm'

--- a/dsh-community-market/src/contracts/identity.ts
+++ b/dsh-community-market/src/contracts/identity.ts
@@ -2,6 +2,7 @@ import { CatalogContractError, semanticIssue } from './errors.js'
 import type { CatalogProviderPage } from './generated/catalog-provider-page.js'
 import type {
   CatalogIdentityChoice,
+  NormalizedGitHubInstallSource,
   NormalizedPackageIdentity,
   NormalizedRepositoryIdentity,
 } from './types.js'
@@ -9,6 +10,8 @@ import type {
 type CatalogItem = CatalogProviderPage['items'][number]
 type RepositoryIdentity = NonNullable<CatalogItem['repository']>
 type PackageIdentity = NonNullable<CatalogItem['package']>
+type InstallSourceIdentity = NonNullable<CatalogItem['installSource']>
+const GITHUB_COMMIT_PATTERN = /^[0-9a-f]{40}$/u
 
 function normalizeSubdirectory(value: string): string {
   if (value.startsWith('/') || value.endsWith('/') || value.includes('\\')) {
@@ -83,6 +86,43 @@ export function normalizeRepositoryIdentity(repository: RepositoryIdentity): Nor
 
 export function normalizePackageIdentity(packageIdentity: PackageIdentity): NormalizedPackageIdentity {
   return { registry: 'npm', name: packageIdentity.name }
+}
+
+/** Validate a pinned GitHub source against the same canonical repository identity. */
+export function normalizeGitHubInstallSource(
+  repository: RepositoryIdentity | undefined,
+  installSource: InstallSourceIdentity,
+): NormalizedGitHubInstallSource {
+  if (installSource.kind !== 'github' || !GITHUB_COMMIT_PATTERN.test(installSource.commit)) {
+    throw new CatalogContractError('identity', [
+      semanticIssue('/installSource/commit', 'must be a lowercase 40-character commit SHA'),
+    ])
+  }
+  if (repository === undefined) {
+    throw new CatalogContractError('identity', [
+      semanticIssue('/installSource', 'requires a repository identity'),
+    ])
+  }
+  const normalized = normalizeRepositoryIdentity(repository)
+  const url = new URL(normalized.url)
+  if (url.hostname !== 'github.com') {
+    throw new CatalogContractError('identity', [
+      semanticIssue('/installSource', 'currently supports GitHub repositories only'),
+    ])
+  }
+  const [owner, repo] = url.pathname.split('/').filter(Boolean)
+  if (owner === undefined || repo === undefined) {
+    throw new CatalogContractError('identity', [
+      semanticIssue('/repository/url', 'must identify a GitHub owner and repository'),
+    ])
+  }
+  return {
+    kind: 'github',
+    owner,
+    repo,
+    commit: installSource.commit,
+    ...(normalized.subdirectory === undefined ? {} : { subdirectory: normalized.subdirectory }),
+  }
 }
 
 export function catalogIdentityChoices(item: CatalogItem): readonly CatalogIdentityChoice[] {

--- a/dsh-community-market/src/contracts/index.ts
+++ b/dsh-community-market/src/contracts/index.ts
@@ -5,6 +5,7 @@ export type { CatalogSnapshot } from './generated/catalog-snapshot.js'
 export type { CatalogSourceManifest } from './generated/catalog-source.js'
 export {
   catalogIdentityChoices,
+  normalizeGitHubInstallSource,
   normalizePackageIdentity,
   normalizeRepositoryIdentity,
 } from './identity.js'
@@ -25,6 +26,7 @@ export type {
   CatalogMediaRole,
   CatalogSourceStore,
   LocalSourceRecord,
+  NormalizedGitHubInstallSource,
   NormalizedPackageIdentity,
   NormalizedRepositoryIdentity,
   ScopedCatalogCursor,

--- a/dsh-community-market/src/contracts/types.ts
+++ b/dsh-community-market/src/contracts/types.ts
@@ -96,6 +96,15 @@ export interface NormalizedPackageIdentity {
   readonly name: string
 }
 
+/** A pinned GitHub source descriptor; metadata only until install support is enabled. */
+export interface NormalizedGitHubInstallSource {
+  readonly kind: 'github'
+  readonly owner: string
+  readonly repo: string
+  readonly commit: string
+  readonly subdirectory?: string
+}
+
 export type CatalogIdentityChoice =
   | { readonly kind: 'repository'; readonly repository: NormalizedRepositoryIdentity }
   | { readonly kind: 'package'; readonly package: NormalizedPackageIdentity }

--- a/dsh-community-market/src/contracts/validate.ts
+++ b/dsh-community-market/src/contracts/validate.ts
@@ -4,7 +4,7 @@ import type { CatalogProviderPage } from './generated/catalog-provider-page.js'
 import type { CatalogQuery } from './generated/catalog-query.js'
 import type { CatalogSnapshot } from './generated/catalog-snapshot.js'
 import type { CatalogSourceManifest } from './generated/catalog-source.js'
-import { normalizeRepositoryIdentity } from './identity.js'
+import { normalizeGitHubInstallSource, normalizeRepositoryIdentity } from './identity.js'
 import { validators } from './schemas.js'
 import type { LocalSourceRecord } from './types.js'
 
@@ -74,6 +74,7 @@ export function parseCatalogProviderPage(value: unknown, effectiveLimit?: number
     }
     seen.add(item.id)
     if (item.repository) normalizeRepositoryIdentity(item.repository)
+    if (item.installSource) normalizeGitHubInstallSource(item.repository, item.installSource)
   }
 
   return page
@@ -103,6 +104,7 @@ export function parseCatalogSnapshot(value: unknown): CatalogSnapshot {
     }
     seen.add(identity)
     if (item.repository) normalizeRepositoryIdentity(item.repository)
+    if (item.installSource) normalizeGitHubInstallSource(item.repository, item.installSource)
   }
 
   return snapshot

--- a/dsh-community-market/src/install/manual.ts
+++ b/dsh-community-market/src/install/manual.ts
@@ -1,4 +1,5 @@
 import type { MarketManualInstallHint } from '../api-types.js'
+import { normalizeGitHubInstallSource } from '../contracts/index.js'
 import type { CatalogSnapshot } from '../contracts/index.js'
 
 type CatalogItem = CatalogSnapshot['items'][number]
@@ -30,6 +31,23 @@ export function manualInstallHint(item: CatalogItem): MarketManualInstallHint | 
       mutable: false,
       desktopVerification: 'not-verified',
       displayCommand: `dsh plugin add --save-exact ${item.package.name}@${item.latestVersion}`,
+    }
+  }
+
+  if (item.installSource !== undefined) {
+    try {
+      const source = normalizeGitHubInstallSource(item.repository, item.installSource)
+      const target = `github:${source.owner}/${source.repo}#${source.commit}`
+      const subdirectory = source.subdirectory === undefined ? '' : `&path:/${source.subdirectory}`
+      return {
+        ...identity(item),
+        kind: 'github',
+        mutable: false,
+        desktopVerification: 'not-verified',
+        displayCommand: `dsh plugin add ${target}${subdirectory}`,
+      }
+    } catch {
+      return undefined
     }
   }
 

--- a/dsh-community-market/tests/contracts.spec.ts
+++ b/dsh-community-market/tests/contracts.spec.ts
@@ -5,6 +5,7 @@ import {
   catalogIdentityChoices,
   CatalogContractError,
   normalizeCatalogQuery,
+  normalizeGitHubInstallSource,
   normalizeRepositoryIdentity,
   parseCatalogProviderPage,
   parseCatalogQuery,
@@ -113,6 +114,26 @@ describe('catalog schemas and semantics', () => {
       .toThrow(CatalogContractError)
   })
 
+  it('accepts a pinned GitHub install source in provider and normalized pages', () => {
+    const installSource = {
+      kind: 'github',
+      commit: '0123456789abcdef0123456789abcdef01234567',
+    } as const
+    const provider = providerFixture() as CatalogProviderPage
+    const providerWithSource = {
+      ...provider,
+      items: [{ ...provider.items[0]!, installSource }],
+    }
+    expect(parseCatalogProviderPage(providerWithSource).items[0]?.installSource).toEqual(installSource)
+
+    const snapshot = snapshotFixture() as ReturnType<typeof parseCatalogSnapshot>
+    const snapshotWithSource = {
+      ...snapshot,
+      items: [{ ...snapshot.items[0]!, installSource }],
+    }
+    expect(parseCatalogSnapshot(snapshotWithSource).items[0]?.installSource).toEqual(installSource)
+  })
+
   it('enforces source limit and sort relationships beyond JSON Schema', () => {
     const source = sourceFixture() as CatalogSourceManifest
     expect(() => parseCatalogSource({
@@ -204,6 +225,35 @@ describe('catalog identity and local source records', () => {
     })).toThrow(CatalogContractError)
     expect(() => normalizeRepositoryIdentity({ url: 'https://github.com/example/plugin/issues' }))
       .toThrow(/exactly owner and repository/u)
+  })
+
+  it('accepts pinned GitHub sources only when they match a canonical repository', () => {
+    expect(normalizeGitHubInstallSource({
+      url: 'https://github.com/Example/Plugin.git',
+      subdirectory: 'packages/market',
+    }, {
+      kind: 'github',
+      commit: '0123456789abcdef0123456789abcdef01234567',
+    })).toEqual({
+      kind: 'github',
+      owner: 'example',
+      repo: 'plugin',
+      commit: '0123456789abcdef0123456789abcdef01234567',
+      subdirectory: 'packages/market',
+    })
+
+    expect(() => normalizeGitHubInstallSource(
+      { url: 'https://github.com/example/plugin' },
+      { kind: 'github', commit: 'not-a-commit' },
+    )).toThrow(/40-character commit SHA/u)
+    expect(() => normalizeGitHubInstallSource(
+      { url: 'https://gitlab.example/example/plugin' },
+      { kind: 'github', commit: '0123456789abcdef0123456789abcdef01234567' },
+    )).toThrow(/GitHub repositories only/u)
+    expect(() => normalizeGitHubInstallSource(
+      undefined,
+      { kind: 'github', commit: '0123456789abcdef0123456789abcdef01234567' },
+    )).toThrow(/requires a repository identity/u)
   })
 
   it('requires one local source location and unique Host identities', () => {

--- a/dsh-community-market/tests/install-manual.spec.ts
+++ b/dsh-community-market/tests/install-manual.spec.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest'
+import { manualInstallHint } from '../src/install/manual.js'
+
+const base = {
+  id: 'example/plugin',
+  name: 'Example Plugin',
+  displayName: 'Example Plugin',
+  summary: 'Example plugin',
+  repository: { url: 'https://github.com/example/plugin', subdirectory: 'packages/plugin' },
+  installSource: {
+    kind: 'github' as const,
+    commit: '0123456789abcdef0123456789abcdef01234567',
+  },
+  provenance: {
+    sourceRecordId: 'source-1',
+    providerId: 'provider.example',
+    itemId: 'example/plugin',
+  },
+}
+
+describe('manual install hints', () => {
+  it('renders pinned GitHub sources as non-executable display commands', () => {
+    expect(manualInstallHint(base)).toMatchObject({
+      kind: 'github',
+      mutable: false,
+      desktopVerification: 'not-verified',
+      displayCommand: 'dsh plugin add github:example/plugin#0123456789abcdef0123456789abcdef01234567&path:/packages/plugin',
+    })
+  })
+
+  it('does not expose malformed pinned sources', () => {
+    expect(manualInstallHint({
+      ...base,
+      installSource: { kind: 'github', commit: 'not-a-commit' },
+    })).toBeUndefined()
+  })
+})


### PR DESCRIPTION
## Summary\n- add an additive catalog installSource contract for GitHub commit pins\n- validate the source against canonical GitHub repository identity and safe subpaths\n- expose a bounded, display-only manual command without enabling automatic installation\n\n## Why\nIssue #520 needs a source shape that can represent GitHub repositories and monorepo packages without accepting provider shell commands. This PR establishes the Host-normalized contract first; the current managed install path remains npm-only.\n\n## Validation\n- 21 focused Market contract/manual-hint tests passed\n- Market check: 21 files, 259 tests passed\n- generated contracts, package exports, Loader check, and docs verification passed\n\n## Follow-up\nThe next PR will add a Host-owned GitHub verifier and current Profile checkpoint-backed install executor.\n\nCloses #520