### PR TITLE
docs: list dsh-recommend ecosystem project

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -209,6 +209,7 @@ Ecosystem projects and developer tools around DeepSeek Harness.
 | --- | --- | --- |
 | dshfind | The learning & sharing community for DeepSeek Harness (DSH). | [GitHub](https://github.com/hikariming/dshfind) · [Website](https://dshfind.com) |
 | DSH 1024Store | A community plugin directory for the DeepSeek Harness (DSH) ecosystem (4,120 plugins), open-sourcing an online marketplace, a collection pipeline, and a public query API — fork it to deploy your own marketplace. | [GitHub](https://github.com/imsai-sh/awesome-deepseek-harness-plugins) |
+| dsh-recommend | Transparent rankings and recommendations for the DSH plugin ecosystem, aggregating GitHub plugin data with a public scoring model for rankings, trends, search, and recommendations. | [GitHub](https://github.com/zp-home/dsh-recommend) · [Leaderboard](https://zp-home.github.io/dsh-recommend/site/) |
 | Awesome DSH Plugin | Curated list of DeepSeek Harness (DSH) plugins. | [GitHub](https://github.com/awesome-dsh-plugin/awesome-dsh-plugin) |
 | dsh-market | Visual plugin market for DeepSeek Harness, with browsing, search, and one-click installation. | [GitHub](https://github.com/dsh-market/dsh-market) |
 | ModLens | Adds OCR, layout, and semantic vision capabilities to DeepSeek Harness and text-only coding agents. | [GitHub](https://github.com/liustack/modlens) · [Website](https://liustack.dev) |

--- a/README.i18n.yaml
+++ b/README.i18n.yaml
@@ -1,5 +1,5 @@
 # Bilingual-pair consistency record: the git blob hash of each side as of the last
 # confirmed-consistent state. Both languages carry equal authority. Update both files
 # and re-record their hashes after editing either side.
-README.md: 5679654969af439b4a7eb05449f741b008223291
-README.en.md: 90333c72d93a057af8c0c403eb95f573119178ac
+README.md: 787dbeeb2871d7f7dd358bd5b8aade8ca3dc7607
+README.en.md: 1adf7c7ad7af0362b0c9c773f67dedb883ec4d6b

--- a/README.md
+++ b/README.md
@@ -209,6 +209,7 @@ Discord：[加入 DSH Desktop 社区](https://discord.gg/TJeGqKRNM)
 | --- | --- | --- |
 | dshfind | DeepSeek Harness（DSH）学习与分享社区。 | [GitHub](https://github.com/hikariming/dshfind) · [官网](https://dshfind.com) |
 | DSH 1024Store | 面向 DeepSeek Harness（dsh）生态的社区插件目录（收录 4120 个插件），并开源了在线插件市场、目录流水线与公开查询 API，可 fork 自建市场。 | [GitHub](https://github.com/imsai-sh/awesome-deepseek-harness-plugins) |
+| dsh-recommend | DSH 插件生态的透明排行与推荐工具，按公开评分模型聚合 GitHub 插件数据，提供排行、趋势、搜索与推荐。 | [GitHub](https://github.com/zp-home/dsh-recommend) · [排行榜](https://zp-home.github.io/dsh-recommend/site/) |
 | Awesome DSH Plugin | DeepSeek Harness（DSH）插件精选列表。 | [GitHub](https://github.com/awesome-dsh-plugin/awesome-dsh-plugin) |
 | dsh-market | DeepSeek Harness 内的可视化插件市场，支持浏览、搜索与一键安装插件。 | [GitHub](https://github.com/dsh-market/dsh-market) |
 | ModLens | 为 DeepSeek Harness 和纯文本 Coding Agent 提供 OCR、版面与语义识别能力。 | [GitHub](https://github.com/liustack/modlens) · [官网](https://liustack.dev) |


### PR DESCRIPTION
## Summary / 摘要

- Add dsh-recommend to the Chinese and English ecosystem-project tables.
- Link both the GitHub repository and its live leaderboard.
- Refresh the tracked bilingual-document blob hashes.

## Related Issues / 关联 Issue

N/A

## Type / 类型

- [ ] Bug fix / 问题修复
- [ ] Feature / 新功能
- [x] Documentation / 文档
- [ ] Release or packaging / 发布或打包
- [ ] Tests only / 仅测试
- [ ] Other / 其他

## Platforms / 影响平台

- [ ] Windows installer / Windows 安装包
- [ ] Windows portable ZIP / Windows 便携版 ZIP
- [ ] macOS Apple Silicon
- [ ] macOS Intel
- [ ] macOS Universal package / macOS 通用安装包
- [ ] Linux
- [x] Not platform-specific / 与平台无关

## Verification / 验证

- [x] `corepack yarn check:bilingual-docs`
- [x] `git diff --check`
- [x] Strict UTF-8 decode and mojibake scan for all edited files
- [x] Manual link check: repository and leaderboard both returned HTTP 200

## Release Notes / 发布说明

Adds dsh-recommend to the ecosystem links in both README languages.
