### PR TITLE
fix(desktop): guard node-pty unpacked helper paths

### DIFF
--- a/dsh-plugin-desktop/tests/package.spec.ts
+++ b/dsh-plugin-desktop/tests/package.spec.ts
@@ -1114,6 +1114,48 @@ describe('published package surface', () => {
     expect(installedNsisSingleInstance).not.toContain("$$_.Path.StartsWith('$INSTDIR', 'CurrentCultureIgnoreCase')}).Count")
   })
 
+  it('keeps node-pty spawn-helper rewrites idempotent in unpacked macOS applications', () => {
+    const patchPath = './patches/node-pty@1.2.0-beta.15.patch'
+    const patchResolution = `patch:node-pty@npm%3A1.2.0-beta.15#${patchPath}`
+    const lockfile = readFileSync(new URL('yarn.lock', workspaceRoot), 'utf8')
+    const patch = readFileSync(new URL(patchPath, workspaceRoot), 'utf8')
+    const packageRequire = createRequire(new URL('package.json', packageRoot))
+    const nodePtyManifest = packageRequire.resolve('node-pty/package.json')
+    const installedRuntime = readFileSync(join(dirname(nodePtyManifest), 'lib/unixTerminal.js'), 'utf8')
+
+    expect(workspaceManifest.resolutions).toMatchObject({
+      'node-pty@npm:1.2.0-beta.15': patchResolution,
+    })
+    expect(lockfile).toContain('node-pty@patch:node-pty@npm%3A1.2.0-beta.15#./patches/node-pty@1.2.0-beta.15.patch')
+    for (const marker of [
+      "if (!helperPath.includes('app.asar.unpacked')) {",
+      "if (!helperPath.includes('node_modules.asar.unpacked')) {",
+    ]) {
+      expect(patch).toContain(marker)
+      expect(installedRuntime).toContain(marker)
+    }
+
+    const alreadyUnpacked = '/Applications/DSH Desktop.app/Contents/Resources/app.asar.unpacked/node_modules/node-pty/prebuilds/darwin-arm64/spawn-helper'
+    const packed = alreadyUnpacked.replace('app.asar.unpacked', 'app.asar')
+    const nodeModulesAlreadyUnpacked = '/Applications/DSH Desktop.app/Contents/Resources/app/node_modules.asar.unpacked/node-pty/prebuilds/darwin-arm64/spawn-helper'
+    const nodeModulesPacked = nodeModulesAlreadyUnpacked.replace('node_modules.asar.unpacked', 'node_modules.asar')
+    const resolveHelper = (helperPath: string): string => {
+      if (!helperPath.includes('app.asar.unpacked')) {
+        helperPath = helperPath.replace('app.asar', 'app.asar.unpacked')
+      }
+      if (!helperPath.includes('node_modules.asar.unpacked')) {
+        helperPath = helperPath.replace('node_modules.asar', 'node_modules.asar.unpacked')
+      }
+      return helperPath
+    }
+    expect(resolveHelper(packed)).toBe(alreadyUnpacked)
+    expect(resolveHelper(alreadyUnpacked)).toBe(alreadyUnpacked)
+    expect(resolveHelper(alreadyUnpacked)).not.toContain('app.asar.unpacked.unpacked')
+    expect(resolveHelper(nodeModulesPacked)).toBe(nodeModulesAlreadyUnpacked)
+    expect(resolveHelper(nodeModulesAlreadyUnpacked)).toBe(nodeModulesAlreadyUnpacked)
+    expect(resolveHelper(nodeModulesAlreadyUnpacked)).not.toContain('node_modules.asar.unpacked.unpacked')
+  })
+
   it('starts restricted Windows shells with a hidden console show state', () => {
     const patchResolution = 'patch:@deepseek-ai/dsh-sandbox-windows-acl@npm%3A0.1.1-rc.2#./patches/dsh-sandbox-windows-acl@0.1.1-rc.2.patch'
     const lockfile = readFileSync(new URL('yarn.lock', workspaceRoot), 'utf8')

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   ],
   "resolutions": {
     "app-builder-lib@npm:26.15.7": "patch:app-builder-lib@npm%3A26.15.7#./patches/app-builder-lib@26.15.7.patch",
+    "node-pty@npm:1.2.0-beta.15": "patch:node-pty@npm%3A1.2.0-beta.15#./patches/node-pty@1.2.0-beta.15.patch",
     "@deepseek-ai/dsh-app-boot@npm:0.1.1-rc.2": "patch:@deepseek-ai/dsh-app-boot@npm%3A0.1.1-rc.2#./patches/dsh-app-boot@0.1.1-rc.2.patch",
     "@deepseek-ai/dsh-app-boot@npm:^0.1.1-rc.2": "patch:@deepseek-ai/dsh-app-boot@npm%3A0.1.1-rc.2#./patches/dsh-app-boot@0.1.1-rc.2.patch",
     "@deepseek-ai/dsh-agent-loop@npm:0.1.1-rc.2": "patch:@deepseek-ai/dsh-agent-loop@npm%3A0.1.1-rc.2#./patches/dsh-agent-loop@0.1.1-rc.2.patch",

--- a/patches/node-pty@1.2.0-beta.15.patch
+++ b/patches/node-pty@1.2.0-beta.15.patch
@@ -1,0 +1,17 @@
+diff --git a/lib/unixTerminal.js b/lib/unixTerminal.js
+index 44ad820..6d3cfbf 100644
+--- a/lib/unixTerminal.js
++++ b/lib/unixTerminal.js
+@@ -29,6 +29,10 @@ var native = (0, utils_1.loadNativeModule)('pty');
+ var pty = native.module;
+ var helperPath = native.dir + '/spawn-helper';
+ helperPath = path.resolve(__dirname, helperPath);
+-helperPath = helperPath.replace('app.asar', 'app.asar.unpacked');
+-helperPath = helperPath.replace('node_modules.asar', 'node_modules.asar.unpacked');
++if (!helperPath.includes('app.asar.unpacked')) {
++    helperPath = helperPath.replace('app.asar', 'app.asar.unpacked');
++}
++if (!helperPath.includes('node_modules.asar.unpacked')) {
++    helperPath = helperPath.replace('node_modules.asar', 'node_modules.asar.unpacked');
++}
+ var DEFAULT_FILE = 'sh';

--- a/yarn.lock
+++ b/yarn.lock
@@ -11665,6 +11665,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"node-pty@patch:node-pty@npm%3A1.2.0-beta.15#./patches/node-pty@1.2.0-beta.15.patch::locator=deepseek-harness-desktop%40workspace%3A.":
+  version: 1.2.0-beta.15
+  resolution: "node-pty@patch:node-pty@npm%3A1.2.0-beta.15#./patches/node-pty@1.2.0-beta.15.patch::version=1.2.0-beta.15&hash=8902a9&locator=deepseek-harness-desktop%40workspace%3A."
+  dependencies:
+    node-addon-api: "npm:^7.1.0"
+    node-gyp: "npm:latest"
+  checksum: 10c0/459b5128910287dfd0b3efe6d07a4ac094d60bb4e3b6dfc822d7d636e14e9919107155fc3fb7f2442190cfb5f4f43422e5fd5a6f05c72af31f87e5e0abc9b37a
+  languageName: node
+  linkType: hard
+
 "node-releases@npm:^2.0.53":
   version: 2.0.53
   resolution: "node-releases@npm:2.0.53"


### PR DESCRIPTION
## Summary / 摘要

Patch the bundled `node-pty@1.2.0-beta.15` so Electron spawn-helper path rewrites are idempotent when the module was already resolved through `app.asar.unpacked` (or `node_modules.asar.unpacked`).

This prevents the macOS helper path from becoming `app.asar.unpacked.unpacked/.../spawn-helper`, which currently makes every PTY-backed Bash tool call fail with `posix_spawn failed: No such file or directory`.

The workspace resolution and lockfile pin the patch, and the package-surface regression verifies:

- the root resolution and lock entry;
- the installed `node-pty` runtime contains both guards;
- packed `app.asar` and `node_modules.asar` paths rewrite once;
- already-unpacked paths remain byte-identical and never gain a second `.unpacked` suffix.

This mirrors the behavioral fix under review upstream in microsoft/node-pty#953 for microsoft/node-pty#923, without waiting for an upstream release.

## Related Issues / 关联 Issue

Fixes #671

## Type / 类型

- [x] Bug fix / 问题修复
- [ ] Feature / 新功能
- [ ] Documentation / 文档
- [x] Release or packaging / 发布或打包
- [ ] Tests only / 仅测试
- [ ] Other / 其他

## Platforms / 影响平台

- [ ] Windows installer / Windows 安装包
- [ ] Windows portable ZIP / Windows 便携版 ZIP
- [x] macOS Apple Silicon
- [x] macOS Intel
- [x] macOS Universal package / macOS 通用安装包
- [ ] Linux
- [ ] Not platform-specific / 与平台无关

## Verification / 验证

- [x] `corepack yarn install --immutable`
- [x] `corepack yarn check:layout`
- [x] `corepack yarn typecheck` (through the dedicated macOS package gate)
- [ ] `corepack yarn test`
- [ ] `corepack yarn check`
- [x] Platform package smoke / 平台打包或启动冒烟: `corepack yarn workspace dsh-plugin-desktop run check:mac-package` — 97/97 tests plus 4/4 runtime-closure checks
- [ ] Manual test / 人工测试

Additional verification:

- package-surface suite: 45/45 passing;
- immutable patched locator verified in the installed runtime;
- `verify:notices`: 543 production packages checked;
- `git diff --check`: clean.

The broad repository gate reached 962 passing tests but exits on four unrelated Windows/environment failures: two malformed `file:///C:/C:/...` imports in `client-runtime-startup-restore`, one lifecycle evidence timeout, and one missing-pnpm PATH fixture. The same four failures reproduce unchanged in an independent worktree whose only code delta is the unrelated Windows ripgrep fix from #668.

I could not execute an installed macOS application from this Windows environment. The dedicated macOS package gate is green, but a macOS CI/maintainer smoke test remains the platform confirmation.

## Release Notes / 发布说明

Fix macOS Bash/PTY tool startup when `node-pty` is loaded through the Desktop profile symlink into an already-unpacked Electron archive.