### PR TITLE
feat(desktop): widen sidebar width clamp range to 80-400px

### DIFF
--- a/dsh-plugin-desktop/src/client/layout-state.ts
+++ b/dsh-plugin-desktop/src/client/layout-state.ts
@@ -25,8 +25,8 @@ export const SIDEBAR_COLLAPSED = 56
 /** Wider compact rail reserved only for the enhanced macOS presentation. */
 export const MACOS_SIDEBAR_COLLAPSED = 90
 export const SIDEBAR_DEFAULT = 280
-export const SIDEBAR_MIN = 264
-export const SIDEBAR_MAX = 420
+export const SIDEBAR_MIN = 80
+export const SIDEBAR_MAX = 400
 export const SIDEBAR_AUTO_COLLAPSE = 1024
 export const DETAILS_DEFAULT = 360
 export const DETAILS_MIN = 300


### PR DESCRIPTION
## Summary / 摘要

侧边栏拖拽宽度被钳制在 [264, 420] 区间，用户无法把左侧边栏缩到 264px 以下。
将 `SIDEBAR_MIN`/`SIDEBAR_MAX` 从 264/420 调整为 80/400，允许更灵活的布局（如窄窗口下把边栏收得更小）。

The sidebar drag width was clamped to [264, 420], preventing users from collapsing the sidebar below 264px. Lowered `SIDEBAR_MIN`/`SIDEBAR_MAX` from 264/420 to 80/400 for a more flexible layout.

## Related Issues / 关联 Issue

N/A

## Type / 类型

- [x] Feature / 新功能

## Platforms / 影响平台

- [x] Windows installer / Windows 安装包
- [x] Windows portable ZIP / Windows 便携版 ZIP
- [x] macOS Apple Silicon
- [x] macOS Intel
- [x] macOS Universal package / macOS 通用安装包
- [x] Linux
- [x] Not platform-specific / 与平台无关

## Verification / 验证

- [x] `corepack yarn workspace dsh-plugin-desktop vitest run tests/client-environment.spec.ts` — 20/20 通过
- [x] `corepack yarn workspace dsh-plugin-desktop test` — 949 passed（13 个失败均为 Windows symlink 权限环境问题，与本次改动无关）
- [x] `corepack yarn workspace dsh-plugin-desktop typecheck` — 通过
- [x] Manual test / 人工测试 — 在已安装的 DSH Desktop 上直接改包验证：侧边栏可拖到 80px（原版最小 264px）

## Release Notes / 发布说明

侧边栏宽度可调范围扩大至 80–400px / Sidebar width range widened to 80–400px