### PR TITLE
fix(desktop): launch packaged Windows executables from the unpacked tree

### DIFF
--- a/dsh-plugin-desktop/src/windows-subprocess.ts
+++ b/dsh-plugin-desktop/src/windows-subprocess.ts
@@ -4,6 +4,8 @@ import { statSync } from 'node:fs'
 import { fileURLToPath } from 'node:url'
 import { win32 } from 'node:path'
 import type {
+  SubprocessHandle,
+  SubprocessSpawnSpec,
   SubprocessTerminalHandle,
   SubprocessTerminalSpawnSpec,
 } from '@deepseek-ai/dsh-subprocess'
@@ -47,6 +49,55 @@ function systemRootOf(env: NodeJS.ProcessEnv): string | undefined {
 
 function sameWindowsPath(left: string, right: string): boolean {
   return win32.normalize(left).toUpperCase() === win32.normalize(right).toUpperCase()
+}
+
+function fullyQualifiedWindowsRoot(path: string): string | undefined {
+  const root = win32.normalize(win32.parse(path).root)
+  // Extended/device namespaces do not share node:path's lexical `..`
+  // normalization contract with CreateProcess. Preserve them verbatim.
+  if (/^\\\\[?.]\\/u.test(root)) return undefined
+  if (/^[A-Z]:\\$/iu.test(root)) return root
+  if (/^\\\\[^\\]+\\[^\\]+\\$/u.test(root)) return root
+  return undefined
+}
+
+/** Adapt an ordinary packaged spawn without mutating the caller-owned spec. */
+export function adaptWindowsPackagedExecutableSpawn(
+  spec: SubprocessSpawnSpec,
+  platform: NodeJS.Platform,
+  resourcesPath: string | undefined,
+): SubprocessSpawnSpec {
+  const executable = spec.argv[0]
+  if (platform !== 'win32'
+    || resourcesPath === undefined
+    || resourcesPath.length === 0
+    || executable === undefined) return spec
+
+  // argv[0] may legitimately be relative to spec.cwd. Never reinterpret a
+  // bare, drive-relative, or root-relative command against this host process.
+  const resourcesRoot = fullyQualifiedWindowsRoot(resourcesPath)
+  const executableRoot = fullyQualifiedWindowsRoot(executable)
+  if (resourcesRoot === undefined
+    || executableRoot === undefined
+    || !sameWindowsPath(resourcesRoot, executableRoot)) return spec
+
+  // Anchor the archive segment to Electron's actual resources directory. A
+  // broad first-segment replacement can redirect the wrong path when an
+  // installation parent is itself named app.asar.
+  const archiveRoot = win32.join(resourcesPath, 'app.asar')
+  const relative = win32.relative(archiveRoot, executable)
+  if (relative.length === 0
+    || win32.isAbsolute(relative)
+    || relative === '..'
+    || relative.startsWith(`..${win32.sep}`)) return spec
+
+  return {
+    ...spec,
+    argv: [
+      win32.join(resourcesPath, 'app.asar.unpacked', relative),
+      ...spec.argv.slice(1),
+    ],
+  }
 }
 
 /** Match only the official persistent-terminal argv when it falls back to Windows PowerShell 5.1. */
@@ -139,6 +190,14 @@ export function adaptWindowsAclTerminalSpawn(
 
 /** Official local subprocess provider with the Electron ACL terminal launch repaired through cmd-owned ConPTY. */
 export class DesktopWindowsSubprocess extends LocalSubprocessRuntime {
+  override spawn(spec: SubprocessSpawnSpec): SubprocessHandle {
+    return super.spawn(adaptWindowsPackagedExecutableSpawn(
+      spec,
+      process.platform,
+      process.resourcesPath,
+    ))
+  }
+
   override spawnTerminal(spec: SubprocessTerminalSpawnSpec): Promise<SubprocessTerminalHandle> {
     return super.spawnTerminal(adaptWindowsAclTerminalSpawn(spec, {
       platform: process.platform,

--- a/dsh-plugin-desktop/tests/windows-subprocess.spec.ts
+++ b/dsh-plugin-desktop/tests/windows-subprocess.spec.ts
@@ -1,8 +1,15 @@
 import { Buffer } from 'node:buffer'
-import type { SubprocessTerminalSpawnSpec } from '@deepseek-ai/dsh-subprocess'
-import { describe, expect, it } from 'vitest'
+import type {
+  SubprocessHandle,
+  SubprocessSpawnSpec,
+  SubprocessTerminalSpawnSpec,
+} from '@deepseek-ai/dsh-subprocess'
+import { LocalSubprocessRuntime } from '@deepseek-ai/dsh-subprocess-local'
+import { describe, expect, it, vi } from 'vitest'
 import {
+  adaptWindowsPackagedExecutableSpawn,
   adaptWindowsAclTerminalSpawn,
+  DesktopWindowsSubprocess,
   desktopWindowsCommandPath,
   isOfficialWindowsPowerShell51Terminal,
   type WindowsAclTerminalAdaptation,
@@ -41,6 +48,146 @@ function terminalSpec(argv: readonly string[], env?: Record<string, string>): Su
     graceMs: 1_000,
   }
 }
+
+const desktopResourcesPath = 'C:\\Program Files\\DSH Desktop\\resources'
+const packagedRipgrep = `${desktopResourcesPath}\\app.asar\\node_modules\\@vscode\\ripgrep\\bin\\rg.exe`
+const unpackedRipgrep = `${desktopResourcesPath}\\app.asar.unpacked\\node_modules\\@vscode\\ripgrep\\bin\\rg.exe`
+
+function ordinarySpec(argv: readonly string[]): SubprocessSpawnSpec {
+  return {
+    argv,
+    cwd: 'C:\\workspace',
+    stdio: {
+      stdin: 'ignore',
+      stdout: { maxBytes: 16_384 },
+      stderr: { maxBytes: 16_384 },
+    },
+    graceMs: 2_000,
+    signal: new AbortController().signal,
+    env: { KEEP: 'value' },
+  }
+}
+
+describe('Windows packaged ordinary subprocess paths (#660)', () => {
+  it('maps only argv[0] from the real app.asar into its physical unpacked tree', () => {
+    const spec = ordinarySpec([packagedRipgrep, '--glob', packagedRipgrep])
+
+    const result = adaptWindowsPackagedExecutableSpawn(spec, 'win32', desktopResourcesPath)
+
+    expect(result).not.toBe(spec)
+    expect(result.argv).toEqual([unpackedRipgrep, '--glob', packagedRipgrep])
+    expect(result.argv).not.toBe(spec.argv)
+    expect(result.cwd).toBe(spec.cwd)
+    expect(result.stdio).toBe(spec.stdio)
+    expect(result.graceMs).toBe(spec.graceMs)
+    expect(result.signal).toBe(spec.signal)
+    expect(result.env).toBe(spec.env)
+    expect(spec.argv).toEqual([packagedRipgrep, '--glob', packagedRipgrep])
+  })
+
+  it('anchors the real archive even when an installation parent is also named app.asar', () => {
+    const resourcesPath = 'C:\\app.asar\\DSH Desktop\\resources'
+    const executable = `${resourcesPath}\\app.asar\\node_modules\\@vscode\\ripgrep\\bin\\rg.exe`
+
+    const result = adaptWindowsPackagedExecutableSpawn(
+      ordinarySpec([executable]),
+      'win32',
+      resourcesPath,
+    )
+
+    expect(result.argv[0]).toBe(
+      `${resourcesPath}\\app.asar.unpacked\\node_modules\\@vscode\\ripgrep\\bin\\rg.exe`,
+    )
+  })
+
+  it('matches the anchored archive case-insensitively', () => {
+    const executable = 'c:\\program files\\dsh desktop\\RESOURCES\\APP.ASAR\\node_modules\\@vscode\\ripgrep\\bin\\rg.exe'
+
+    const result = adaptWindowsPackagedExecutableSpawn(
+      ordinarySpec([executable]),
+      'win32',
+      desktopResourcesPath,
+    )
+
+    expect(result.argv[0]).toBe(unpackedRipgrep)
+  })
+
+  it('maps a fully qualified UNC executable on the same share', () => {
+    const resourcesPath = '\\\\build-server\\dsh-share\\DSH Desktop\\resources'
+    const executable = `${resourcesPath}\\app.asar\\node_modules\\@vscode\\ripgrep\\bin\\rg.exe`
+
+    const result = adaptWindowsPackagedExecutableSpawn(
+      ordinarySpec([executable]),
+      'win32',
+      resourcesPath,
+    )
+
+    expect(result.argv[0]).toBe(
+      `${resourcesPath}\\app.asar.unpacked\\node_modules\\@vscode\\ripgrep\\bin\\rg.exe`,
+    )
+  })
+
+  it.each([
+    ['already unpacked', unpackedRipgrep, 'win32' as const],
+    ['archive backup', `${desktopResourcesPath}\\app.asar.backup\\node_modules\\rg.exe`, 'win32' as const],
+    ['lookalike archive', `${desktopResourcesPath}\\my-app.asar\\node_modules\\rg.exe`, 'win32' as const],
+    ['unrelated archive', 'D:\\other\\app.asar\\node_modules\\rg.exe', 'win32' as const],
+    ['plain executable', 'C:\\tools\\rg.exe', 'win32' as const],
+    ['bare relative executable', 'resources\\app.asar\\node_modules\\rg.exe', 'win32' as const],
+    ['drive-relative executable', 'C:resources\\app.asar\\node_modules\\rg.exe', 'win32' as const],
+    ['root-relative executable', '\\Program Files\\DSH Desktop\\resources\\app.asar\\node_modules\\rg.exe', 'win32' as const],
+    ['archive escape', `${desktopResourcesPath}\\app.asar\\..\\outside\\rg.exe`, 'win32' as const],
+    ['non-Windows', packagedRipgrep, 'darwin' as const],
+  ])('leaves %s unchanged by identity', (_label, executable, platform) => {
+    const spec = ordinarySpec([executable, '--files'])
+
+    const result = adaptWindowsPackagedExecutableSpawn(spec, platform, desktopResourcesPath)
+
+    expect(result).toBe(spec)
+  })
+
+  it.each([
+    ['extended device', '\\\\?\\C:\\Program Files\\DSH Desktop\\resources'],
+    ['local device', '\\\\.\\C:\\Program Files\\DSH Desktop\\resources'],
+  ])('leaves a %s namespace unchanged by identity', (_label, resourcesPath) => {
+    const executable = `${resourcesPath}\\app.asar\\node_modules\\@vscode\\ripgrep\\bin\\rg.exe`
+    const spec = ordinarySpec([executable, '--files'])
+
+    const result = adaptWindowsPackagedExecutableSpawn(spec, 'win32', resourcesPath)
+
+    expect(result).toBe(spec)
+  })
+
+  it('leaves an empty argv unchanged', () => {
+    const spec = ordinarySpec([])
+    expect(adaptWindowsPackagedExecutableSpawn(spec, 'win32', desktopResourcesPath)).toBe(spec)
+  })
+
+  it('routes the class spawn override through the packaged-path adapter', () => {
+    const platformDescriptor = Object.getOwnPropertyDescriptor(process, 'platform')
+    const resourcesDescriptor = Object.getOwnPropertyDescriptor(process, 'resourcesPath')
+    const handle = {} as SubprocessHandle
+    const baseSpawn = vi.spyOn(LocalSubprocessRuntime.prototype, 'spawn').mockReturnValue(handle)
+    try {
+      Object.defineProperty(process, 'platform', { configurable: true, value: 'win32' })
+      Object.defineProperty(process, 'resourcesPath', { configurable: true, value: desktopResourcesPath })
+      const runtime = Object.create(DesktopWindowsSubprocess.prototype) as DesktopWindowsSubprocess
+      const spec = ordinarySpec([packagedRipgrep, '--files'])
+
+      expect(runtime.spawn(spec)).toBe(handle)
+      expect(baseSpawn).toHaveBeenCalledOnce()
+      expect(baseSpawn.mock.calls[0]?.[0].argv).toEqual([unpackedRipgrep, '--files'])
+    } finally {
+      baseSpawn.mockRestore()
+      if (platformDescriptor !== undefined) Object.defineProperty(process, 'platform', platformDescriptor)
+      if (resourcesDescriptor !== undefined) {
+        Object.defineProperty(process, 'resourcesPath', resourcesDescriptor)
+      } else {
+        Reflect.deleteProperty(process, 'resourcesPath')
+      }
+    }
+  })
+})
 
 describe('Windows Electron persistent-terminal relay', () => {
   it('routes only the exact ACL runner through a cmd-owned ConPTY', () => {


### PR DESCRIPTION
## Summary / 摘要

The Windows Desktop package exposes `@vscode/ripgrep` through a logical path inside `app.asar`, but ordinary native process launch cannot execute that path. As a result, the built-in `grep` and `glob` tools fail with `ENOENT` in installed and portable 2.0.3 builds.

This patch repairs that at the Desktop-owned subprocess boundary:

- map only a fully qualified Windows `argv[0]` below the exact `process.resourcesPath\app.asar` root to the sibling `app.asar.unpacked` tree;
- preserve every argument and every other `SubprocessSpawnSpec` field/reference;
- leave non-Windows, relative/root-relative/drive-relative, cross-volume, already-unpacked, lookalike, traversal, and Win32 device-namespace paths unchanged;
- anchor matching to the real Electron resources directory, including ordinary UNC shares, so an installation parent named `app.asar` cannot redirect the wrong segment.

The pinned `deepseek-harness/` submodule is unchanged.

## Related Issues / 关联 Issue

Fixes #660.
Fixes #655.

## Type / 类型

- [x] Bug fix / 问题修复
- [ ] Feature / 新功能
- [ ] Documentation / 文档
- [ ] Release or packaging / 发布或打包
- [ ] Tests only / 仅测试
- [ ] Other / 其他

## Platforms / 影响平台

- [x] Windows installer / Windows 安装包
- [x] Windows portable ZIP / Windows 便携版 ZIP
- [ ] macOS Apple Silicon
- [ ] macOS Intel
- [ ] macOS Universal package / macOS 通用安装包
- [ ] Linux
- [ ] Not platform-specific / 与平台无关

## Verification / 验证

- [x] `corepack yarn check:layout` (passed during the full gate)
- [ ] `corepack yarn typecheck`
- [ ] `corepack yarn test`
- [ ] `corepack yarn check`
- [x] Platform package smoke / 平台打包或启动冒烟
- [ ] Manual test / 人工测试

Commands actually run:

- `corepack yarn workspace dsh-plugin-desktop vitest run tests/windows-subprocess.spec.ts` — 48/48 passed. The initial no-op adapter produced the expected red result: 3 failed / 37 passed.
- `corepack yarn workspace dsh-plugin-desktop typecheck` — passed.
- `corepack yarn workspace dsh-plugin-desktop check:win-package` — build/typecheck passed; 243/243 Windows package tests passed; runtime closure verified 201 first-party nodes.
- `corepack yarn workspace dsh-plugin-desktop exec electron-builder --dir --config.npmRebuild=false` — completed a real unpacked Windows layout. An adapter smoke then mapped the logical `resources\app.asar\...\rg.exe` request to the generated `resources\app.asar.unpacked\...\rg.exe`, preserved the caller-owned spec, and launched that bundled executable successfully (`ripgrep 15.0.0`, exit 0).
- `corepack yarn workspace dsh-plugin-desktop package:dir` — application build passed, but the canonical native-dependency rebuild stopped with `MSB8040` because this host lacks Visual Studio's Spectre-mitigated C++ libraries. This environment-limited command is not claimed as a pass.
- `corepack yarn check` — ran through layout, Fabric/Market checks, Market's 268 tests, and Desktop build; Desktop's full test phase then reproduced four failures in three existing, untouched test files (`client-runtime-startup-restore`, `lifecycle-events`, and `recovery-plugin-uninstall`). Each also reproduces when run alone and none imports or reaches this two-file subprocess change, so they are reported here rather than hidden.
- `git diff --check` — passed.
- Independent exact-diff path/security review — publish verdict after relative-path and device-namespace edge cases were added and verified.

No packaged GUI session was claimed as manually tested.

## Release Notes / 发布说明

Windows packaged builds can launch the physical unpacked ripgrep executable used by the built-in `grep` and `glob` tools instead of failing on the logical `app.asar` path.
