### PR TITLE
fix(desktop): show setup wizard on Windows startup

### DIFF
--- a/dsh-plugin-desktop/src/setup-wizard-window.ts
+++ b/dsh-plugin-desktop/src/setup-wizard-window.ts
@@ -159,7 +159,10 @@ export class DesktopSetupWizardWindow {
       resizable: true,
       maximizable: false,
       fullscreenable: false,
-      show: false,
+      // Electron can emit `ready-to-show` before the first hidden Win32 HWND
+      // accepts BrowserWindow.show(). Create the local Wizard visibly on
+      // Windows so startup never waits behind an unreachable surface.
+      show: input.platform === 'win32',
       autoHideMenuBar: true,
       backgroundColor: '#202124',
       webPreferences: {

--- a/dsh-plugin-desktop/tests/setup-wizard-window.spec.ts
+++ b/dsh-plugin-desktop/tests/setup-wizard-window.spec.ts
@@ -141,6 +141,7 @@ describe('DesktopSetupWizardWindow', () => {
       minWidth: 680,
       minHeight: 560,
       useContentSize: true,
+      show: true,
       webPreferences: expect.objectContaining({
         contextIsolation: true,
         nodeIntegration: false,
@@ -167,6 +168,22 @@ describe('DesktopSetupWizardWindow', () => {
     await expect(result).resolves.toEqual({ action: 'skip' })
     expect(prevented).toHaveBeenCalledOnce()
     expect(window?.destroy).toHaveBeenCalledOnce()
+  })
+
+  it('keeps non-Windows Wizards hidden until Electron reports them ready', async () => {
+    const result = new DesktopSetupWizardWindow({
+      locale: 'en',
+      input: input({ platform: 'darwin' }),
+    }).run()
+    await vi.waitFor(() => { expect(electron.windows).toHaveLength(1) })
+    const window = electron.windows[0]
+    expect(window?.options.show).toBe(false)
+    window?.onceListeners.get('ready-to-show')?.()
+    expect(window?.show).toHaveBeenCalledOnce()
+    expect(window?.focus).toHaveBeenCalledOnce()
+    const prevented = navigate(window!, 'dsh-setup-wizard://skip')
+    await expect(result).resolves.toEqual({ action: 'skip' })
+    expect(prevented).toHaveBeenCalledOnce()
   })
 
   it('returns the full immutable selection after explicit completion', async () => {


### PR DESCRIPTION
## Summary / 摘要

- Create the setup wizard BrowserWindow visibly on Windows instead of relying only on `ready-to-show`.
- Keep the existing hidden-until-ready behavior on non-Windows platforms.
- Add regression coverage for Windows initial visibility and non-Windows ready-to-show behavior.

This prevents first-run Windows desktop startup from waiting behind an unreachable hidden setup wizard.

## Related Issues / 关联 Issue

N/A

## Type / 类型

- [x] Bug fix / 问题修复
- [ ] Feature / 新功能
- [ ] Documentation / 文档
- [ ] Release or packaging / 发布或打包
- [ ] Tests only / 仅测试
- [ ] Other / 其他

## Platforms / 影响平台

- [x] Windows installer / Windows 安装包
- [x] Windows portable ZIP / Windows 便携版 ZIP
- [ ] macOS Apple Silicon
- [ ] macOS Intel
- [ ] macOS Universal package / macOS 通用安装包
- [ ] Linux
- [ ] Not platform-specific / 与平台无关

## Verification / 验证

- [ ] `corepack yarn check:layout`
- [x] `yarn workspace dsh-plugin-desktop typecheck`
- [x] `yarn workspace dsh-plugin-desktop vitest run tests/setup-wizard-window.spec.ts tests/shutdown.spec.ts` (15 tests)
- [x] `yarn workspace dsh-plugin-desktop build`
- [x] Manual Windows dev startup: the setup wizard was visible and completion reached a healthy main window.

## Release Notes / 发布说明

On Windows, the first-run setup wizard now opens reliably when DSH Desktop starts.
