### PR TITLE
feat(desktop): make setup wizard sequential

### DIFF
--- a/dsh-plugin-desktop/src/native-ui/components/ui/dialog.tsx
+++ b/dsh-plugin-desktop/src/native-ui/components/ui/dialog.tsx
@@ -1,0 +1,131 @@
+import { Dialog as DialogPrimitive } from '@base-ui/react/dialog'
+import { XIcon } from 'lucide-react'
+import type { ComponentProps } from 'react'
+import { cn } from '../../lib/utils.ts'
+import { Button } from './button.tsx'
+
+function Dialog(props: DialogPrimitive.Root.Props): JSX.Element {
+  return <DialogPrimitive.Root data-slot="dialog" {...props} />
+}
+
+function DialogTrigger(props: DialogPrimitive.Trigger.Props): JSX.Element {
+  return <DialogPrimitive.Trigger data-slot="dialog-trigger" {...props} />
+}
+
+function DialogPortal(props: DialogPrimitive.Portal.Props): JSX.Element {
+  return <DialogPrimitive.Portal data-slot="dialog-portal" {...props} />
+}
+
+function DialogClose(props: DialogPrimitive.Close.Props): JSX.Element {
+  return <DialogPrimitive.Close data-slot="dialog-close" {...props} />
+}
+
+function DialogOverlay({ className, ...props }: DialogPrimitive.Backdrop.Props): JSX.Element {
+  return (
+    <DialogPrimitive.Backdrop
+      className={cn(
+        'fixed inset-0 isolate z-50 bg-black/30 duration-100 supports-backdrop-filter:backdrop-blur-sm data-open:animate-in data-open:fade-in-0 data-closed:animate-out data-closed:fade-out-0',
+        className,
+      )}
+      data-slot="dialog-overlay"
+      {...props}
+    />
+  )
+}
+
+function DialogContent({
+  className,
+  children,
+  showCloseButton = true,
+  ...props
+}: DialogPrimitive.Popup.Props & {
+  showCloseButton?: boolean
+}): JSX.Element {
+  return (
+    <DialogPortal>
+      <DialogOverlay />
+      <DialogPrimitive.Popup
+        className={cn(
+          'fixed top-1/2 left-1/2 z-50 grid w-full max-w-[calc(100%-2rem)] -translate-x-1/2 -translate-y-1/2 gap-6 rounded-2xl bg-popover p-6 text-sm text-popover-foreground shadow-xl ring-1 ring-foreground/5 duration-100 outline-none sm:max-w-md dark:ring-foreground/10 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95',
+          className,
+        )}
+        data-slot="dialog-content"
+        {...props}
+      >
+        {children}
+        {showCloseButton && (
+          <DialogPrimitive.Close
+            render={<Button className="absolute top-4 right-4 size-7 bg-secondary" size="icon" variant="ghost" />}
+          >
+            <XIcon />
+            <span className="sr-only">Close</span>
+          </DialogPrimitive.Close>
+        )}
+      </DialogPrimitive.Popup>
+    </DialogPortal>
+  )
+}
+
+function DialogHeader({ className, ...props }: ComponentProps<'div'>): JSX.Element {
+  return <div className={cn('flex flex-col gap-1.5', className)} data-slot="dialog-header" {...props} />
+}
+
+function DialogFooter({
+  className,
+  showCloseButton = false,
+  children,
+  ...props
+}: ComponentProps<'div'> & {
+  showCloseButton?: boolean
+}): JSX.Element {
+  return (
+    <div
+      className={cn('flex flex-col-reverse gap-2 sm:flex-row sm:justify-end', className)}
+      data-slot="dialog-footer"
+      {...props}
+    >
+      {children}
+      {showCloseButton && (
+        <DialogPrimitive.Close render={<Button variant="outline" />}>
+          Close
+        </DialogPrimitive.Close>
+      )}
+    </div>
+  )
+}
+
+function DialogTitle({ className, ...props }: DialogPrimitive.Title.Props): JSX.Element {
+  return (
+    <DialogPrimitive.Title
+      className={cn('text-base leading-none font-medium', className)}
+      data-slot="dialog-title"
+      {...props}
+    />
+  )
+}
+
+function DialogDescription({ className, ...props }: DialogPrimitive.Description.Props): JSX.Element {
+  return (
+    <DialogPrimitive.Description
+      className={cn(
+        'text-sm text-muted-foreground *:[a]:underline *:[a]:underline-offset-3 *:[a]:hover:text-foreground',
+        className,
+      )}
+      data-slot="dialog-description"
+      {...props}
+    />
+  )
+}
+
+export {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogOverlay,
+  DialogPortal,
+  DialogTitle,
+  DialogTrigger,
+}

--- a/dsh-plugin-desktop/src/native-ui/components/ui/radio-group.tsx
+++ b/dsh-plugin-desktop/src/native-ui/components/ui/radio-group.tsx
@@ -1,0 +1,35 @@
+import { Radio as RadioPrimitive } from '@base-ui/react/radio'
+import { RadioGroup as RadioGroupPrimitive } from '@base-ui/react/radio-group'
+import { cn } from '../../lib/utils.ts'
+
+function RadioGroup({ className, ...props }: RadioGroupPrimitive.Props): JSX.Element {
+  return (
+    <RadioGroupPrimitive
+      className={cn('grid w-full gap-3', className)}
+      data-slot="radio-group"
+      {...props}
+    />
+  )
+}
+
+function RadioGroupItem({ className, ...props }: RadioPrimitive.Root.Props): JSX.Element {
+  return (
+    <RadioPrimitive.Root
+      className={cn(
+        'group/radio-group-item peer relative flex aspect-square size-4 shrink-0 rounded-2xl border border-transparent bg-input/90 outline-none group-has-[:focus-visible]/field-label:border-transparent group-has-[:focus-visible]/field-label:ring-0 after:absolute after:-inset-x-3 after:-inset-y-2 focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/30 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 data-checked:bg-primary data-checked:text-primary-foreground dark:data-checked:bg-primary',
+        className,
+      )}
+      data-slot="radio-group-item"
+      {...props}
+    >
+      <RadioPrimitive.Indicator
+        className="flex size-4 items-center justify-center"
+        data-slot="radio-group-indicator"
+      >
+        <span className="absolute top-1/2 left-1/2 size-2 -translate-x-1/2 -translate-y-1/2 rounded-full bg-primary-foreground dark:size-2.5" />
+      </RadioPrimitive.Indicator>
+    </RadioPrimitive.Root>
+  )
+}
+
+export { RadioGroup, RadioGroupItem }

--- a/dsh-plugin-desktop/src/native-ui/components/ui/switch.tsx
+++ b/dsh-plugin-desktop/src/native-ui/components/ui/switch.tsx
@@ -1,0 +1,29 @@
+import { Switch as SwitchPrimitive } from '@base-ui/react/switch'
+import { cn } from '../../lib/utils.ts'
+
+function Switch({
+  className,
+  size = 'default',
+  ...props
+}: SwitchPrimitive.Root.Props & {
+  size?: 'sm' | 'default'
+}): JSX.Element {
+  return (
+    <SwitchPrimitive.Root
+      className={cn(
+        'peer group/switch relative inline-flex shrink-0 items-center rounded-2xl border-2 transition-all outline-none group-has-[:focus-visible]/field-label:ring-0 after:absolute after:-inset-x-3 after:-inset-y-2 focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/30 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 data-[size=default]:h-5 data-[size=default]:w-8 data-[size=sm]:h-4 data-[size=sm]:w-6 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 data-checked:border-primary data-checked:bg-primary group-has-[:focus-visible]/field-label:data-checked:border-primary data-unchecked:border-transparent data-unchecked:bg-input/90 group-has-[:focus-visible]/field-label:data-unchecked:border-transparent data-disabled:cursor-not-allowed data-disabled:opacity-50',
+        className,
+      )}
+      data-size={size}
+      data-slot="switch"
+      {...props}
+    >
+      <SwitchPrimitive.Thumb
+        className="pointer-events-none block rounded-2xl bg-background shadow-sm ring-0 transition-transform not-dark:bg-clip-padding group-data-[size=default]/switch:size-4 group-data-[size=sm]/switch:size-3 data-checked:translate-x-[calc(100%-4px)] dark:data-checked:bg-primary-foreground data-unchecked:translate-x-0 dark:data-unchecked:bg-foreground"
+        data-slot="switch-thumb"
+      />
+    </SwitchPrimitive.Root>
+  )
+}
+
+export { Switch }

--- a/dsh-plugin-desktop/src/native-ui/setup-wizard/App.tsx
+++ b/dsh-plugin-desktop/src/native-ui/setup-wizard/App.tsx
@@ -3,7 +3,6 @@ import {
   AlertTriangle,
   ArrowLeft,
   ArrowRight,
-  Check,
   CheckCircle2,
   SkipForward,
 } from 'lucide-react'
@@ -34,6 +33,7 @@ import {
   DialogTrigger,
 } from '../components/ui/dialog.tsx'
 import { Label } from '../components/ui/label.tsx'
+import { RadioGroup, RadioGroupItem } from '../components/ui/radio-group.tsx'
 import { Switch } from '../components/ui/switch.tsx'
 import { DesktopFrame } from '../shared/DesktopFrame.tsx'
 
