### PR TITLE
feat(desktop): mark beta network features

### DIFF
--- a/dsh-plugin-desktop/src/client/DesktopSettingsSection.tsx
+++ b/dsh-plugin-desktop/src/client/DesktopSettingsSection.tsx
@@ -89,6 +89,7 @@ function Choice({
   disabled,
   action,
   status,
+  badge,
 }: {
   title: ReactNode
   body: ReactNode
@@ -98,6 +99,7 @@ function Choice({
   disabled?: boolean
   action: () => void
   status?: ReactNode
+  badge?: ReactNode
 }) {
   const actionable = disabled !== true && (!selected || reselectable === true)
   const choose = (): void => {
@@ -122,6 +124,7 @@ function Choice({
       <span className="dshDesktopSettingsChoiceCopy">
         <span className="dshDesktopSettingsChoiceTitle">
           {title}
+          {badge !== undefined && <span className="dshDesktopSettingsBadge">{badge}</span>}
           {status !== undefined && <span className="dshDesktopSettingsBadge">{status}</span>}
         </span>
         <span className="dshDesktopSettingsChoiceBody">{body}</span>
@@ -147,11 +150,13 @@ function RepositoryLink({ href, children }: { href: string; children: ReactNode 
 
 function ToggleRow({
   label,
+  badge,
   checked,
   disabled,
   onChange,
 }: {
   label: ReactNode
+  badge?: ReactNode
   checked: boolean
   disabled: boolean
   onChange: (checked: boolean) => void
@@ -159,7 +164,10 @@ function ToggleRow({
   const labelId = useId()
   return (
     <div className="dshDesktopSettingsToggleRow">
-      <span id={labelId}>{label}</span>
+      <span className="dshDesktopSettingsToggleLabel" id={labelId}>
+        {label}
+        {badge !== undefined && <span className="dshDesktopSettingsBadge">{badge}</span>}
+      </span>
       <button
         type="button"
         role="switch"
@@ -497,6 +505,7 @@ export function DesktopSettingsSection({
               <Choice
                 key={option.id}
                 title={marketTitle(option, t)}
+                badge={option.id === 'community-market' ? t('beta') : undefined}
                 body={marketBody(option, t)}
                 selected={view.market.requested === option.id}
                 reselectable={view.market.requested === option.id && view.market.requested !== view.market.effective}
@@ -587,6 +596,7 @@ export function DesktopSettingsSection({
         <p className="dshDesktopSettingsNotice">{t('browserCompatibilityNotice')}</p>
         <ToggleRow
           label={t('lanAccess')}
+          badge={t('beta')}
           checked={networkExposure === 'lan'}
           disabled={!browserAccess || !settingsWritable || busy !== undefined || restart !== 'none'}
           onChange={(checked) => {

--- a/dsh-plugin-desktop/src/client/desktop-settings-locales.ts
+++ b/dsh-plugin-desktop/src/client/desktop-settings-locales.ts
@@ -1,6 +1,7 @@
 /** Desktop-owned settings copy. */
 
 export const zh = {
+  beta: 'Beta',
   nav: '桌面设置',
   title: 'DSH Desktop 设置',
   intro: '管理当前 Profile、插件市场和桌面功能。',
@@ -84,7 +85,7 @@ export const zh = {
   browserUrls: '浏览器访问 URL',
   lanUrlsAfterRestart: '重启后将在这里显示实际的局域网 URL。',
   lanWarningTitle: '确认向局域网开放？',
-  lanWarningBody: '这样很危险，所有在你局域网内的人都能直接操作你的电脑，请谨慎开启。此连接没有身份认证。',
+  lanWarningBody: '这样很危险，所有在你局域网内的人都能直接操作你的电脑，请谨慎开启。此连接没有身份认证。由于浏览器安全限制，从局域网内使用 HTTP 访问时，部分安全模块可能不可用，可能导致 DSH Desktop 无法正常使用。',
   lanCancel: '取消',
   lanConfirm: '我已了解风险，仍然开启',
   notificationsTitle: '桌面通知',
@@ -99,6 +100,7 @@ export const zh = {
 export type DesktopSettingsLocaleKey = keyof typeof zh
 
 export const en: Record<DesktopSettingsLocaleKey, string> = {
+  beta: 'Beta',
   nav: 'Desktop settings',
   title: 'DSH Desktop settings',
   intro: 'Manage the current Profile, plugin market, and Desktop features.',
@@ -182,7 +184,7 @@ export const en: Record<DesktopSettingsLocaleKey, string> = {
   browserUrls: 'Browser URLs',
   lanUrlsAfterRestart: 'The actual local-network URLs will appear here after restart.',
   lanWarningTitle: 'Expose DSH Desktop to your local network?',
-  lanWarningBody: 'This is dangerous. Anyone on your local network can directly operate your computer. Enable it only with extreme care. This connection has no authentication.',
+  lanWarningBody: 'This is dangerous. Anyone on your local network can directly operate your computer. Enable it only with extreme care. This connection has no authentication. Browser security restrictions may prevent some security modules from working when DSH Desktop is accessed over HTTP from the local network, which may cause it not to work correctly.',
   lanCancel: 'Cancel',
   lanConfirm: 'I understand the risk — enable it',
   notificationsTitle: 'Desktop notifications',

--- a/dsh-plugin-desktop/src/client/desktop-settings-styles.ts
+++ b/dsh-plugin-desktop/src/client/desktop-settings-styles.ts
@@ -66,6 +66,7 @@ const CSS = `
 }
 .dshDesktopSettingsChoice[aria-disabled="true"]:not([data-selected="true"]) { opacity: .58; }
 .dshDesktopSettingsChoiceCopy { display: block; flex: 1; min-width: 0; }
+.dshDesktopSettingsToggleLabel { display: flex; align-items: center; flex-wrap: wrap; gap: 8px; }
 .dshDesktopSettingsChoiceAside { flex: 0 0 auto; margin-left: 12px; }
 .dshDesktopSettingsDeleteConfirm { display: flex; align-items: flex-end; flex-direction: column; gap: 8px; max-width: 320px; }
 .dshDesktopSettingsDeleteWarning { color: var(--dsw-alias-state-warning-primary); font-size: 12px; line-height: 1.4; text-align: right; }

--- a/dsh-plugin-desktop/src/native-ui/components/ui/badge.tsx
+++ b/dsh-plugin-desktop/src/native-ui/components/ui/badge.tsx
@@ -1,0 +1,27 @@
+import { cva, type VariantProps } from 'class-variance-authority'
+import type { HTMLAttributes } from 'react'
+import { cn } from '../../lib/utils.ts'
+
+const badgeVariants = cva(
+  'inline-flex w-fit shrink-0 items-center justify-center rounded-md border px-2 py-0.5 text-xs font-medium whitespace-nowrap',
+  {
+    variants: {
+      variant: {
+        default: 'border-transparent bg-primary text-primary-foreground',
+        secondary: 'border-transparent bg-secondary text-secondary-foreground',
+        outline: 'text-foreground',
+      },
+    },
+    defaultVariants: { variant: 'default' },
+  },
+)
+
+function Badge({
+  className,
+  variant,
+  ...props
+}: HTMLAttributes<HTMLSpanElement> & VariantProps<typeof badgeVariants>): JSX.Element {
+  return <span className={cn(badgeVariants({ variant }), className)} data-slot="badge" {...props} />
+}
+
+export { Badge, badgeVariants }

--- a/dsh-plugin-desktop/src/native-ui/setup-wizard/App.tsx
+++ b/dsh-plugin-desktop/src/native-ui/setup-wizard/App.tsx
@@ -20,6 +20,7 @@ import {
 } from '../../setup-wizard-contract.ts'
 import { desktopSetupWizardCopy, type DesktopSetupWizardCopy } from '../../setup-wizard-copy.ts'
 import { Alert, AlertDescription, AlertTitle } from '../components/ui/alert.tsx'
+import { Badge } from '../components/ui/badge.tsx'
 import { Button } from '../components/ui/button.tsx'
 import { Card, CardContent } from '../components/ui/card.tsx'
 import {
@@ -157,6 +158,7 @@ function Choice({
   body,
   selected,
   disabled = false,
+  badge,
 }: {
   readonly id: string
   readonly value: string
@@ -164,13 +166,20 @@ function Choice({
   readonly body: string
   readonly selected: boolean
   readonly disabled?: boolean
+  readonly badge?: string
 }): JSX.Element {
   return <Label
     className={`flex w-full items-start gap-3 rounded-xl border p-4 text-left leading-normal outline-none transition-colors ${disabled ? 'cursor-not-allowed opacity-50' : 'cursor-pointer'} ${selected ? 'border-primary bg-muted/70' : 'hover:bg-muted/40'}`}
     htmlFor={id}
   >
     <RadioGroupItem className="mt-0.5" disabled={disabled} id={id} value={value} />
-    <span className="min-w-0"><span className="block text-sm font-medium">{title}</span><span className="mt-1 block text-xs leading-relaxed text-muted-foreground">{body}</span></span>
+    <span className="min-w-0">
+      <span className="flex flex-wrap items-center gap-2 text-sm font-medium">
+        <span>{title}</span>
+        {badge === undefined ? null : <Badge variant="secondary">{badge}</Badge>}
+      </span>
+      <span className="mt-1 block text-xs leading-relaxed text-muted-foreground">{body}</span>
+    </span>
   </Label>
 }
 
@@ -346,6 +355,7 @@ function MarketOptions({
     }}
     value={selection.market}
   >{markets.map(option => <Choice
+    {...(option.value === 'community-market' ? { badge: copy.beta } : {})}
     body={option.body}
     id={`setup-plugin-market-${option.value}`}
     key={option.value}
@@ -412,7 +422,7 @@ function BrowserOptions({
         value={selection.networkExposure}
       >
         <Choice body={copy.loopbackBody} id="setup-network-exposure-loopback" selected={selection.networkExposure === 'loopback'} title={copy.loopback} value="loopback" />
-        <Choice body={copy.lanBody} disabled={selection.mode !== 'compatibility' || !selection.openBrowser} id="setup-network-exposure-lan" selected={selection.networkExposure === 'lan'} title={copy.lan} value="lan" />
+        <Choice badge={copy.beta} body={copy.lanBody} disabled={selection.mode !== 'compatibility' || !selection.openBrowser} id="setup-network-exposure-lan" selected={selection.networkExposure === 'lan'} title={copy.lan} value="lan" />
       </RadioGroup>
     </section>
   </div>

--- a/dsh-plugin-desktop/src/setup-wizard-copy.ts
+++ b/dsh-plugin-desktop/src/setup-wizard-copy.ts
@@ -3,6 +3,7 @@
 import type { DesktopLocale } from './runtime.ts'
 
 export interface DesktopSetupWizardCopy {
+  readonly beta: string
   readonly title: string
   readonly profile: string
   readonly welcomeTitle: string
@@ -76,6 +77,7 @@ export interface DesktopSetupWizardCopy {
 
 const COPY: Record<DesktopLocale, DesktopSetupWizardCopy> = {
   en: {
+    beta: 'Beta',
     title: 'Set up DSH Desktop',
     profile: 'Profile',
     welcomeTitle: 'Welcome to DSH Desktop',
@@ -116,7 +118,7 @@ const COPY: Record<DesktopLocale, DesktopSetupWizardCopy> = {
     lan: 'Local network',
     lanBody: 'Allow other devices on the same LAN to open and operate the client.',
     lanWarningTitle: 'Allow control from your local network?',
-    lanWarningBody: 'This is dangerous: everyone on your local network may be able to operate your computer directly. Enable it only with great care.',
+    lanWarningBody: 'This is dangerous: everyone on your local network may be able to operate your computer directly. Enable it only with great care. Browser security restrictions may prevent some security modules from working when DSH Desktop is accessed over HTTP from the local network, which may cause it not to work correctly.',
     confirmLan: 'Enable LAN access',
     cancelLan: 'Keep this computer only',
     marketTitle: 'Choose a plugin market',
@@ -147,6 +149,7 @@ const COPY: Record<DesktopLocale, DesktopSetupWizardCopy> = {
     invalidState: 'Setup information could not be loaded. Close this window and try again.',
   },
   zh: {
+    beta: 'Beta',
     title: '设置 DSH Desktop',
     profile: 'Profile',
     welcomeTitle: '欢迎设置 DSH Desktop',
@@ -187,7 +190,7 @@ const COPY: Record<DesktopLocale, DesktopSetupWizardCopy> = {
     lan: '局域网',
     lanBody: '允许同一局域网中的其他设备打开并操作客户端。',
     lanWarningTitle: '允许局域网中的设备控制吗？',
-    lanWarningBody: '这样很危险，所有在你局域网内的人都能直接操作你的电脑，请谨慎开启。',
+    lanWarningBody: '这样很危险，所有在你局域网内的人都能直接操作你的电脑，请谨慎开启。由于浏览器安全限制，从局域网内使用 HTTP 访问时，部分安全模块可能不可用，可能导致 DSH Desktop 无法正常使用。',
     confirmLan: '确认开启局域网访问',
     cancelLan: '保持仅本机访问',
     marketTitle: '选择插件市场',

--- a/dsh-plugin-desktop/tests/client-desktop-settings.spec.ts
+++ b/dsh-plugin-desktop/tests/client-desktop-settings.spec.ts
@@ -91,8 +91,18 @@ describe('Desktop settings API', () => {
     expect(en.browserCompatibilityNotice).toMatch(/only.+compatibility mode/iu)
     expect(en.browserCompatibilityNotice).toMatch(/select compatibility mode first/iu)
     expect(en.browserCompatibilityNotice).not.toMatch(/switch(?:es|ing)?.+profile/iu)
+    expect(zh.beta).toBe('Beta')
+    expect(en.beta).toBe('Beta')
     expect(zh.lanWarningBody).toContain('所有在你局域网内的人都能直接操作你的电脑')
+    expect(zh.lanWarningBody).toContain('浏览器安全限制')
+    expect(zh.lanWarningBody).toContain('HTTP')
+    expect(zh.lanWarningBody).toContain('安全模块可能不可用')
+    expect(zh.lanWarningBody).toContain('无法正常使用')
     expect(en.lanWarningBody).toContain('Anyone on your local network can directly operate your computer')
+    expect(en.lanWarningBody).toContain('Browser security restrictions')
+    expect(en.lanWarningBody).toContain('HTTP')
+    expect(en.lanWarningBody).toContain('security modules')
+    expect(en.lanWarningBody).toContain('not to work correctly')
   })
 
   it('shows actual URLs only when browser access is permitted and requires explicit LAN confirmation', () => {

--- a/dsh-plugin-desktop/tests/setup-wizard-copy.spec.ts
+++ b/dsh-plugin-desktop/tests/setup-wizard-copy.spec.ts
@@ -36,12 +36,24 @@ describe('Desktop Setup Wizard copy and contract', () => {
     expect(Object.values(chinese).every(value => value.length > 0)).toBe(true)
   })
 
-  it('contains the required direct-control LAN danger warning in both locales', () => {
-    expect(desktopSetupWizardCopy('zh').lanWarningBody).toContain(
+  it('contains the required direct-control and HTTP security warnings in both locales', () => {
+    const chinese = desktopSetupWizardCopy('zh')
+    const english = desktopSetupWizardCopy('en')
+    expect(chinese.beta).toBe('Beta')
+    expect(english.beta).toBe('Beta')
+    expect(chinese.lanWarningBody).toContain(
       '这样很危险，所有在你局域网内的人都能直接操作你的电脑，请谨慎开启',
     )
-    expect(desktopSetupWizardCopy('en').lanWarningBody).toContain('everyone on your local network')
-    expect(desktopSetupWizardCopy('en').lanWarningBody).toContain('operate your computer directly')
+    expect(chinese.lanWarningBody).toContain('浏览器安全限制')
+    expect(chinese.lanWarningBody).toContain('HTTP')
+    expect(chinese.lanWarningBody).toContain('安全模块可能不可用')
+    expect(chinese.lanWarningBody).toContain('无法正常使用')
+    expect(english.lanWarningBody).toContain('everyone on your local network')
+    expect(english.lanWarningBody).toContain('operate your computer directly')
+    expect(english.lanWarningBody).toContain('Browser security restrictions')
+    expect(english.lanWarningBody).toContain('HTTP')
+    expect(english.lanWarningBody).toContain('security modules')
+    expect(english.lanWarningBody).toContain('not to work correctly')
   })
 
   it('describes the sequential navigation, skip confirmation, and final success action', () => {

--- a/dsh-plugin-desktop/tests/setup-wizard-native-ui.spec.ts
+++ b/dsh-plugin-desktop/tests/setup-wizard-native-ui.spec.ts
@@ -215,6 +215,24 @@ describe('Setup Wizard setting pages', () => {
     expect(browser).not.toContain(copy.dshMarket)
   })
 
+  it('marks Community Market and LAN access as Beta features', () => {
+    const market = renderStep('market')
+    const browser = renderStep('browser')
+    const communityOption = market.indexOf('for="setup-plugin-market-community-market"')
+    const nextMarketOption = market.indexOf('for="setup-plugin-market-dsh-market"')
+    const marketBadge = market.indexOf('data-slot="badge"')
+    const lanOption = browser.indexOf('for="setup-network-exposure-lan"')
+    const lanBadge = browser.indexOf('data-slot="badge"')
+
+    expect(occurrences(market, 'data-slot="badge"')).toBe(1)
+    expect(occurrences(browser, 'data-slot="badge"')).toBe(1)
+    expect(market).toContain(copy.beta)
+    expect(browser).toContain(copy.beta)
+    expect(marketBadge).toBeGreaterThan(communityOption)
+    expect(marketBadge).toBeLessThan(nextMarketOption)
+    expect(lanBadge).toBeGreaterThan(lanOption)
+  })
+
   it('describes browser access as an opt-in capability limited to compatibility mode', () => {
     const browser = renderStep('browser')
     expect(browser).toContain(copy.openBrowser)
@@ -380,6 +398,10 @@ describe('Setup Wizard native UI boundaries', () => {
     })
     const text = elementText(content)
     expect(text).toContain('这样很危险，所有在你局域网内的人都能直接操作你的电脑，请谨慎开启')
+    expect(text).toContain('由于浏览器安全限制')
+    expect(text).toContain('HTTP')
+    expect(text).toContain('部分安全模块可能不可用')
+    expect(text).toContain('无法正常使用')
     expect(text).toContain('确认开启局域网访问')
     expect(text).toContain('保持仅本机访问')
     const descendants = elementTree(content)


### PR DESCRIPTION
## Summary

- show a `Beta` badge on Community Market and LAN exposure in Desktop settings and the Setup Wizard
- keep Beta independent from selected and retry state badges
- warn that LAN access over HTTP may lose security modules because of browser restrictions and may not work correctly
- provide matching Chinese and English copy

## Validation

- Desktop typecheck
- Desktop production build
- Desktop tests: 942 passed, 4 skipped
- Focused UI/copy tests: 53 passed