### PR TITLE
fix(llm-pi-ai): accept inputModalities as alias for per-model input

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,8 @@
     "dsh-community-market"
   ],
   "resolutions": {
+    "@deepseek-ai/dsh-llm-pi-ai@npm:0.1.1-rc.2": "patch:@deepseek-ai/dsh-llm-pi-ai@npm%3A0.1.1-rc.2#./patches/dsh-llm-pi-ai-input-modalities-alias@0.1.1-rc.2.patch",
+    "@deepseek-ai/dsh-llm-pi-ai@npm:^0.1.1-rc.2": "patch:@deepseek-ai/dsh-llm-pi-ai@npm%3A0.1.1-rc.2#./patches/dsh-llm-pi-ai-input-modalities-alias@0.1.1-rc.2.patch",
     "app-builder-lib@npm:26.15.7": "patch:app-builder-lib@npm%3A26.15.7#./patches/app-builder-lib@26.15.7.patch",
     "@deepseek-ai/dsh-app-boot@npm:0.1.1-rc.2": "patch:@deepseek-ai/dsh-app-boot@npm%3A0.1.1-rc.2#./patches/dsh-app-boot@0.1.1-rc.2.patch",
     "@deepseek-ai/dsh-app-boot@npm:^0.1.1-rc.2": "patch:@deepseek-ai/dsh-app-boot@npm%3A0.1.1-rc.2#./patches/dsh-app-boot@0.1.1-rc.2.patch",

--- a/patches/dsh-llm-pi-ai-input-modalities-alias@0.1.1-rc.2.patch
+++ b/patches/dsh-llm-pi-ai-input-modalities-alias@0.1.1-rc.2.patch
@@ -1,0 +1,20 @@
+diff --git a/lib/index.js b/lib/index.js
+@@ -648,7 +648,7 @@
+ 			api,
+ 			provider,
+ 			baseUrl,
+-			input: declaredInput(entry.input) ?? base?.input ?? [...request.defaultInput],
++			input: declaredInput(entry.input) ?? declaredInput(entry.inputModalities) ?? declaredInput(base?.input) ?? declaredInput(base?.inputModalities) ?? [...request.defaultInput],
+ 			cost: base?.cost ?? NO_COST,
+ 			contextWindow,
+ 			maxTokens,
+@@ -919,7 +919,8 @@
+ 	name: z.string(),
+ 	contextWindow: z.number().step(1).min(1),
+ 	maxTokens: z.number().step(1).min(1),
+-	input: z.array(z.union(MODALITIES)),
++	input: z.array(z.union(MODALITIES)).default([]),
++	inputModalities: z.array(z.union(MODALITIES)).default([]),
+ 	reasoningEfforts: z.union([z.const(false), reasoningEfforts]),
+ 	compat: compatProfile
+ };


### PR DESCRIPTION
## 为什么

桌面端模型目录(配合 `dsh-host-apiproxy-model-modalities` 补丁)对外输出的字段名是 **`inputModalities`**,但 `dsh-llm-pi-ai` 解析 per-model 配置时只读 **`input`**。

于是用户在 settings 里声明 `inputModalities: [text, image]` 会被静默忽略,
回落为默认的 `["text"]`,发送图片时触发:

```
MODEL_DOES_NOT_SUPPORT_IMAGES
当前模型不支持图片，请切换支持图片的模型
```

## 改了什么

- schema: `input` 改为 `.default([])`,新增同类型的 `inputModalities` 字段作为别名
- 消费链:改为
  `entry.input ?? entry.inputModalities ?? base.input ?? base.inputModalities ?? defaultInput`
- 注册 `@deepseek-ai/dsh-llm-pi-ai@0.1.1-rc.2` 的 yarn patch resolution

优先级保持:原生 `input` > 别名 `inputModalities` > 目录 `base.input` > 目录别名 > 路由默认。

## 验证

用 `resolveProfiles()` 直接驱动真实管线做了冒烟测试：

| 用例 | 配置 | 结果 |
|---|---|---|
| A | 只写 `inputModalities: [text,image]` | `input == ["text","image"]` ✅ |
| B | 两个都不写 | `input == ["text"]`(回落默认) ✅ |
| C | `input` 与 `inputModalities` 同时写 | 原生 `input` 优先 ✅ |

`node --check` 语法校验通过。