@@ -146,29 +146,27 @@ function finish(selection: DesktopSetupWizardSelection): void {
 }
 
 function Choice({
+  id,
+  value,
   title,
   body,
   selected,
   disabled = false,
-  onSelect,
 }: {
+  readonly id: string
+  readonly value: string
   readonly title: string
   readonly body: string
   readonly selected: boolean
   readonly disabled?: boolean
-  readonly onSelect: () => void
 }): JSX.Element {
-  return <button
-    aria-checked={selected}
-    className={`flex w-full items-start gap-3 rounded-xl border p-4 text-left outline-none transition-colors focus-visible:ring-3 focus-visible:ring-ring/30 ${selected ? 'border-primary bg-muted/70' : 'hover:bg-muted/40'}`}
-    disabled={disabled}
-    onClick={onSelect}
-    role="radio"
-    type="button"
+  return <Label
+    className={`flex w-full items-start gap-3 rounded-xl border p-4 text-left leading-normal outline-none transition-colors ${disabled ? 'cursor-not-allowed opacity-50' : 'cursor-pointer'} ${selected ? 'border-primary bg-muted/70' : 'hover:bg-muted/40'}`}
+    htmlFor={id}
   >
-    <span aria-hidden="true" className={`mt-0.5 flex size-5 shrink-0 items-center justify-center rounded-full border ${selected ? 'border-primary bg-primary text-primary-foreground' : 'border-muted-foreground/60'}`}>{selected ? <Check className="size-3" /> : null}</span>
+    <RadioGroupItem className="mt-0.5" disabled={disabled} id={id} value={value} />
     <span className="min-w-0"><span className="block text-sm font-medium">{title}</span><span className="mt-1 block text-xs leading-relaxed text-muted-foreground">{body}</span></span>
-  </button>
+  </Label>
 }
 
 function ToggleRow({
@@ -212,7 +210,7 @@ function Page({
   readonly subtitle: string
   readonly children: ReactNode
 }): JSX.Element {
-  return <div className="mx-auto flex w-full max-w-2xl flex-col py-5" data-setup-step={step}>
+  return <div className="mx-auto flex w-full max-w-2xl flex-col py-5" data-orientation="vertical" data-setup-step={step}>
     <header className="mb-6">
       <h1 className="text-2xl font-semibold tracking-tight">{title}</h1>
       <p className="mt-2 text-sm leading-relaxed text-muted-foreground">{subtitle}</p>
@@ -237,14 +235,25 @@ function ModeOptions({
     { value: 'extended', title: copy.extendedMode, body: input.platform === 'linux' ? copy.unavailableOnLinux : copy.extendedModeBody },
     { value: 'advanced', title: copy.advancedMode, body: input.platform === 'linux' ? copy.unavailableOnLinux : copy.advancedModeBody },
   ]
-  return <div aria-orientation="vertical" className="space-y-3" role="radiogroup">{modes.map(option => <Choice
+  return <RadioGroup
+    aria-label={copy.presentationTitle}
+    aria-orientation="vertical"
+    name="setup-window-mode"
+    onValueChange={value => {
+      if (value === 'compatibility' || value === 'extended' || value === 'advanced') {
+        update({ ...selection, mode: value })
+      }
+    }}
+    value={selection.mode}
+  >{modes.map(option => <Choice
     body={option.body}
     disabled={input.platform === 'linux' && option.value !== 'compatibility'}
+    id={`setup-window-mode-${option.value}`}
     key={option.value}
-    onSelect={() => { update({ ...selection, mode: option.value }) }}
     selected={selection.mode === option.value}
     title={option.title}
-  />)}</div>
+    value={option.value}
+  />)}</RadioGroup>
 }
 
 type MaterialOption = {
@@ -283,14 +292,23 @@ function MaterialOptions({
       update({ ...selection, windowsMaterial: value })
     }
   }
-  return <div aria-orientation="vertical" className="space-y-3" role="radiogroup">{options.map(option => <Choice
+  return <RadioGroup
+    aria-label={copy.windowMaterial}
+    aria-orientation="vertical"
+    name="setup-window-material"
+    onValueChange={value => {
+      if (value === 'off' || value === 'transparent' || value === 'acrylic' || value === 'mica') choose(value)
+    }}
+    value={selected}
+  >{options.map(option => <Choice
     body={option.body}
     disabled={input.platform === 'linux'}
+    id={`setup-window-material-${option.value}`}
     key={option.value}
-    onSelect={() => { choose(option.value) }}
     selected={selected === option.value}
     title={option.title}
-  />)}</div>
+    value={option.value}
+  />)}</RadioGroup>
 }
 
 function MarketOptions({
@@ -307,13 +325,24 @@ function MarketOptions({
     { value: 'community-market', title: copy.communityMarket, body: copy.communityMarketBody },
     { value: 'dsh-market', title: copy.dshMarket, body: copy.dshMarketBody },
   ]
-  return <div aria-orientation="vertical" className="space-y-3" role="radiogroup">{markets.map(option => <Choice
+  return <RadioGroup
+    aria-label={copy.marketTitle}
+    aria-orientation="vertical"
+    name="setup-plugin-market"
+    onValueChange={value => {
+      if (value === 'disabled' || value === 'community-market' || value === 'dsh-market') {
+        update({ ...selection, market: value })
+      }
+    }}
+    value={selection.market}
+  >{markets.map(option => <Choice
     body={option.body}
+    id={`setup-plugin-market-${option.value}`}
     key={option.value}
-    onSelect={() => { update({ ...selection, market: option.value }) }}
     selected={selection.market === option.value}
     title={option.title}
-  />)}</div>
+    value={option.value}
+  />)}</RadioGroup>
 }
 
 function NotificationOptions({
@@ -328,7 +357,7 @@ function NotificationOptions({
   const set = (key: keyof DesktopSetupWizardNotifications, checked: boolean): void => {
     update({ ...notifications, [key]: checked })
   }
-  return <div aria-orientation="vertical" className="space-y-3">
+  return <div className="space-y-3" data-orientation="vertical">
     <ToggleRow checked={notifications.enabled} id="setup-notifications-enabled" label={copy.notificationsEnabled} onChange={checked => { set('enabled', checked) }} />
     <div className="space-y-3 border-l pl-4">
       <ToggleRow checked={notifications.notifyOnTurnCompletion} disabled={!notifications.enabled} id="setup-turn-completion" label={copy.turnCompletion} onChange={checked => { set('notifyOnTurnCompletion', checked) }} />
@@ -355,10 +384,19 @@ function BrowserOptions({
     <section>
       <h2 className="text-sm font-semibold">{copy.networkExposure}</h2>
       <p className="mt-1 text-xs leading-relaxed text-muted-foreground">{copy.networkExposureBody}</p>
-      <div aria-orientation="vertical" className="mt-3 space-y-3" role="radiogroup">
-        <Choice body={copy.loopbackBody} onSelect={() => { requestExposure('loopback') }} selected={selection.networkExposure === 'loopback'} title={copy.loopback} />
-        <Choice body={copy.lanBody} onSelect={() => { requestExposure('lan') }} selected={selection.networkExposure === 'lan'} title={copy.lan} />
-      </div>
+      <RadioGroup
+        aria-label={copy.networkExposure}
+        aria-orientation="vertical"
+        className="mt-3"
+        name="setup-network-exposure"
+        onValueChange={value => {
+          if (value === 'loopback' || value === 'lan') requestExposure(value)
+        }}
+        value={selection.networkExposure}
+      >
+        <Choice body={copy.loopbackBody} id="setup-network-exposure-loopback" selected={selection.networkExposure === 'loopback'} title={copy.loopback} value="loopback" />
+        <Choice body={copy.lanBody} id="setup-network-exposure-lan" selected={selection.networkExposure === 'lan'} title={copy.lan} value="lan" />
+      </RadioGroup>
     </section>
   </div>
 }
@@ -467,8 +505,8 @@ export function SetupWizardLanConfirmation({ copy, confirm, cancel }: {
         </div>
       </DialogHeader>
       <DialogFooter>
-        <Button onClick={cancel} type="button" variant="outline">{copy.cancelLan}</Button>
-        <Button autoFocus onClick={confirm} type="button" variant="destructive"><AlertTriangle />{copy.confirmLan}</Button>
+        <DialogClose render={<Button autoFocus type="button" variant="outline" />}>{copy.cancelLan}</DialogClose>
+        <Button onClick={confirm} type="button" variant="destructive"><AlertTriangle />{copy.confirmLan}</Button>
       </DialogFooter>
     </DialogContent>
   </Dialog>

--- a/dsh-plugin-desktop/src/native-ui/setup-wizard/App.tsx
+++ b/dsh-plugin-desktop/src/native-ui/setup-wizard/App.tsx
@@ -1,35 +1,79 @@
-import { useEffect, useState, type ReactNode } from 'react'
+import { useState, type ReactNode } from 'react'
 import {
   AlertTriangle,
-  Bell,
+  ArrowLeft,
+  ArrowRight,
   Check,
-  Globe2,
-  Monitor,
-  PanelsTopLeft,
+  CheckCircle2,
   SkipForward,
 } from 'lucide-react'
 import {
   desktopSetupWizardRequiresLanAcknowledgement,
   isDesktopSetupWizardInput,
   type DesktopSetupWizardInput,
+  type DesktopSetupWizardMacosMaterial,
   type DesktopSetupWizardMarket,
   type DesktopSetupWizardMode,
   type DesktopSetupWizardNetworkExposure,
   type DesktopSetupWizardNotifications,
   type DesktopSetupWizardSelection,
+  type DesktopSetupWizardWindowsMaterial,
 } from '../../setup-wizard-contract.ts'
 import { desktopSetupWizardCopy, type DesktopSetupWizardCopy } from '../../setup-wizard-copy.ts'
 import { Alert, AlertDescription, AlertTitle } from '../components/ui/alert.tsx'
 import { Button } from '../components/ui/button.tsx'
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '../components/ui/card.tsx'
+import { Card, CardContent } from '../components/ui/card.tsx'
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from '../components/ui/dialog.tsx'
 import { Label } from '../components/ui/label.tsx'
-import { Tabs, TabsContent, TabsList, TabsTrigger } from '../components/ui/tabs.tsx'
+import { Switch } from '../components/ui/switch.tsx'
 import { DesktopFrame } from '../shared/DesktopFrame.tsx'
 
 const SCHEME = 'dsh-setup-wizard:'
 const MAX_STATE_CHARACTERS = 32 * 1024
 
 type Locale = 'en' | 'zh'
+
+export type DesktopSetupWizardStep =
+  | 'mode'
+  | 'material'
+  | 'market'
+  | 'notifications'
+  | 'browser'
+  | 'success'
+
+export const DESKTOP_SETUP_WIZARD_STEPS = Object.freeze([
+  'mode',
+  'material',
+  'market',
+  'notifications',
+  'browser',
+  'success',
+] as const satisfies readonly DesktopSetupWizardStep[])
+
+export function previousDesktopSetupWizardStep(
+  step: DesktopSetupWizardStep,
+): DesktopSetupWizardStep | undefined {
+  const index = DESKTOP_SETUP_WIZARD_STEPS.indexOf(step)
+  return index > 0 ? DESKTOP_SETUP_WIZARD_STEPS[index - 1] : undefined
+}
+
+export function nextDesktopSetupWizardStep(
+  step: DesktopSetupWizardStep,
+): DesktopSetupWizardStep | undefined {
+  const index = DESKTOP_SETUP_WIZARD_STEPS.indexOf(step)
+  return index >= 0 && index < DESKTOP_SETUP_WIZARD_STEPS.length - 1
+    ? DESKTOP_SETUP_WIZARD_STEPS[index + 1]
+    : undefined
+}
 
 function localLocale(search: string): Locale {
   return new URLSearchParams(search).get('locale') === 'zh' ? 'zh' : 'en'
@@ -128,41 +172,56 @@ function Choice({
 }
 
 function ToggleRow({
+  id,
   label,
   description,
   checked,
   disabled = false,
   onChange,
 }: {
+  readonly id: string
   readonly label: string
   readonly description?: string
   readonly checked: boolean
   readonly disabled?: boolean
   readonly onChange: (checked: boolean) => void
 }): JSX.Element {
-  return <div className="flex items-center justify-between gap-5 border-b py-3 last:border-b-0">
-    <span className="min-w-0"><span className="block text-sm font-medium">{label}</span>{description === undefined ? null : <span className="mt-1 block text-xs leading-relaxed text-muted-foreground">{description}</span>}</span>
-    <button
-      aria-checked={checked}
+  return <div className="flex items-center justify-between gap-5 rounded-xl border p-4">
+    <div className="min-w-0 space-y-1">
+      <Label className="block text-sm font-medium" htmlFor={id}>{label}</Label>
+      {description === undefined ? null : <p className="text-xs leading-relaxed text-muted-foreground">{description}</p>}
+    </div>
+    <Switch
       aria-label={label}
-      className={`relative h-6 w-11 shrink-0 rounded-full border transition-colors outline-none focus-visible:ring-3 focus-visible:ring-ring/30 ${checked ? 'border-primary bg-primary' : 'bg-muted'}`}
+      checked={checked}
       disabled={disabled}
-      onClick={() => { onChange(!checked) }}
-      role="switch"
-      type="button"
-    ><span aria-hidden="true" className={`absolute top-0.5 size-4 rounded-full bg-background shadow-sm transition-transform ${checked ? 'translate-x-5' : 'translate-x-0.5'}`} /></button>
+      id={id}
+      onCheckedChange={onChange}
+    />
   </div>
 }
 
-function PageCard({ title, body, children }: {
+function Page({
+  step,
+  title,
+  subtitle,
+  children,
+}: {
+  readonly step: DesktopSetupWizardStep
   readonly title: string
-  readonly body: string
+  readonly subtitle: string
   readonly children: ReactNode
 }): JSX.Element {
-  return <Card><CardHeader className="pb-4"><CardTitle>{title}</CardTitle><CardDescription>{body}</CardDescription></CardHeader><CardContent>{children}</CardContent></Card>
+  return <div className="mx-auto flex w-full max-w-2xl flex-col py-5" data-setup-step={step}>
+    <header className="mb-6">
+      <h1 className="text-2xl font-semibold tracking-tight">{title}</h1>
+      <p className="mt-2 text-sm leading-relaxed text-muted-foreground">{subtitle}</p>
+    </header>
+    <Card><CardContent className="space-y-3 p-4 sm:p-5">{children}</CardContent></Card>
+  </div>
 }
 
-function AppearancePanel({
+function ModeOptions({
   copy,
   input,
   selection,
@@ -178,61 +237,86 @@ function AppearancePanel({
     { value: 'extended', title: copy.extendedMode, body: input.platform === 'linux' ? copy.unavailableOnLinux : copy.extendedModeBody },
     { value: 'advanced', title: copy.advancedMode, body: input.platform === 'linux' ? copy.unavailableOnLinux : copy.advancedModeBody },
   ]
-  const material = input.platform === 'darwin' ? selection.macosMaterial
-    : input.platform === 'win32' ? selection.windowsMaterial : 'off'
-  return <div className="space-y-4 py-4">
-    <PageCard body={copy.presentationBody} title={copy.presentationTitle}><div className="grid gap-3 sm:grid-cols-3" role="radiogroup">{modes.map(option => <Choice
-      body={option.body}
-      disabled={input.platform === 'linux' && option.value !== 'compatibility'}
-      key={option.value}
-      onSelect={() => { update({ ...selection, mode: option.value }) }}
-      selected={selection.mode === option.value}
-      title={option.title}
-    />)}</div></PageCard>
-    <PageCard body={copy.windowMaterialBody} title={copy.windowMaterial}>
-      {input.platform === 'linux' ? <p className="text-sm text-muted-foreground">{copy.materialOff}</p> : <div className="max-w-sm space-y-2"><Label htmlFor="setup-window-material">{copy.windowMaterial}</Label><select
-        className="h-9 w-full rounded-lg border bg-background px-3 text-sm outline-none focus-visible:ring-3 focus-visible:ring-ring/30"
-        id="setup-window-material"
-        onChange={(event) => {
-          const next = event.currentTarget.value
-          if (input.platform === 'darwin' && (next === 'off' || next === 'transparent')) {
-            update({ ...selection, macosMaterial: next })
-          } else if (input.platform === 'win32' && (next === 'off' || next === 'acrylic' || next === 'mica' && input.micaSupported)) {
-            update({ ...selection, windowsMaterial: next })
-          }
-        }}
-        value={material}
-      ><option value="off">{copy.materialOff}</option>{input.platform === 'darwin' ? <option value="transparent">{copy.materialTransparent}</option> : <><option value="acrylic">{copy.materialAcrylic}</option>{input.micaSupported ? <option value="mica">{copy.materialMica}</option> : null}</>}</select></div>}
-    </PageCard>
-  </div>
+  return <div aria-orientation="vertical" className="space-y-3" role="radiogroup">{modes.map(option => <Choice
+    body={option.body}
+    disabled={input.platform === 'linux' && option.value !== 'compatibility'}
+    key={option.value}
+    onSelect={() => { update({ ...selection, mode: option.value }) }}
+    selected={selection.mode === option.value}
+    title={option.title}
+  />)}</div>
 }
 
-function AccessPanel({
+type MaterialOption = {
+  readonly value: DesktopSetupWizardMacosMaterial | DesktopSetupWizardWindowsMaterial
+  readonly title: string
+  readonly body: string
+}
+
+function MaterialOptions({
+  copy,
+  input,
+  selection,
+  update,
+}: {
+  readonly copy: DesktopSetupWizardCopy
+  readonly input: DesktopSetupWizardInput
+  readonly selection: DesktopSetupWizardSelection
+  readonly update: (selection: DesktopSetupWizardSelection) => void
+}): JSX.Element {
+  const options: readonly MaterialOption[] = input.platform === 'darwin' ? [
+    { value: 'off', title: copy.materialOff, body: copy.materialOffBody },
+    { value: 'transparent', title: copy.materialTransparent, body: copy.materialTransparentBody },
+  ] : input.platform === 'win32' ? [
+    { value: 'off', title: copy.materialOff, body: copy.materialOffBody },
+    { value: 'acrylic', title: copy.materialAcrylic, body: copy.materialAcrylicBody },
+    ...(input.micaSupported ? [{ value: 'mica' as const, title: copy.materialMica, body: copy.materialMicaBody }] : []),
+  ] : [
+    { value: 'off', title: copy.materialOff, body: copy.unavailableOnLinux },
+  ]
+  const selected = input.platform === 'darwin' ? selection.macosMaterial
+    : input.platform === 'win32' ? selection.windowsMaterial : 'off'
+  const choose = (value: MaterialOption['value']): void => {
+    if (input.platform === 'darwin' && (value === 'off' || value === 'transparent')) {
+      update({ ...selection, macosMaterial: value })
+    } else if (input.platform === 'win32' && (value === 'off' || value === 'acrylic' || value === 'mica')) {
+      update({ ...selection, windowsMaterial: value })
+    }
+  }
+  return <div aria-orientation="vertical" className="space-y-3" role="radiogroup">{options.map(option => <Choice
+    body={option.body}
+    disabled={input.platform === 'linux'}
+    key={option.value}
+    onSelect={() => { choose(option.value) }}
+    selected={selected === option.value}
+    title={option.title}
+  />)}</div>
+}
+
+function MarketOptions({
   copy,
   selection,
   update,
-  requestExposure,
 }: {
   readonly copy: DesktopSetupWizardCopy
   readonly selection: DesktopSetupWizardSelection
   readonly update: (selection: DesktopSetupWizardSelection) => void
-  readonly requestExposure: (exposure: DesktopSetupWizardNetworkExposure) => void
 }): JSX.Element {
   const markets: readonly { readonly value: DesktopSetupWizardMarket; readonly title: string; readonly body: string }[] = [
     { value: 'disabled', title: copy.marketDisabled, body: copy.marketDisabledBody },
     { value: 'community-market', title: copy.communityMarket, body: copy.communityMarketBody },
     { value: 'dsh-market', title: copy.dshMarket, body: copy.dshMarketBody },
   ]
-  return <div className="space-y-4 py-4">
-    <PageCard body={copy.browserBody} title={copy.browserTitle}>
-      <ToggleRow checked={selection.openBrowser} label={copy.openBrowser} onChange={openBrowser => { update({ ...selection, openBrowser }) }} />
-      <div className="pt-4"><h3 className="text-sm font-semibold">{copy.networkExposure}</h3><p className="mt-1 text-xs leading-relaxed text-muted-foreground">{copy.networkExposureBody}</p><div className="mt-3 grid gap-3 sm:grid-cols-2" role="radiogroup"><Choice body={copy.loopbackBody} onSelect={() => { requestExposure('loopback') }} selected={selection.networkExposure === 'loopback'} title={copy.loopback} /><Choice body={copy.lanBody} onSelect={() => { requestExposure('lan') }} selected={selection.networkExposure === 'lan'} title={copy.lan} /></div></div>
-    </PageCard>
-    <PageCard body={copy.marketBody} title={copy.marketTitle}><div className="grid gap-3 sm:grid-cols-3" role="radiogroup">{markets.map(option => <Choice body={option.body} key={option.value} onSelect={() => { update({ ...selection, market: option.value }) }} selected={selection.market === option.value} title={option.title} />)}</div></PageCard>
-  </div>
+  return <div aria-orientation="vertical" className="space-y-3" role="radiogroup">{markets.map(option => <Choice
+    body={option.body}
+    key={option.value}
+    onSelect={() => { update({ ...selection, market: option.value }) }}
+    selected={selection.market === option.value}
+    title={option.title}
+  />)}</div>
 }
 
-function NotificationsPanel({
+function NotificationOptions({
   copy,
   notifications,
   update,
@@ -244,10 +328,126 @@ function NotificationsPanel({
   const set = (key: keyof DesktopSetupWizardNotifications, checked: boolean): void => {
     update({ ...notifications, [key]: checked })
   }
-  return <div className="py-4"><PageCard body={copy.notificationsBody} title={copy.notificationsTitle}>
-    <ToggleRow checked={notifications.enabled} label={copy.notificationsEnabled} onChange={checked => { set('enabled', checked) }} />
-    <div className="ml-4 border-l pl-4"><ToggleRow checked={notifications.notifyOnTurnCompletion} disabled={!notifications.enabled} label={copy.turnCompletion} onChange={checked => { set('notifyOnTurnCompletion', checked) }} /><ToggleRow checked={notifications.notifyOnTurnFailure} disabled={!notifications.enabled} label={copy.turnFailure} onChange={checked => { set('notifyOnTurnFailure', checked) }} /><ToggleRow checked={notifications.notifyOnJobCompletion} disabled={!notifications.enabled} label={copy.jobCompletion} onChange={checked => { set('notifyOnJobCompletion', checked) }} /><ToggleRow checked={notifications.notifyOnJobFailure} disabled={!notifications.enabled} label={copy.jobFailure} onChange={checked => { set('notifyOnJobFailure', checked) }} /></div>
-  </PageCard></div>
+  return <div aria-orientation="vertical" className="space-y-3">
+    <ToggleRow checked={notifications.enabled} id="setup-notifications-enabled" label={copy.notificationsEnabled} onChange={checked => { set('enabled', checked) }} />
+    <div className="space-y-3 border-l pl-4">
+      <ToggleRow checked={notifications.notifyOnTurnCompletion} disabled={!notifications.enabled} id="setup-turn-completion" label={copy.turnCompletion} onChange={checked => { set('notifyOnTurnCompletion', checked) }} />
+      <ToggleRow checked={notifications.notifyOnTurnFailure} disabled={!notifications.enabled} id="setup-turn-failure" label={copy.turnFailure} onChange={checked => { set('notifyOnTurnFailure', checked) }} />
+      <ToggleRow checked={notifications.notifyOnJobCompletion} disabled={!notifications.enabled} id="setup-job-completion" label={copy.jobCompletion} onChange={checked => { set('notifyOnJobCompletion', checked) }} />
+      <ToggleRow checked={notifications.notifyOnJobFailure} disabled={!notifications.enabled} id="setup-job-failure" label={copy.jobFailure} onChange={checked => { set('notifyOnJobFailure', checked) }} />
+    </div>
+  </div>
+}
+
+function BrowserOptions({
+  copy,
+  selection,
+  update,
+  requestExposure,
+}: {
+  readonly copy: DesktopSetupWizardCopy
+  readonly selection: DesktopSetupWizardSelection
+  readonly update: (selection: DesktopSetupWizardSelection) => void
+  readonly requestExposure: (exposure: DesktopSetupWizardNetworkExposure) => void
+}): JSX.Element {
+  return <div className="space-y-5">
+    <ToggleRow checked={selection.openBrowser} id="setup-open-browser" label={copy.openBrowser} onChange={openBrowser => { update({ ...selection, openBrowser }) }} />
+    <section>
+      <h2 className="text-sm font-semibold">{copy.networkExposure}</h2>
+      <p className="mt-1 text-xs leading-relaxed text-muted-foreground">{copy.networkExposureBody}</p>
+      <div aria-orientation="vertical" className="mt-3 space-y-3" role="radiogroup">
+        <Choice body={copy.loopbackBody} onSelect={() => { requestExposure('loopback') }} selected={selection.networkExposure === 'loopback'} title={copy.loopback} />
+        <Choice body={copy.lanBody} onSelect={() => { requestExposure('lan') }} selected={selection.networkExposure === 'lan'} title={copy.lan} />
+      </div>
+    </section>
+  </div>
+}
+
+export function SetupWizardStepPage({
+  step,
+  copy,
+  input,
+  selection,
+  update,
+  requestExposure,
+}: {
+  readonly step: DesktopSetupWizardStep
+  readonly copy: DesktopSetupWizardCopy
+  readonly input: DesktopSetupWizardInput
+  readonly selection: DesktopSetupWizardSelection
+  readonly update: (selection: DesktopSetupWizardSelection) => void
+  readonly requestExposure: (exposure: DesktopSetupWizardNetworkExposure) => void
+}): JSX.Element {
+  if (step === 'mode') return <Page step={step} subtitle={copy.presentationBody} title={copy.presentationTitle}><ModeOptions copy={copy} input={input} selection={selection} update={update} /></Page>
+  if (step === 'material') return <Page step={step} subtitle={copy.windowMaterialBody} title={copy.windowMaterial}><MaterialOptions copy={copy} input={input} selection={selection} update={update} /></Page>
+  if (step === 'market') return <Page step={step} subtitle={copy.marketBody} title={copy.marketTitle}><MarketOptions copy={copy} selection={selection} update={update} /></Page>
+  if (step === 'notifications') return <Page step={step} subtitle={copy.notificationsBody} title={copy.notificationsTitle}><NotificationOptions copy={copy} notifications={selection.notifications} update={notifications => { update({ ...selection, notifications }) }} /></Page>
+  if (step === 'browser') return <Page step={step} subtitle={copy.browserBody} title={copy.browserTitle}><BrowserOptions copy={copy} requestExposure={requestExposure} selection={selection} update={update} /></Page>
+  return <div data-setup-step="success" />
+}
+
+function SetupWizardSkipDialog({
+  copy,
+  onSkip,
+  outlined = false,
+}: {
+  readonly copy: DesktopSetupWizardCopy
+  readonly onSkip: () => void
+  readonly outlined?: boolean
+}): JSX.Element {
+  return <Dialog>
+    <DialogTrigger render={<Button type="button" variant={outlined ? 'outline' : 'ghost'} />}><SkipForward />{copy.skip}</DialogTrigger>
+    <DialogContent aria-describedby="skip-warning-body" aria-labelledby="skip-warning-title" aria-modal="true" role="alertdialog" showCloseButton={false}>
+      <DialogHeader>
+        <DialogTitle id="skip-warning-title">{copy.skipDialogTitle}</DialogTitle>
+        <DialogDescription id="skip-warning-body">{copy.skipDialogBody}</DialogDescription>
+      </DialogHeader>
+      <DialogFooter>
+        <DialogClose render={<Button autoFocus type="button" variant="outline" />}>{copy.cancelSkip}</DialogClose>
+        <Button onClick={onSkip} type="button">{copy.confirmSkip}</Button>
+      </DialogFooter>
+    </DialogContent>
+  </Dialog>
+}
+
+export function SetupWizardNavigation({
+  copy,
+  step,
+  onBack,
+  onNext,
+  onSkip,
+}: {
+  readonly copy: DesktopSetupWizardCopy
+  readonly step: DesktopSetupWizardStep
+  readonly onBack: () => void
+  readonly onNext: () => void
+  readonly onSkip: () => void
+}): JSX.Element | null {
+  if (step === 'success') return null
+  return <footer className="flex shrink-0 items-center justify-between gap-3 border-t pt-4">
+    <SetupWizardSkipDialog copy={copy} onSkip={onSkip} />
+    <div className="flex items-center gap-2">
+      <Button aria-label={copy.back} disabled={previousDesktopSetupWizardStep(step) === undefined} onClick={onBack} size="icon" title={copy.back} type="button" variant="outline"><ArrowLeft /></Button>
+      <Button aria-label={copy.next} onClick={onNext} size="icon" title={copy.next} type="button"><ArrowRight /></Button>
+    </div>
+  </footer>
+}
+
+export function SetupWizardSuccess({
+  copy,
+  onStart,
+}: {
+  readonly copy: DesktopSetupWizardCopy
+  readonly onStart: () => void
+}): JSX.Element {
+  return <div className="flex flex-1 items-center justify-center" data-align="center" data-setup-step="success">
+    <div className="flex max-w-md flex-col items-center text-center">
+      <span className="mb-5 flex size-16 items-center justify-center rounded-full bg-primary text-primary-foreground"><CheckCircle2 className="size-8" /></span>
+      <h1 className="text-2xl font-semibold tracking-tight">{copy.successTitle}</h1>
+      <p className="mt-2 text-sm leading-relaxed text-muted-foreground">{copy.successBody}</p>
+      <Button className="mt-8" onClick={onStart} size="lg" type="button">{copy.startUsing}</Button>
+    </div>
+  </div>
 }
 
 export function SetupWizardLanConfirmation({ copy, confirm, cancel }: {
@@ -255,29 +455,39 @@ export function SetupWizardLanConfirmation({ copy, confirm, cancel }: {
   readonly confirm: () => void
   readonly cancel: () => void
 }): JSX.Element {
-  useEffect(() => {
-    const escape = (event: KeyboardEvent): void => { if (event.key === 'Escape') cancel() }
-    window.addEventListener('keydown', escape)
-    return () => { window.removeEventListener('keydown', escape) }
-  }, [cancel])
-  return <div className="fixed inset-0 z-[2000] flex items-center justify-center bg-black/60 p-6">
-    <Card aria-describedby="lan-warning-body" aria-labelledby="lan-warning-title" aria-modal="true" className="w-full max-w-lg shadow-2xl" role="alertdialog">
-      <CardHeader><div className="flex gap-3"><AlertTriangle aria-hidden="true" className="size-6 shrink-0 text-destructive" /><div><CardTitle id="lan-warning-title">{copy.lanWarningTitle}</CardTitle><CardDescription className="mt-2 text-foreground" id="lan-warning-body">{copy.lanWarningBody}</CardDescription></div></div></CardHeader>
-      <CardContent className="flex flex-wrap justify-end gap-2"><Button onClick={cancel} type="button" variant="outline">{copy.cancelLan}</Button><Button autoFocus onClick={confirm} type="button" variant="destructive"><AlertTriangle />{copy.confirmLan}</Button></CardContent>
-    </Card>
-  </div>
+  return <Dialog onOpenChange={open => { if (!open) cancel() }} open>
+    <DialogContent aria-describedby="lan-warning-body" aria-labelledby="lan-warning-title" aria-modal="true" role="alertdialog" showCloseButton={false}>
+      <DialogHeader>
+        <div className="flex gap-3">
+          <AlertTriangle aria-hidden="true" className="size-6 shrink-0 text-destructive" />
+          <div>
+            <DialogTitle id="lan-warning-title">{copy.lanWarningTitle}</DialogTitle>
+            <DialogDescription className="mt-2 text-foreground" id="lan-warning-body">{copy.lanWarningBody}</DialogDescription>
+          </div>
+        </div>
+      </DialogHeader>
+      <DialogFooter>
+        <Button onClick={cancel} type="button" variant="outline">{copy.cancelLan}</Button>
+        <Button autoFocus onClick={confirm} type="button" variant="destructive"><AlertTriangle />{copy.confirmLan}</Button>
+      </DialogFooter>
+    </DialogContent>
+  </Dialog>
 }
+
+type LanConfirmationReason = 'select' | 'advance' | 'start'
 
 export function SetupWizardApp(): JSX.Element {
   const locale = localLocale(window.location.search)
   const copy = desktopSetupWizardCopy(locale)
   const input = decodeDesktopSetupWizardInput(window.location.search)
   const [selection, setSelection] = useState<DesktopSetupWizardSelection | undefined>(() => input === undefined ? undefined : normalizedSelection(input))
+  const [step, setStep] = useState<DesktopSetupWizardStep>('mode')
   const [lanAcknowledged, setLanAcknowledged] = useState(false)
-  const [confirmLan, setConfirmLan] = useState<'select' | 'finish'>()
+  const [confirmLan, setConfirmLan] = useState<LanConfirmationReason>()
   if (input === undefined || selection === undefined) {
-    return <><DesktopFrame /><main className="dshNativeContent flex h-screen items-center justify-center p-6"><div className="w-full max-w-lg space-y-4"><Alert variant="destructive"><AlertTriangle /><AlertTitle>{copy.title}</AlertTitle><AlertDescription>{copy.invalidState}</AlertDescription></Alert><div className="flex justify-end"><Button onClick={() => { window.location.assign(`${SCHEME}//skip`) }} type="button" variant="outline"><SkipForward />{copy.skip}</Button></div></div></main></>
+    return <><DesktopFrame /><main className="dshNativeContent flex h-screen items-center justify-center p-6"><div className="w-full max-w-lg space-y-4"><Alert variant="destructive"><AlertTriangle /><AlertTitle>{copy.title}</AlertTitle><AlertDescription>{copy.invalidState}</AlertDescription></Alert><div className="flex justify-end"><SetupWizardSkipDialog copy={copy} onSkip={() => { window.location.assign(`${SCHEME}//skip`) }} outlined /></div></div></main></>
   }
+
   const requestExposure = (requested: DesktopSetupWizardNetworkExposure): void => {
     if (desktopSetupWizardRequiresLanAcknowledgement(
       selection.networkExposure,
@@ -290,30 +500,64 @@ export function SetupWizardApp(): JSX.Element {
     if (requested === 'loopback') setLanAcknowledged(false)
     setSelection({ ...selection, networkExposure: requested })
   }
-  const complete = (): void => {
+
+  const advance = (): void => {
+    const next = nextDesktopSetupWizardStep(step)
+    if (next === undefined) return
+    if (step === 'browser' && desktopSetupWizardRequiresLanAcknowledgement(
+      selection.networkExposure,
+      selection.networkExposure,
+      lanAcknowledged,
+    )) {
+      setConfirmLan('advance')
+      return
+    }
+    setStep(next)
+  }
+
+  const startUsing = (): void => {
     if (desktopSetupWizardRequiresLanAcknowledgement(
       selection.networkExposure,
       selection.networkExposure,
       lanAcknowledged,
     )) {
-      setConfirmLan('finish')
+      setConfirmLan('start')
       return
     }
     finish(selection)
   }
-  return <><DesktopFrame /><main className="dshNativeContent h-screen overflow-hidden p-5 sm:p-6"><section className="mx-auto flex h-full w-full max-w-5xl flex-col">
-    <header className="mb-4 shrink-0"><div className="flex flex-wrap items-start justify-between gap-3"><div><h1 className="text-xl font-semibold tracking-tight">{copy.heading}</h1><p className="mt-1.5 max-w-2xl text-sm text-muted-foreground">{copy.introduction}</p></div><span className="rounded-full bg-muted px-3 py-1.5 text-xs font-medium">{copy.profile}: {input.profileName}</span></div></header>
-    <Tabs defaultValue="appearance"><TabsList className="w-full justify-start"><TabsTrigger value="appearance"><Monitor />{copy.appearanceTab}</TabsTrigger><TabsTrigger value="access"><Globe2 />{copy.accessTab}</TabsTrigger><TabsTrigger value="notifications"><Bell />{copy.notificationsTab}</TabsTrigger></TabsList><TabsContent className="overflow-y-auto" value="appearance"><AppearancePanel copy={copy} input={input} selection={selection} update={setSelection} /></TabsContent><TabsContent className="overflow-y-auto" value="access"><AccessPanel copy={copy} requestExposure={requestExposure} selection={selection} update={setSelection} /></TabsContent><TabsContent className="overflow-y-auto" value="notifications"><NotificationsPanel copy={copy} notifications={selection.notifications} update={notifications => { setSelection({ ...selection, notifications }) }} /></TabsContent></Tabs>
-    <footer className="flex shrink-0 flex-wrap justify-end gap-2 border-t pt-4"><Button onClick={() => { window.location.assign(`${SCHEME}//skip`) }} type="button" variant="outline"><SkipForward />{copy.skip}</Button><Button onClick={complete} type="button"><PanelsTopLeft />{copy.complete}</Button></footer>
-  </section></main>{confirmLan === undefined ? null : <SetupWizardLanConfirmation
+
+  return <><DesktopFrame /><main className="dshNativeContent h-screen overflow-hidden p-5 sm:p-6"><section className="mx-auto flex h-full w-full max-w-3xl flex-col">
+    <header className="flex shrink-0 items-center justify-between gap-3 pb-2">
+      <span className="text-sm font-semibold">{copy.title}</span>
+      <span className="rounded-full bg-muted px-3 py-1.5 text-xs font-medium">{copy.profile}: {input.profileName}</span>
+    </header>
+    <div className="flex min-h-0 flex-1 overflow-y-auto">
+      {step === 'success'
+        ? <SetupWizardSuccess copy={copy} onStart={startUsing} />
+        : <SetupWizardStepPage copy={copy} input={input} requestExposure={requestExposure} selection={selection} step={step} update={setSelection} />}
+    </div>
+    <SetupWizardNavigation
+      copy={copy}
+      onBack={() => {
+        const previous = previousDesktopSetupWizardStep(step)
+        if (previous !== undefined) setStep(previous)
+      }}
+      onNext={advance}
+      onSkip={() => { window.location.assign(`${SCHEME}//skip`) }}
+      step={step}
+    />
+  </section></main>
+  {confirmLan === undefined ? null : <SetupWizardLanConfirmation
     cancel={() => { setConfirmLan(undefined) }}
     confirm={() => {
       const next = { ...selection, networkExposure: 'lan' as const }
-      const completeAfterAcknowledgement = confirmLan === 'finish'
+      const reason = confirmLan
       setSelection(next)
       setLanAcknowledged(true)
       setConfirmLan(undefined)
-      if (completeAfterAcknowledgement) finish(next)
+      if (reason === 'advance') setStep('success')
+      if (reason === 'start') finish(next)
     }}
     copy={copy}
   />}</>

--- a/dsh-plugin-desktop/src/native-ui/shared/theme.css
+++ b/dsh-plugin-desktop/src/native-ui/shared/theme.css
@@ -9,6 +9,8 @@
   --color-foreground: var(--foreground);
   --color-card: var(--card);
   --color-card-foreground: var(--card-foreground);
+  --color-popover: var(--popover);
+  --color-popover-foreground: var(--popover-foreground);
   --color-muted: var(--muted);
   --color-muted-foreground: var(--muted-foreground);
   --color-primary: var(--primary);
@@ -26,6 +28,8 @@
   --foreground: oklch(0.145 0 0);
   --card: oklch(1 0 0);
   --card-foreground: oklch(0.145 0 0);
+  --popover: oklch(1 0 0);
+  --popover-foreground: oklch(0.145 0 0);
   --primary: oklch(0.205 0 0);
   --primary-foreground: oklch(0.985 0 0);
   --secondary: oklch(0.97 0 0);
@@ -45,6 +49,8 @@
   --foreground: oklch(0.985 0 0);
   --card: oklch(0.205 0 0);
   --card-foreground: oklch(0.985 0 0);
+  --popover: oklch(0.205 0 0);
+  --popover-foreground: oklch(0.985 0 0);
   --primary: oklch(0.922 0 0);
   --primary-foreground: oklch(0.205 0 0);
   --secondary: oklch(0.269 0 0);

--- a/dsh-plugin-desktop/src/native-ui/shared/theme.css
+++ b/dsh-plugin-desktop/src/native-ui/shared/theme.css
@@ -67,6 +67,7 @@
 @layer base {
   * { @apply border-border outline-ring/50; }
   html, body, #root { width: 100%; height: 100%; }
+  #root { isolation: isolate; }
   html.dshDesktopDialogDocument,
   html.dshDesktopDialogDocument body,
   html.dshDesktopDialogDocument #root { height: auto; min-height: 0; }

--- a/dsh-plugin-desktop/src/setup-wizard-copy.ts
+++ b/dsh-plugin-desktop/src/setup-wizard-copy.ts
@@ -4,12 +4,7 @@ import type { DesktopLocale } from './runtime.ts'
 
 export interface DesktopSetupWizardCopy {
   readonly title: string
-  readonly heading: string
-  readonly introduction: string
   readonly profile: string
-  readonly appearanceTab: string
-  readonly accessTab: string
-  readonly notificationsTab: string
   readonly presentationTitle: string
   readonly presentationBody: string
   readonly compatibilityMode: string
@@ -22,9 +17,13 @@ export interface DesktopSetupWizardCopy {
   readonly windowMaterial: string
   readonly windowMaterialBody: string
   readonly materialOff: string
+  readonly materialOffBody: string
   readonly materialTransparent: string
+  readonly materialTransparentBody: string
   readonly materialAcrylic: string
+  readonly materialAcrylicBody: string
   readonly materialMica: string
+  readonly materialMicaBody: string
   readonly browserTitle: string
   readonly browserBody: string
   readonly openBrowser: string
@@ -53,21 +52,24 @@ export interface DesktopSetupWizardCopy {
   readonly turnFailure: string
   readonly jobCompletion: string
   readonly jobFailure: string
-  readonly complete: string
+  readonly back: string
+  readonly next: string
   readonly skip: string
+  readonly skipDialogTitle: string
+  readonly skipDialogBody: string
+  readonly cancelSkip: string
+  readonly confirmSkip: string
+  readonly successTitle: string
+  readonly successBody: string
+  readonly startUsing: string
   readonly invalidState: string
 }
 
 const COPY: Record<DesktopLocale, DesktopSetupWizardCopy> = {
   en: {
     title: 'Set up DSH Desktop',
-    heading: 'Set up this Profile',
-    introduction: 'Choose the initial Desktop experience. You can change these options later in Desktop settings.',
     profile: 'Profile',
-    appearanceTab: 'Window',
-    accessTab: 'Browser & market',
-    notificationsTab: 'Notifications',
-    presentationTitle: 'Window mode',
+    presentationTitle: 'Choose a window mode',
     presentationBody: 'Choose how DSH Desktop presents the official client.',
     compatibilityMode: 'Compatibility mode',
     compatibilityModeBody: 'Keep the official client layout for the broadest compatibility.',
@@ -76,13 +78,17 @@ const COPY: Record<DesktopLocale, DesktopSetupWizardCopy> = {
     advancedMode: 'Enhanced mode',
     advancedModeBody: 'Use the layout and window interactions optimized for Desktop.',
     unavailableOnLinux: 'This mode is currently available on macOS and Windows.',
-    windowMaterial: 'Window material',
+    windowMaterial: 'Choose a window material',
     windowMaterialBody: 'Choose the transparency or glass effect used by the Desktop window.',
     materialOff: 'No window material',
+    materialOffBody: 'Use a solid, opaque window background.',
     materialTransparent: 'Transparent',
+    materialTransparentBody: 'Let content behind the window show through the Desktop surface.',
     materialAcrylic: 'Acrylic',
+    materialAcrylicBody: 'Use the Windows acrylic blur material.',
     materialMica: 'Mica',
-    browserTitle: 'Browser access',
+    materialMicaBody: 'Use the native Windows Mica material when it is supported.',
+    browserTitle: 'Set up browser access',
     browserBody: 'Choose whether to open the client in your browser and who can reach it.',
     openBrowser: 'Open the client in my browser after startup',
     networkExposure: 'Network access',
@@ -95,7 +101,7 @@ const COPY: Record<DesktopLocale, DesktopSetupWizardCopy> = {
     lanWarningBody: 'This is dangerous: everyone on your local network may be able to operate your computer directly. Enable it only with great care.',
     confirmLan: 'Enable LAN access',
     cancelLan: 'Keep this computer only',
-    marketTitle: 'Plugin market',
+    marketTitle: 'Choose a plugin market',
     marketBody: 'Choose one plugin market for this Desktop installation.',
     marketDisabled: 'Do not enable a plugin market',
     marketDisabledBody: 'Keep plugin market features turned off.',
@@ -103,26 +109,29 @@ const COPY: Record<DesktopLocale, DesktopSetupWizardCopy> = {
     communityMarketBody: 'The open market built into DSH Desktop, including custom data sources.',
     dshMarket: 'dsh-market',
     dshMarketBody: 'The popular community market powered by awesome-dsh-plugin data.',
-    notificationsTitle: 'Desktop notifications',
+    notificationsTitle: 'Set up Desktop notifications',
     notificationsBody: 'Choose which completion and failure events send a system notification. Notification text never includes conversation content.',
     notificationsEnabled: 'Enable Desktop notifications',
     turnCompletion: 'User turn completed',
     turnFailure: 'User turn failed',
     jobCompletion: 'Background job completed',
     jobFailure: 'Background job failed',
-    complete: 'Finish setup',
+    back: 'Previous',
+    next: 'Next',
     skip: 'Skip setup',
+    skipDialogTitle: 'Skip setup?',
+    skipDialogBody: 'You can still configure all of these options later under Settings > Desktop settings.',
+    cancelSkip: 'Continue setup',
+    confirmSkip: 'Skip setup',
+    successTitle: 'Setup complete',
+    successBody: 'DSH Desktop is ready for this Profile.',
+    startUsing: 'Start using DSH Desktop',
     invalidState: 'Setup information could not be loaded. Close this window and try again.',
   },
   zh: {
     title: '设置 DSH Desktop',
-    heading: '设置这个 Profile',
-    introduction: '选择初始桌面体验。之后仍可在“桌面设置”中修改这些选项。',
     profile: 'Profile',
-    appearanceTab: '窗口',
-    accessTab: '浏览器与市场',
-    notificationsTab: '通知',
-    presentationTitle: '窗口模式',
+    presentationTitle: '选择窗口模式',
     presentationBody: '选择 DSH Desktop 如何呈现官方客户端。',
     compatibilityMode: '兼容模式',
     compatibilityModeBody: '保留官方客户端布局，兼容性最好。',
@@ -131,13 +140,17 @@ const COPY: Record<DesktopLocale, DesktopSetupWizardCopy> = {
     advancedMode: '增强模式',
     advancedModeBody: '使用针对桌面端优化的布局和窗口交互。',
     unavailableOnLinux: '此模式目前支持 macOS 和 Windows。',
-    windowMaterial: '窗口材质',
+    windowMaterial: '选择窗口材质',
     windowMaterialBody: '选择桌面窗口使用的透明或玻璃效果。',
     materialOff: '不使用窗口材质',
+    materialOffBody: '使用不透明的纯色窗口背景。',
     materialTransparent: '透明材质',
+    materialTransparentBody: '让桌面窗口呈现可透出背后内容的透明效果。',
     materialAcrylic: '亚克力',
+    materialAcrylicBody: '使用 Windows 亚克力模糊材质。',
     materialMica: 'Mica',
-    browserTitle: '浏览器访问',
+    materialMicaBody: '在系统支持时使用 Windows 原生 Mica 材质。',
+    browserTitle: '设置浏览器访问',
     browserBody: '选择启动后是否在浏览器中打开客户端，以及谁可以访问。',
     openBrowser: '启动后在我的浏览器中打开客户端',
     networkExposure: '网络访问范围',
@@ -150,7 +163,7 @@ const COPY: Record<DesktopLocale, DesktopSetupWizardCopy> = {
     lanWarningBody: '这样很危险，所有在你局域网内的人都能直接操作你的电脑，请谨慎开启。',
     confirmLan: '确认开启局域网访问',
     cancelLan: '保持仅本机访问',
-    marketTitle: '插件市场',
+    marketTitle: '选择插件市场',
     marketBody: '为这套桌面安装选择一个插件市场。',
     marketDisabled: '不启用插件市场',
     marketDisabledBody: '保持插件市场功能关闭。',
@@ -158,15 +171,23 @@ const COPY: Record<DesktopLocale, DesktopSetupWizardCopy> = {
     communityMarketBody: 'DSH Desktop 内置的开放市场，并支持自定义数据源。',
     dshMarket: 'dsh-market',
     dshMarketBody: '使用 awesome-dsh-plugin 数据的热门社区市场。',
-    notificationsTitle: '桌面通知',
+    notificationsTitle: '设置桌面通知',
     notificationsBody: '选择哪些完成或失败事件发送系统通知。通知文本不会包含会话内容。',
     notificationsEnabled: '启用桌面通知',
     turnCompletion: '用户回合完成',
     turnFailure: '用户回合失败',
     jobCompletion: '后台任务完成',
     jobFailure: '后台任务失败',
-    complete: '完成设置',
+    back: '上一步',
+    next: '下一步',
     skip: '跳过设置',
+    skipDialogTitle: '跳过设置？',
+    skipDialogBody: '之后仍可在“设置” > “桌面设置”中配置这里的所有内容。',
+    cancelSkip: '继续设置',
+    confirmSkip: '确认跳过',
+    successTitle: '设置成功',
+    successBody: '这个 Profile 的 DSH Desktop 已准备就绪。',
+    startUsing: '开始使用',
     invalidState: '无法加载设置信息。请关闭此窗口后重试。',
   },
 }

--- a/dsh-plugin-desktop/tests/native-ui-frame.spec.ts
+++ b/dsh-plugin-desktop/tests/native-ui-frame.spec.ts
@@ -17,4 +17,8 @@ describe('Desktop-owned native UI frame', () => {
     expect(theme).toContain('.dshNativeFrame ~ .dshNativeContent')
     expect(theme).not.toContain('.dshNativeFrame + .dshNativeContent')
   })
+
+  it('isolates the app root so body-level dialogs cover the high native frame layer', () => {
+    expect(theme).toMatch(/#root\s*\{\s*isolation:\s*isolate;/u)
+  })
 })

--- a/dsh-plugin-desktop/tests/setup-wizard-copy.spec.ts
+++ b/dsh-plugin-desktop/tests/setup-wizard-copy.spec.ts
@@ -44,6 +44,22 @@ describe('Desktop Setup Wizard copy and contract', () => {
     expect(desktopSetupWizardCopy('en').lanWarningBody).toContain('operate your computer directly')
   })
 
+  it('describes the sequential navigation, skip confirmation, and final success action', () => {
+    const english = desktopSetupWizardCopy('en')
+    const chinese = desktopSetupWizardCopy('zh')
+    expect(chinese.back).toBe('上一步')
+    expect(chinese.next).toBe('下一步')
+    expect(chinese.successTitle).toContain('成功')
+    expect(chinese.startUsing).toBe('开始使用')
+    expect(chinese.skipDialogBody).toContain('设置')
+    expect(chinese.skipDialogBody).toContain('桌面设置')
+    expect(english.back).toMatch(/^(?:Back|Previous)$/u)
+    expect(english.next).toBe('Next')
+    expect(english.startUsing).toContain('Start using')
+    expect(english.skipDialogBody).toContain('Settings')
+    expect(english.skipDialogBody).toContain('Desktop settings')
+  })
+
   it('requires confirmation only when loopback access is changed to LAN', () => {
     expect(desktopSetupWizardRequiresLanConfirmation('loopback', 'lan')).toBe(true)
     expect(desktopSetupWizardRequiresLanConfirmation('lan', 'loopback')).toBe(false)

--- a/dsh-plugin-desktop/tests/setup-wizard-native-ui.spec.ts
+++ b/dsh-plugin-desktop/tests/setup-wizard-native-ui.spec.ts
@@ -1,10 +1,20 @@
-import { createElement } from 'react'
+import { Children, createElement, isValidElement, type ReactElement, type ReactNode } from 'react'
 import { renderToStaticMarkup } from 'react-dom/server'
 import { afterEach, describe, expect, it, vi } from 'vitest'
-import type { DesktopSetupWizardInput } from '../src/setup-wizard-contract.ts'
+import type {
+  DesktopSetupWizardInput,
+  DesktopSetupWizardNetworkExposure,
+  DesktopSetupWizardSelection,
+} from '../src/setup-wizard-contract.ts'
 import {
   decodeDesktopSetupWizardInput,
+  DESKTOP_SETUP_WIZARD_STEPS,
+  nextDesktopSetupWizardStep,
+  previousDesktopSetupWizardStep,
   SetupWizardLanConfirmation,
+  SetupWizardNavigation,
+  SetupWizardStepPage,
+  SetupWizardSuccess,
 } from '../src/native-ui/setup-wizard/App.tsx'
 import { desktopSetupWizardCopy } from '../src/setup-wizard-copy.ts'
 
@@ -27,20 +37,207 @@ const input: DesktopSetupWizardInput = {
   },
 }
 
+const selection: DesktopSetupWizardSelection = {
+  mode: input.mode,
+  macosMaterial: input.macosMaterial,
+  windowsMaterial: input.windowsMaterial,
+  openBrowser: input.openBrowser,
+  networkExposure: input.networkExposure,
+  market: input.market,
+  notifications: input.notifications,
+}
+
+const copy = desktopSetupWizardCopy('zh')
+
+function renderStep(step: Exclude<(typeof DESKTOP_SETUP_WIZARD_STEPS)[number], 'success'>): string {
+  return renderToStaticMarkup(createElement(SetupWizardStepPage, {
+    copy,
+    input,
+    requestExposure: (_exposure: DesktopSetupWizardNetworkExposure) => {},
+    selection,
+    step,
+    update: (_next: DesktopSetupWizardSelection) => {},
+  }))
+}
+
+function occurrences(markup: string, fragment: string): number {
+  return markup.split(fragment).length - 1
+}
+
+function elementText(node: ReactNode): string {
+  if (typeof node === 'string' || typeof node === 'number') return String(node)
+  if (!isValidElement(node)) return Children.toArray(node).map(elementText).join(' ')
+  return elementText((node.props as { readonly children?: ReactNode }).children)
+}
+
 afterEach(() => { vi.unstubAllGlobals() })
+
+describe('Setup Wizard step flow', () => {
+  it('keeps one setting per page and browser access as the final setting page', () => {
+    expect(DESKTOP_SETUP_WIZARD_STEPS).toEqual([
+      'mode',
+      'material',
+      'market',
+      'notifications',
+      'browser',
+      'success',
+    ])
+  })
+
+  it('moves only between adjacent pages and stops at both boundaries', () => {
+    expect(DESKTOP_SETUP_WIZARD_STEPS.map(step => previousDesktopSetupWizardStep(step))).toEqual([
+      undefined,
+      'mode',
+      'material',
+      'market',
+      'notifications',
+      'browser',
+    ])
+    expect(DESKTOP_SETUP_WIZARD_STEPS.map(step => nextDesktopSetupWizardStep(step))).toEqual([
+      'material',
+      'market',
+      'notifications',
+      'browser',
+      'success',
+      undefined,
+    ])
+  })
+})
+
+describe('Setup Wizard setting pages', () => {
+  it.each([
+    ['mode', 'presentationTitle', 'presentationBody'],
+    ['material', 'windowMaterial', 'windowMaterialBody'],
+    ['market', 'marketTitle', 'marketBody'],
+    ['notifications', 'notificationsTitle', 'notificationsBody'],
+    ['browser', 'browserTitle', 'browserBody'],
+  ] as const)('renders the %s page with its own title and subtitle', (step, title, body) => {
+    const markup = renderStep(step)
+    expect(markup).toContain(`data-setup-step="${step}"`)
+    expect(markup).toContain(copy[title])
+    expect(markup).toContain(copy[body])
+    expect(occurrences(markup, 'data-setup-step=')).toBe(1)
+  })
+
+  it.each(['mode', 'material', 'market', 'notifications', 'browser'] as const)(
+    'lays out the %s page options vertically',
+    (step) => {
+      expect(renderStep(step)).toContain('aria-orientation="vertical"')
+    },
+  )
+
+  it('does not combine the plugin market and browser settings', () => {
+    const market = renderStep('market')
+    const browser = renderStep('browser')
+    expect(market).toContain(copy.marketTitle)
+    expect(market).not.toContain(copy.browserTitle)
+    expect(market).not.toContain(copy.openBrowser)
+    expect(browser).toContain(copy.browserTitle)
+    expect(browser).not.toContain(copy.marketTitle)
+    expect(browser).not.toContain(copy.communityMarket)
+    expect(browser).not.toContain(copy.dshMarket)
+  })
+
+  it('uses the shadcn Switch component for every wizard toggle', () => {
+    const notifications = renderStep('notifications')
+    const browser = renderStep('browser')
+    expect(occurrences(notifications, 'data-slot="switch"')).toBe(5)
+    expect(occurrences(notifications, 'role="switch"')).toBe(5)
+    expect(occurrences(browser, 'data-slot="switch"')).toBe(1)
+    expect(occurrences(browser, 'role="switch"')).toBe(1)
+  })
+})
+
+describe('Setup Wizard navigation and completion', () => {
+  it('shows Skip on the left and back/forward arrow buttons on every setting page', () => {
+    for (const step of DESKTOP_SETUP_WIZARD_STEPS.slice(0, -1)) {
+      const markup = renderToStaticMarkup(createElement(SetupWizardNavigation, {
+        copy,
+        onBack: () => {},
+        onNext: () => {},
+        onSkip: () => {},
+        step,
+      }))
+      expect(markup).toContain(copy.skip)
+      expect(markup).toContain(`aria-label="${copy.back}"`)
+      expect(markup).toContain(`aria-label="${copy.next}"`)
+      expect(markup).toContain('lucide-arrow-left')
+      expect(markup).toContain('lucide-arrow-right')
+      expect(markup.indexOf(copy.skip)).toBeLessThan(markup.indexOf(`aria-label="${copy.back}"`))
+    }
+  })
+
+  it('keeps the first-page back button visible but disabled', () => {
+    const markup = renderToStaticMarkup(createElement(SetupWizardNavigation, {
+      copy,
+      onBack: () => {},
+      onNext: () => {},
+      onSkip: () => {},
+      step: 'mode',
+    }))
+    expect(markup).toMatch(new RegExp(`<button[^>]+aria-label="${copy.back}"[^>]+disabled`, 'u'))
+  })
+
+  it('uses a dialog trigger for Skip and explains where setup remains available', () => {
+    const markup = renderToStaticMarkup(createElement(SetupWizardNavigation, {
+      copy,
+      onBack: () => {},
+      onNext: () => {},
+      onSkip: () => {},
+      step: 'market',
+    }))
+    expect(markup).toContain('data-slot="dialog-trigger"')
+    expect(markup).toContain('aria-haspopup="dialog"')
+    expect(copy.skipDialogBody).toContain('设置')
+    expect(copy.skipDialogBody).toContain('桌面设置')
+  })
+
+  it('renders only centered success and Start using controls on the final page', () => {
+    const success = renderToStaticMarkup(createElement(SetupWizardSuccess, {
+      copy,
+      onStart: () => {},
+    }))
+    const navigation = renderToStaticMarkup(createElement(SetupWizardNavigation, {
+      copy,
+      onBack: () => {},
+      onNext: () => {},
+      onSkip: () => {},
+      step: 'success',
+    }))
+    expect(success).toContain('data-setup-step="success"')
+    expect(success).toContain('data-align="center"')
+    expect(success).toContain(copy.successTitle)
+    expect(success).toContain(copy.successBody)
+    expect(success).toContain(copy.startUsing)
+    expect(success).not.toContain(copy.skip)
+    expect(success).not.toContain(`aria-label="${copy.back}"`)
+    expect(success).not.toContain(`aria-label="${copy.next}"`)
+    expect(navigation).toBe('')
+  })
+})
 
 describe('Setup Wizard native UI boundaries', () => {
   it('renders the LAN warning as an in-window alert dialog with explicit choices', () => {
-    const markup = renderToStaticMarkup(createElement(SetupWizardLanConfirmation, {
-      copy: desktopSetupWizardCopy('zh'),
+    const dialog = SetupWizardLanConfirmation({
+      copy,
       confirm: () => {},
       cancel: () => {},
-    }))
-    expect(markup).toContain('role="alertdialog"')
-    expect(markup).toContain('aria-modal="true"')
-    expect(markup).toContain('这样很危险，所有在你局域网内的人都能直接操作你的电脑，请谨慎开启')
-    expect(markup).toContain('确认开启局域网访问')
-    expect(markup).toContain('保持仅本机访问')
+    })
+    const dialogProps = dialog.props as { readonly children?: ReactNode; readonly open?: boolean }
+    const content = Children.toArray(dialogProps.children).find(isValidElement) as ReactElement | undefined
+    expect(dialogProps.open).toBe(true)
+    expect(content).toBeDefined()
+    expect(content?.props).toMatchObject({
+      'aria-describedby': 'lan-warning-body',
+      'aria-labelledby': 'lan-warning-title',
+      'aria-modal': 'true',
+      role: 'alertdialog',
+      showCloseButton: false,
+    })
+    const text = elementText(content)
+    expect(text).toContain('这样很危险，所有在你局域网内的人都能直接操作你的电脑，请谨慎开启')
+    expect(text).toContain('确认开启局域网访问')
+    expect(text).toContain('保持仅本机访问')
   })
 
   it('decodes only the exact bounded state tuple emitted by the owner window', () => {

--- a/dsh-plugin-desktop/tests/setup-wizard-native-ui.spec.ts
+++ b/dsh-plugin-desktop/tests/setup-wizard-native-ui.spec.ts
@@ -16,6 +16,8 @@ import {
   SetupWizardStepPage,
   SetupWizardSuccess,
 } from '../src/native-ui/setup-wizard/App.tsx'
+import { Button } from '../src/native-ui/components/ui/button.tsx'
+import { DialogClose } from '../src/native-ui/components/ui/dialog.tsx'
 import { desktopSetupWizardCopy } from '../src/setup-wizard-copy.ts'
 
 const input: DesktopSetupWizardInput = {
@@ -70,6 +72,16 @@ function elementText(node: ReactNode): string {
   return elementText((node.props as { readonly children?: ReactNode }).children)
 }
 
+function elementTree(node: ReactNode): readonly ReactElement[] {
+  const elements: ReactElement[] = []
+  Children.forEach(node, child => {
+    if (!isValidElement(child)) return
+    elements.push(child)
+    elements.push(...elementTree((child.props as { readonly children?: ReactNode }).children))
+  })
+  return elements
+}
+
 afterEach(() => { vi.unstubAllGlobals() })
 
 describe('Setup Wizard step flow', () => {
@@ -122,9 +134,21 @@ describe('Setup Wizard setting pages', () => {
   it.each(['mode', 'material', 'market', 'notifications', 'browser'] as const)(
     'lays out the %s page options vertically',
     (step) => {
-      expect(renderStep(step)).toContain('aria-orientation="vertical"')
+      expect(renderStep(step)).toContain('data-orientation="vertical"')
     },
   )
+
+  it.each([
+    ['mode', copy.presentationTitle],
+    ['material', copy.windowMaterial],
+    ['market', copy.marketTitle],
+    ['browser', copy.networkExposure],
+  ] as const)('uses a named shadcn RadioGroup for the %s choices', (step, accessibleName) => {
+    const markup = renderStep(step)
+    expect(markup).toContain('data-slot="radio-group"')
+    expect(markup).toContain(`aria-label="${accessibleName}"`)
+    expect(markup).toContain('data-slot="radio-group-item"')
+  })
 
   it('does not combine the plugin market and browser settings', () => {
     const market = renderStep('market')
@@ -238,6 +262,15 @@ describe('Setup Wizard native UI boundaries', () => {
     expect(text).toContain('这样很危险，所有在你局域网内的人都能直接操作你的电脑，请谨慎开启')
     expect(text).toContain('确认开启局域网访问')
     expect(text).toContain('保持仅本机访问')
+    const descendants = elementTree(content)
+    const close = descendants.find(element => element.type === DialogClose)
+    const confirm = descendants.find(element => element.type === Button
+      && elementText(element).includes(copy.confirmLan)
+      && (element.props as { readonly variant?: string }).variant === 'destructive')
+    expect(close).toBeDefined()
+    expect((close?.props as { readonly render?: ReactElement }).render?.props).toMatchObject({ autoFocus: true })
+    expect(confirm).toBeDefined()
+    expect((confirm?.props as { readonly autoFocus?: boolean }).autoFocus).not.toBe(true)
   })
 
   it('decodes only the exact bounded state tuple emitted by the owner window', () => {


### PR DESCRIPTION
## Summary

- split Profile setup into one setting category per page, with browser access last and a centered success page
- replace the hand-written toggle with official shadcn Base UI Switch, Dialog, and RadioGroup components
- add back/forward navigation, confirmed Skip flow, and guarded LAN acknowledgement with safe default focus
- keep modal layers above native window chrome and cover the new flow with bilingual and native UI tests

## Verification

- `corepack yarn check`
- Market: 266 passed
- Desktop: 905 passed, 4 skipped