### PR TITLE
feat(market): verify pinned GitHub package manifests

### DIFF
--- a/dsh-community-market/src/index.ts
+++ b/dsh-community-market/src/index.ts
@@ -8,7 +8,7 @@ import {
 } from './host/routes.js'
 import { createRestrictedHttpClient } from './network/restricted-http.js'
 import {
-  createNpmRegistryVerifier,
+  createMarketPackageVerifier,
   MarketInstallService,
   type MarketDesktopPnpm,
   type MarketDesktopProfile,
@@ -70,7 +70,7 @@ export function apply(ctx: Context): void {
       const service = new MarketInstallService(
         () => profiles.current,
         pnpm,
-        createNpmRegistryVerifier(npmRegistryHttp),
+        createMarketPackageVerifier(npmRegistryHttp),
       )
       installService = service
       return () => {

--- a/dsh-community-market/src/install/github.ts
+++ b/dsh-community-market/src/install/github.ts
@@ -1,0 +1,97 @@
+import { prerelease, valid } from 'semver'
+import type { CatalogHttpClient, NormalizedGitHubInstallSource } from '../contracts/index.js'
+
+const RAW_GITHUB_ORIGIN = 'https://raw.githubusercontent.com'
+const PACKAGE_NAME_PATTERN = /^(?:@[a-z0-9][a-z0-9._-]*\/)?[a-z0-9][a-z0-9._-]*$/u
+const OWNER_PATTERN = /^[a-z0-9][a-z0-9-]{0,99}$/iu
+const REPOSITORY_PATTERN = /^[a-z0-9._-]{1,100}$/iu
+const COMMIT_PATTERN = /^[0-9a-f]{40}$/u
+const MAX_MANIFEST_BYTES = 1024 * 1024
+const BLOCKED_PACKAGES = new Set(['dsh-plugin-desktop', 'dsh-community-market'])
+
+export interface GitHubPackageVerification {
+  readonly packageName: string
+  readonly version: string
+  readonly bundlePatch: string
+  readonly source: NormalizedGitHubInstallSource
+}
+
+function fail(message: string): never {
+  throw new Error(`GitHub package verification failed: ${message}`)
+}
+
+function stableExactVersion(value: unknown): value is string {
+  return typeof value === 'string'
+    && valid(value, { loose: false }) === value
+    && prerelease(value, { loose: false }) === null
+}
+
+function safeBundlePatch(value: unknown): value is string {
+  if (typeof value !== 'string' || value.length === 0 || value.length > 512 || value.includes('\0')) return false
+  const path = value.startsWith('./') ? value.slice(2) : value
+  return path.length > 0
+    && !path.startsWith('/')
+    && !path.includes('\\')
+    && path.split('/').every(segment => segment.length > 0 && segment !== '.' && segment !== '..' && !segment.includes(':'))
+}
+
+function packageName(value: unknown): value is string {
+  return typeof value === 'string' && PACKAGE_NAME_PATTERN.test(value) && !BLOCKED_PACKAGES.has(value)
+}
+
+function assertSource(source: NormalizedGitHubInstallSource): void {
+  if (
+    source.kind !== 'github'
+    || !OWNER_PATTERN.test(source.owner)
+    || !REPOSITORY_PATTERN.test(source.repo)
+    || !COMMIT_PATTERN.test(source.commit)
+  ) fail('source identity is invalid')
+}
+
+export function githubPackageTarget(source: NormalizedGitHubInstallSource): string {
+  assertSource(source)
+  const path = source.subdirectory === undefined ? '' : `&path:/${source.subdirectory}`
+  return `github:${source.owner}/${source.repo}#${source.commit}${path}`
+}
+
+export function githubPackageManifestUrl(source: NormalizedGitHubInstallSource): string {
+  assertSource(source)
+  const subdirectory = source.subdirectory === undefined ? '' : `${source.subdirectory}/`
+  return `${RAW_GITHUB_ORIGIN}/${source.owner}/${source.repo}/${source.commit}/${subdirectory}package.json`
+}
+
+function readManifest(value: unknown): Record<string, unknown> {
+  if (value === null || typeof value !== 'object' || Array.isArray(value)) fail('package.json is not an object')
+  return value as Record<string, unknown>
+}
+
+export function createGitHubPackageVerifier(http: CatalogHttpClient) {
+  return {
+    async verify(source: NormalizedGitHubInstallSource, signal: AbortSignal): Promise<GitHubPackageVerification> {
+      const url = githubPackageManifestUrl(source)
+      let response
+      try {
+        response = await http.getJson(url, signal, { allowedOrigin: RAW_GITHUB_ORIGIN })
+      } catch {
+        fail('package.json could not be fetched from the pinned commit')
+      }
+      if (response.finalUrl !== url) fail('package.json request redirected or changed path')
+      const manifest = readManifest(response.value)
+      const packageNameValue = manifest.name
+      const versionValue = manifest.version
+      if (!packageName(packageNameValue)) fail('package name is invalid')
+      if (!stableExactVersion(versionValue)) fail('package version must be an exact stable semver')
+      const dsh = manifest.dsh
+      const bundle = dsh !== null && typeof dsh === 'object' && !Array.isArray(dsh)
+        ? (dsh as Record<string, unknown>).bundle
+        : undefined
+      const patch = bundle !== null && typeof bundle === 'object' && !Array.isArray(bundle)
+        ? (bundle as Record<string, unknown>).patch
+        : undefined
+      if (!safeBundlePatch(patch)) fail('package does not declare a valid DSH bundle')
+      return { packageName: packageNameValue, version: versionValue, bundlePatch: patch, source }
+    },
+  }
+}
+
+export const githubPackageManifestLimits = Object.freeze({ maxBytes: MAX_MANIFEST_BYTES })

--- a/dsh-community-market/src/install/service.ts
+++ b/dsh-community-market/src/install/service.ts
@@ -9,7 +9,16 @@ import type {
   MarketSourceView,
 } from '../api-types.js'
 import type { CatalogHttpClient } from '../contracts/types.js'
-import type { CatalogSnapshot } from '../contracts/index.js'
+import {
+  normalizeGitHubInstallSource,
+  type CatalogSnapshot,
+  type NormalizedGitHubInstallSource,
+} from '../contracts/index.js'
+import {
+  createGitHubPackageVerifier,
+  githubPackageTarget,
+  type GitHubPackageVerification,
+} from './github.js'
 import { manualInstallHints } from './manual.js'
 
 const NPM_REGISTRY_ORIGIN = 'https://registry.npmjs.org'
@@ -99,14 +108,15 @@ interface InstallCandidate {
   readonly providerId: string
   readonly itemId: string
   readonly displayName: string
-  readonly packageName: string
+  readonly packageName?: string
+  readonly source?: NormalizedGitHubInstallSource
   readonly savedAt: number
 }
 
 interface InstallIntent {
   readonly kind: 'install'
   readonly candidate: InstallCandidate
-  readonly verification: MarketNpmPackageVerification
+  readonly verification: MarketPackageVerification
   readonly profile: MarketDesktopProfile
   readonly expiresAt: number
 }
@@ -135,6 +145,20 @@ export interface MarketNpmPackageVerifier {
 
 export interface MarketNpmPackageVerification {
   readonly version: string
+}
+
+export interface MarketPackageVerification extends MarketNpmPackageVerification {
+  readonly packageName?: string
+  readonly source?: NormalizedGitHubInstallSource
+}
+
+export interface MarketInstallCandidateInput {
+  readonly packageName?: string
+  readonly source?: NormalizedGitHubInstallSource
+}
+
+export interface MarketPackageVerifier {
+  verify(candidate: MarketInstallCandidateInput, signal: AbortSignal): Promise<MarketPackageVerification>
 }
 
 export interface MarketInstallServiceOptions {
@@ -220,6 +244,34 @@ export function createNpmRegistryVerifier(http: CatalogHttpClient): MarketNpmPac
         throw new MarketInstallError('verification-failed', 'The npm package does not declare a valid DSH bundle.')
       }
       return { version: manifest.version }
+    },
+  }
+}
+
+/** Combine the stable npm verifier and the pinned GitHub manifest verifier. */
+export function createMarketPackageVerifier(
+  http: CatalogHttpClient,
+): MarketPackageVerifier {
+  const npm = createNpmRegistryVerifier(http)
+  return {
+    async verify(candidate, signal) {
+      if (candidate.source !== undefined) {
+        try {
+          const verification: GitHubPackageVerification = await createGitHubPackageVerifier(http)
+            .verify(candidate.source, signal)
+          return verification
+        } catch (cause) {
+          signal.throwIfAborted()
+          throw new MarketInstallError(
+            'verification-failed',
+            cause instanceof Error ? cause.message : 'The GitHub package could not be verified.',
+          )
+        }
+      }
+      if (candidate.packageName === undefined) {
+        throw new MarketInstallError('verification-failed', 'The plugin install source is incomplete.')
+      }
+      return await npm.verify({ packageName: candidate.packageName }, signal)
     },
   }
 }
@@ -351,7 +403,7 @@ export class MarketInstallService {
   constructor(
     private readonly currentProfile: () => MarketDesktopProfile,
     private readonly pnpm: MarketDesktopPnpm,
-    private readonly verifier: MarketNpmPackageVerifier,
+    private readonly verifier: MarketPackageVerifier,
     options: MarketInstallServiceOptions = {},
   ) {
     this.now = options.now ?? Date.now
@@ -375,13 +427,20 @@ export class MarketInstallService {
     for (const item of snapshot.items) {
       const key = candidateKey(snapshot.source.sourceRecordId, item.id)
       this.candidates.delete(key)
+      let source: NormalizedGitHubInstallSource | undefined
+      if (item.installSource !== undefined) {
+        try { source = normalizeGitHubInstallSource(item.repository, item.installSource) }
+        catch { continue }
+      }
+      const packageName = source === undefined && item.package?.registry === 'npm' && safePackageName(item.package.name)
+        ? item.package.name
+        : undefined
       if (
         item.provenance.sourceRecordId !== snapshot.source.sourceRecordId
         || item.provenance.providerId !== snapshot.source.providerId
         || item.provenance.itemId !== item.id
-        || item.package?.registry !== 'npm'
-        || !safePackageName(item.package.name)
-        || !marketManagedPackage(item.package.name)
+        || (packageName === undefined && source === undefined)
+        || (packageName !== undefined && !marketManagedPackage(packageName))
       ) {
         continue
       }
@@ -391,7 +450,8 @@ export class MarketInstallService {
         providerId: snapshot.source.providerId,
         itemId: item.id,
         displayName: item.displayName,
-        packageName: item.package.name,
+        ...(packageName === undefined ? {} : { packageName }),
+        ...(source === undefined ? {} : { source }),
         savedAt: this.now(),
       }
       this.candidates.set(key, candidate)
@@ -452,8 +512,8 @@ export class MarketInstallService {
       throw new MarketInstallError('not-available', 'This catalog item has no verified install target. Refresh the active source and try again.')
     }
     const profile = this.profile()
-    await assertNotInstalled(profile, candidate.packageName)
-    let verification: MarketNpmPackageVerification
+    if (candidate.packageName !== undefined) await assertNotInstalled(profile, candidate.packageName)
+    let verification: MarketPackageVerification
     try { verification = await this.verifier.verify(candidate, operationSignal) }
     catch (cause) {
       operationSignal.throwIfAborted()
@@ -471,11 +531,16 @@ export class MarketInstallService {
       profile,
       expiresAt: this.now() + this.intentTtlMs,
     })
+    const packageName = verification.packageName ?? candidate.packageName
+    if (packageName === undefined || !safePackageName(packageName)) {
+      throw new MarketInstallError('verification-failed', 'The verified package name is invalid.')
+    }
+    await assertNotInstalled(profile, packageName)
     return {
       intent: token,
       action: 'install',
       profileName: profile.name,
-      packageName: candidate.packageName,
+      packageName,
       version: verification.version,
       displayName: candidate.displayName,
       expiresAt: new Date(this.now() + this.intentTtlMs).toISOString(),
@@ -491,19 +556,26 @@ export class MarketInstallService {
       if (this.candidates.get(candidate.key) !== candidate) {
         throw new MarketInstallError('not-available', 'The verified catalog item is no longer available.')
       }
-      await assertNotInstalled(profile, candidate.packageName)
       const verification = intent.verification
+      const packageName = verification.packageName ?? candidate.packageName
+      if (packageName === undefined || !safePackageName(packageName)) {
+        throw new MarketInstallError('verification-failed', 'The verified package name is invalid.')
+      }
+      await assertNotInstalled(profile, packageName)
       if (this.candidates.get(candidate.key) !== candidate) {
         throw new MarketInstallError('not-available', 'The catalog source changed before installation.')
       }
+      const target = candidate.source === undefined
+        ? `${packageName}@${verification.version}`
+        : githubPackageTarget(candidate.source)
       await this.runPnpm([
         'add',
-        ...this.installOptions(candidate.packageName),
-        `${candidate.packageName}@${verification.version}`,
+        ...(candidate.source === undefined ? this.installOptions(packageName) : ['--save-exact']),
+        target,
       ], operationSignal)
       try {
-        await setProfileBundle(profile, candidate.packageName, true)
-        const installedVersion = await directProfilePluginVersion(profile, candidate.packageName)
+        await setProfileBundle(profile, packageName, true)
+        const installedVersion = await directProfilePluginVersion(profile, packageName)
         if (installedVersion !== verification.version) throw new Error('installed version mismatch')
         operationSignal.throwIfAborted()
       } catch {
@@ -512,7 +584,7 @@ export class MarketInstallService {
           'The package manager changed the Profile, but the plugin bundle could not be validated. Use a Recovery checkpoint if you need to restore the previous Profile state.',
         )
       }
-      return { packageName: candidate.packageName, version: verification.version }
+      return { packageName, version: verification.version }
     })
   }
 

--- a/dsh-community-market/tests/github-install.spec.ts
+++ b/dsh-community-market/tests/github-install.spec.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it, vi } from 'vitest'
+import {
+  createGitHubPackageVerifier,
+  githubPackageManifestUrl,
+  githubPackageTarget,
+} from '../src/install/github.js'
+
+const source = {
+  kind: 'github' as const,
+  owner: 'example',
+  repo: 'plugin',
+  commit: '0123456789abcdef0123456789abcdef01234567',
+  subdirectory: 'packages/plugin',
+}
+
+describe('GitHub package verification', () => {
+  it('constructs a pinned target and raw manifest URL', () => {
+    expect(githubPackageTarget(source)).toBe(
+      'github:example/plugin#0123456789abcdef0123456789abcdef01234567&path:/packages/plugin',
+    )
+    expect(githubPackageManifestUrl(source)).toBe(
+      'https://raw.githubusercontent.com/example/plugin/0123456789abcdef0123456789abcdef01234567/packages/plugin/package.json',
+    )
+  })
+
+  it('verifies package identity, stable version, and DSH bundle metadata', async () => {
+    const url = githubPackageManifestUrl(source)
+    const http = {
+      getJson: vi.fn(async () => ({
+        finalUrl: url,
+        value: {
+          name: '@example/dsh-plugin',
+          version: '1.2.3',
+          dsh: { bundle: { patch: './patches/plugin.patch' } },
+        },
+      })),
+    }
+    await expect(createGitHubPackageVerifier(http).verify(source, new AbortController().signal)).resolves.toEqual({
+      packageName: '@example/dsh-plugin',
+      version: '1.2.3',
+      bundlePatch: './patches/plugin.patch',
+      source,
+    })
+    expect(http.getJson).toHaveBeenCalledWith(url, expect.any(AbortSignal), { allowedOrigin: 'https://raw.githubusercontent.com' })
+  })
+
+  it.each([
+    ['a redirect', { finalUrl: 'https://evil.example/package.json', value: {} }],
+    ['an invalid package name', { value: { name: 'bad name', version: '1.2.3', dsh: { bundle: { patch: './plugin.patch' } } } }],
+    ['an invalid version', { value: { name: 'plugin', version: 'latest', dsh: { bundle: { patch: './plugin.patch' } } } }],
+    ['a missing bundle patch', { value: { name: 'plugin', version: '1.2.3', dsh: { bundle: {} } } }],
+  ])('rejects %s', async (_label, response) => {
+    const http = { getJson: vi.fn(async () => ({ finalUrl: githubPackageManifestUrl(source), ...response })) }
+    await expect(createGitHubPackageVerifier(http).verify(source, new AbortController().signal)).rejects.toThrow(/GitHub package verification failed/u)
+  })
+})

--- a/dsh-community-market/tests/market-github-install.spec.ts
+++ b/dsh-community-market/tests/market-github-install.spec.ts
@@ -1,0 +1,102 @@
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { Readable } from 'node:stream'
+import { describe, expect, it, vi } from 'vitest'
+import { MarketInstallService, type MarketDesktopPnpm } from '../src/install/service.js'
+import type { CatalogSnapshot } from '../src/contracts/index.js'
+
+const source = {
+  kind: 'github' as const,
+  owner: 'example',
+  repo: 'plugin',
+  commit: '0123456789abcdef0123456789abcdef01234567',
+  subdirectory: 'packages/plugin',
+}
+
+async function profile(): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), 'market-github-install-'))
+  await writeFile(join(dir, 'package.json'), JSON.stringify({
+    name: 'fixture-profile',
+    dependencies: {},
+    dsh: { profile: { bundles: [] } },
+  }))
+  return dir
+}
+
+function snapshot(): CatalogSnapshot {
+  return {
+    schemaVersion: '1.0.0',
+    source: {
+      sourceRecordId: 'source-1',
+      providerId: 'provider.example',
+      adapterId: 'market.standard-http-v1',
+      registrationKind: 'user-added',
+      fetchedAt: '2026-08-26T00:00:00.000Z',
+      finalUrl: 'https://example.test/plugins',
+    },
+    items: [{
+      id: 'example/plugin',
+      name: 'Example Plugin',
+      displayName: 'Example Plugin',
+      summary: 'Pinned GitHub plugin',
+      repository: { url: 'https://github.com/example/plugin', subdirectory: 'packages/plugin' },
+      installSource: source,
+      provenance: { sourceRecordId: 'source-1', providerId: 'provider.example', itemId: 'example/plugin' },
+    }],
+    page: {},
+  }
+}
+
+describe('Market GitHub install target', () => {
+  it('verifies the source first and runs a pinned, shell-free pnpm target', async () => {
+    const profileDir = await profile()
+    const calls: string[][] = []
+    const pnpm: MarketDesktopPnpm = {
+      run(argv) {
+        calls.push([...argv])
+        return {
+          stdout: Readable.from([]),
+          stderr: Readable.from([]),
+          done: (async () => {
+            await writeFile(join(profileDir, 'package.json'), JSON.stringify({
+              name: 'fixture-profile',
+              dependencies: { 'dsh-plugin-git': '1.2.3' },
+              dsh: { profile: { bundles: ['dsh-plugin-git'] } },
+            }))
+            return { exitCode: 0, signal: null }
+          })(),
+          cancel: vi.fn(),
+        }
+      },
+    }
+    const verifier = {
+      verify: vi.fn(async candidate => ({
+        packageName: 'dsh-plugin-git',
+        version: '1.2.3',
+        source: candidate.source!,
+      })),
+    }
+    const service = new MarketInstallService(
+      () => ({ name: 'desktop', dir: profileDir }),
+      pnpm,
+      verifier,
+    )
+    try {
+      service.observeCatalog(snapshot())
+      const preview = await service.previewInstall('source-1', 'example/plugin', new AbortController().signal)
+      expect(preview).toMatchObject({ packageName: 'dsh-plugin-git', version: '1.2.3' })
+      await service.executePreview(preview.intent, new AbortController().signal)
+      expect(calls).toEqual([[
+        'add',
+        '--save-exact',
+        'github:example/plugin#0123456789abcdef0123456789abcdef01234567&path:/packages/plugin',
+      ]])
+      expect(verifier.verify).toHaveBeenCalledWith(expect.objectContaining({ source }), expect.any(AbortSignal))
+      expect(JSON.parse(await readFile(join(profileDir, 'package.json'), 'utf8')).dependencies).toEqual({ 'dsh-plugin-git': '1.2.3' })
+    } finally {
+      service.dispose()
+      await rm(profileDir, { recursive: true, force: true })
+    }
+  })
+})


### PR DESCRIPTION
## Summary\n- verify pinned GitHub package.json manifests from raw.githubusercontent.com\n- reject redirects, invalid package identity/version, blocked packages, and unsafe DSH bundle patches\n- route catalog candidates with pinned GitHub sources through Market preview and execute\n- construct only the fixed-commit GitHub target while preserving the existing npm path\n\n## Context\nThis follows #630. The current Market contract now carries a pinned source; this PR adds the Host verifier and connects it to the current preview/execute boundary without accepting provider shell text.\n\n## Validation\n- focused GitHub verifier and Market install tests: 13 passed\n- Market check: 23 files, 266 tests passed\n- generated contracts, package exports, Loader check, and docs verification passed\n\n## Remaining follow-up\nProfile checkpoint-backed rollback and live provider-side source emission should be reviewed as the next hardening step.\n\nFollow-up to #630