### PR TITLE
docs: remove duplicate README preview

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -29,10 +29,6 @@
   <img src="https://img.shields.io/badge/macOS%20%7C%20Windows-4493F8?style=flat-square" alt="Supported platforms: macOS and Windows">
 </p>
 
-<p align="center">
-  <img src="assets/desktop-preview.png" alt="DSH Desktop preview" width="100%">
-</p>
-
 DSH Desktop integrates the local Web UI, Host service, and plugin system from [DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness) into a native desktop application. It runs a pinned upstream version unchanged, while DSH Desktop provides the window, tray, terminal, updates, and work profiles through the plugin mechanism provided by DeepSeek Harness.
 
 <a id="run"></a>

--- a/README.i18n.yaml
+++ b/README.i18n.yaml
@@ -1,5 +1,5 @@
 # Bilingual-pair consistency record: the git blob hash of each side as of the last
 # confirmed-consistent state. Both languages carry equal authority. Update both files
 # and re-record their hashes after editing either side.
-README.md: 73c3fc9a12f73820b19f311b3b360bf0078a33a1
-README.en.md: c9f39ad0f2f9ba0ee0b6dde86ebedbc607e8b323
+README.md: 5679654969af439b4a7eb05449f741b008223291
+README.en.md: 90333c72d93a057af8c0c403eb95f573119178ac

--- a/README.md
+++ b/README.md
@@ -29,10 +29,6 @@
   <img src="https://img.shields.io/badge/macOS%20%7C%20Windows-4493F8?style=flat-square" alt="Supported platforms: macOS and Windows">
 </p>
 
-<p align="center">
-  <img src="assets/desktop-preview.png" alt="DSH Desktop 界面预览" width="100%">
-</p>
-
 DSH Desktop 将 [DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness) 的本地 Web UI、Host 服务和插件系统集成到原生桌面应用中。项目固定并原样运行特定上游版本；DSH Desktop 提供窗口、托盘、终端、更新和工作配置，并通过 DeepSeek Harness 提供的插件机制与上游能力组合。
 
 <a id="run"></a>


### PR DESCRIPTION
## Summary

- remove the old `desktop-preview.png` block from both localized READMEs
- keep the new localized chat screenshot as the only chat image
- retain the old image asset in the repository

## Verification

- `corepack yarn check:bilingual-docs`
- `git diff --check`