### PR TITLE
fix(desktop): 正确识别配置的图片输入能力

### DIFF
--- a/.yarn/patches/@deepseek-ai-dsh-llm-pi-ai-npm-0.1.1-rc.2-bc3be41a56.patch
+++ b/.yarn/patches/@deepseek-ai-dsh-llm-pi-ai-npm-0.1.1-rc.2-bc3be41a56.patch
@@ -1,0 +1,21 @@
+diff --git a/lib/index.js b/lib/index.js
+index b819f847403e2bd76a7c04518da4652562a7a791..0370c48148039cd277c7ccda0cd0d9c4e355a160 100644
+--- a/lib/index.js
++++ b/lib/index.js
+@@ -648,7 +648,7 @@ function resolveRouteModels(request) {
+ 			api,
+ 			provider,
+ 			baseUrl,
+-			input: declaredInput(entry.input) ?? base?.input ?? [...request.defaultInput],
++			input: declaredInput(entry.input) ?? declaredInput(entry.inputModalities) ?? base?.input ?? [...request.defaultInput],
+ 			cost: base?.cost ?? NO_COST,
+ 			contextWindow,
+ 			maxTokens,
+@@ -920,6 +920,7 @@ const modelFields = {
+ 	contextWindow: z.number().step(1).min(1),
+ 	maxTokens: z.number().step(1).min(1),
+ 	input: z.array(z.union(MODALITIES)),
++	inputModalities: z.array(z.union(MODALITIES)),
+ 	reasoningEfforts: z.union([z.const(false), reasoningEfforts]),
+ 	compat: compatProfile
+ };

--- a/dsh-plugin-desktop/tests/package.spec.ts
+++ b/dsh-plugin-desktop/tests/package.spec.ts
@@ -429,6 +429,26 @@ describe('published package surface', () => {
     expect(installedTypes).toContain("inputModalities?: readonly ('text' | 'image')[];")
   })
 
+  it('accepts Desktop model modality settings as pi-ai input overrides', () => {
+    const patchPath = '~/.yarn/patches/@deepseek-ai-dsh-llm-pi-ai-npm-0.1.1-rc.2-bc3be41a56.patch'
+    expect(workspaceManifest.resolutions).toMatchObject({
+      '@deepseek-ai/dsh-llm-pi-ai@npm:0.1.1-rc.2': expect.stringContaining(patchPath),
+      '@deepseek-ai/dsh-llm-pi-ai@npm:^0.1.1-rc.2': expect.stringContaining(patchPath),
+    })
+    const patch = readFileSync(new URL(patchPath.slice(2), workspaceRoot), 'utf8')
+    const installedRuntime = readFileSync(new URL(
+      'node_modules/@deepseek-ai/dsh-llm-pi-ai/lib/index.js',
+      packageRoot,
+    ), 'utf8')
+    const aliasSchemaMarker = 'inputModalities: z.array(z.union(MODALITIES))'
+    const resolutionMarker = 'declaredInput(entry.input) ?? declaredInput(entry.inputModalities)'
+
+    expect(patch).toContain(aliasSchemaMarker)
+    expect(patch).toContain(resolutionMarker)
+    expect(installedRuntime).toContain('inputModalities:')
+    expect(installedRuntime).toContain(resolutionMarker)
+  })
+
   it('localizes Trajectory toolbar labels in Simplified Chinese', () => {
     const patchPath = './patches/dsh-client-ui-trajectory@0.1.1-rc.2.patch'
     expect(workspaceManifest.resolutions).toMatchObject({

--- a/package.json
+++ b/package.json
@@ -53,7 +53,9 @@
     "dshmarket@npm:1.17.1": "patch:dshmarket@npm%3A1.17.1#./.yarn/patches/dshmarket-npm-1.17.1-d9fe6da08c.patch",
     "koffi@npm:^3.1.0": "3.1.5",
     "@deepseek-ai/dsh-client-ui-settings-general@npm:0.1.1-rc.2": "patch:@deepseek-ai/dsh-client-ui-settings-general@npm%3A0.1.1-rc.2#./.yarn/patches/@deepseek-ai-dsh-client-ui-settings-general-npm-0.1.1-rc.2-ef120ba0cf.patch",
-    "@deepseek-ai/dsh-client-ui-settings-general@npm:^0.1.1-rc.2": "patch:@deepseek-ai/dsh-client-ui-settings-general@npm%3A0.1.1-rc.2#./.yarn/patches/@deepseek-ai-dsh-client-ui-settings-general-npm-0.1.1-rc.2-ef120ba0cf.patch"
+    "@deepseek-ai/dsh-client-ui-settings-general@npm:^0.1.1-rc.2": "patch:@deepseek-ai/dsh-client-ui-settings-general@npm%3A0.1.1-rc.2#./.yarn/patches/@deepseek-ai-dsh-client-ui-settings-general-npm-0.1.1-rc.2-ef120ba0cf.patch",
+    "@deepseek-ai/dsh-llm-pi-ai@npm:0.1.1-rc.2": "patch:@deepseek-ai/dsh-llm-pi-ai@npm%3A0.1.1-rc.2#~/.yarn/patches/@deepseek-ai-dsh-llm-pi-ai-npm-0.1.1-rc.2-bc3be41a56.patch",
+    "@deepseek-ai/dsh-llm-pi-ai@npm:^0.1.1-rc.2": "patch:@deepseek-ai/dsh-llm-pi-ai@npm%3A0.1.1-rc.2#~/.yarn/patches/@deepseek-ai-dsh-llm-pi-ai-npm-0.1.1-rc.2-bc3be41a56.patch"
   },
   "dependenciesMeta": {
     "@deepseek-ai/dsh-subprocess-local": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2884,7 +2884,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@deepseek-ai/dsh-llm-pi-ai@npm:^0.1.1-rc.2":
+"@deepseek-ai/dsh-llm-pi-ai@npm:0.1.1-rc.2":
   version: 0.1.1-rc.2
   resolution: "@deepseek-ai/dsh-llm-pi-ai@npm:0.1.1-rc.2"
   dependencies:
@@ -2901,6 +2901,26 @@ __metadata:
     "@deepseek-ai/dsh-settings": ^0.1.1-rc.2
     "@deepseek-ai/dsh-timeout": ^0.1.1-rc.2
   checksum: 10c0/bbac1d7eca4c38e3c3e40e4cb297971e0174fad223484871351a602040ae03d1e91d28d30af3b13c8e756849d115a4fd9063438ba4a741aeb745e212613a9cb4
+  languageName: node
+  linkType: hard
+
+"@deepseek-ai/dsh-llm-pi-ai@patch:@deepseek-ai/dsh-llm-pi-ai@npm%3A0.1.1-rc.2#~/.yarn/patches/@deepseek-ai-dsh-llm-pi-ai-npm-0.1.1-rc.2-bc3be41a56.patch":
+  version: 0.1.1-rc.2
+  resolution: "@deepseek-ai/dsh-llm-pi-ai@patch:@deepseek-ai/dsh-llm-pi-ai@npm%3A0.1.1-rc.2#~/.yarn/patches/@deepseek-ai-dsh-llm-pi-ai-npm-0.1.1-rc.2-bc3be41a56.patch::version=0.1.1-rc.2&hash=3e02dc"
+  dependencies:
+    "@deepseek-ai/schemastery": "npm:^3.18.1"
+    "@earendil-works/pi-ai": "npm:^0.82.1"
+  peerDependencies:
+    "@deepseek-ai/cordis": ^4.0.1
+    "@deepseek-ai/dsh-attachment": ^0.1.1-rc.2
+    "@deepseek-ai/dsh-authorization": ^0.1.1-rc.2
+    "@deepseek-ai/dsh-credentials": ^0.1.1-rc.2
+    "@deepseek-ai/dsh-invariants": ^0.1.1-rc.2
+    "@deepseek-ai/dsh-launch-environment": ^0.1.1-rc.2
+    "@deepseek-ai/dsh-llm": ^0.1.1-rc.2
+    "@deepseek-ai/dsh-settings": ^0.1.1-rc.2
+    "@deepseek-ai/dsh-timeout": ^0.1.1-rc.2
+  checksum: 10c0/80c769210497c41aaca84c5e5f19c99a3d3e332511e7fcc122773fbb11c2b1a379d7a626326ba4409cdea204498e685ba08af77934fb3dd48a27ed83618416e0
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## 修改内容
- 将桌面端模型配置保存的 inputModalities 兼容为 pi-ai 运行时模型的输入能力。
- 保持已有 input 配置的优先级不变。
- 补充发布包层面的回归检查。

## 问题背景
桌面设置页已将模型保存为“文本和图片”时，运行时仍可能回退为纯文本能力，导致图片在发送前被本地校验拦截。

## 验证
- 已运行 git diff --check。
- 已运行 yarn install --mode=update-lockfile。
- 针对性 Vitest 已启动，但未能在本地执行时间窗口内完成。