### PR TITLE
fix: accept same-mode sandbox permission requests

### DIFF
--- a/dsh-plugin-desktop/tests/package.spec.ts
+++ b/dsh-plugin-desktop/tests/package.spec.ts
@@ -14,6 +14,7 @@ import { tmpdir } from 'node:os'
 import { dirname, join } from 'node:path'
 import { fileURLToPath, pathToFileURL } from 'node:url'
 import sharp from 'sharp'
+import { approveEscalation } from '@deepseek-ai/dsh-sandbox'
 import { describe, expect, it } from 'vitest'
 
 const packageRoot = new URL('../', import.meta.url)
@@ -1141,5 +1142,44 @@ describe('published package surface', () => {
     expect(installedRuntime).toContain('api.createProcessAsUserW(token, null, commandLine, null, null, 1, 0, null')
     expect(installedRuntime).toContain('api.createProcessAsUserW(token, null, commandLine, null, null, 1, 4, null')
     expect(installedRuntime).not.toContain('134217728')
+  })
+
+  it('treats an already-effective sandbox permission as an unprompted no-op', async () => {
+    const patchPath = './patches/dsh-sandbox@0.1.1-rc.2.patch'
+    const patchResolution = `patch:@deepseek-ai/dsh-sandbox@npm%3A0.1.1-rc.2#${patchPath}`
+    const lockfile = readFileSync(new URL('yarn.lock', workspaceRoot), 'utf8')
+    const patch = readFileSync(new URL(patchPath, workspaceRoot), 'utf8')
+
+    expect(workspaceManifest.resolutions).toMatchObject({
+      '@deepseek-ai/dsh-sandbox@npm:0.1.1-rc.2': patchResolution,
+      '@deepseek-ai/dsh-sandbox@npm:^0.1.1-rc.2': patchResolution,
+    })
+    expect(lockfile).toContain('@deepseek-ai/dsh-sandbox@patch:@deepseek-ai/dsh-sandbox@npm%3A0.1.1-rc.2#./patches/dsh-sandbox@0.1.1-rc.2.patch')
+    expect(patch).toContain('+\tif (mode === effectiveMode) return effectiveMode;')
+
+    const granted = await approveEscalation({
+      requestedMode: 'danger-full-access',
+      effectiveMode: 'danger-full-access',
+      justification: 'the model repeated the active mode',
+      subject: 'command',
+    }, {
+      approver: undefined,
+      agent: undefined,
+      callId: 'same-mode',
+      toolName: 'bash',
+    })
+    expect(granted).toBe('danger-full-access')
+
+    await expect(approveEscalation({
+      requestedMode: 'workspace-write',
+      effectiveMode: 'danger-full-access',
+      justification: 'this request is narrower',
+      subject: 'command',
+    }, {
+      approver: undefined,
+      agent: undefined,
+      callId: 'narrower-mode',
+      toolName: 'bash',
+    })).rejects.toThrow('not strictly wider')
   })
 })

--- a/package.json
+++ b/package.json
@@ -22,6 +22,8 @@
     "@deepseek-ai/dsh-host-apiproxy@npm:0.1.1-rc.2": "patch:@deepseek-ai/dsh-host-apiproxy@npm%3A0.1.1-rc.2#./patches/dsh-host-apiproxy-model-modalities@0.1.1-rc.2.patch",
     "@deepseek-ai/dsh-host-apiproxy@npm:^0.1.1-rc.2": "patch:@deepseek-ai/dsh-host-apiproxy@npm%3A0.1.1-rc.2#./patches/dsh-host-apiproxy-model-modalities@0.1.1-rc.2.patch",
     "@deepseek-ai/dsh-llm-deepseek@npm:^0.1.1-rc.2": "patch:@deepseek-ai/dsh-llm-deepseek@npm%3A0.1.1-rc.2#./patches/dsh-llm-deepseek@0.1.1-rc.2.patch",
+    "@deepseek-ai/dsh-sandbox@npm:0.1.1-rc.2": "patch:@deepseek-ai/dsh-sandbox@npm%3A0.1.1-rc.2#./patches/dsh-sandbox@0.1.1-rc.2.patch",
+    "@deepseek-ai/dsh-sandbox@npm:^0.1.1-rc.2": "patch:@deepseek-ai/dsh-sandbox@npm%3A0.1.1-rc.2#./patches/dsh-sandbox@0.1.1-rc.2.patch",
     "@deepseek-ai/dsh-sandbox-windows-acl@npm:0.1.1-rc.2": "patch:@deepseek-ai/dsh-sandbox-windows-acl@npm%3A0.1.1-rc.2#./patches/dsh-sandbox-windows-acl@0.1.1-rc.2.patch",
     "@deepseek-ai/dsh-sandbox-windows-acl@npm:^0.1.1-rc.2": "patch:@deepseek-ai/dsh-sandbox-windows-acl@npm%3A0.1.1-rc.2#./patches/dsh-sandbox-windows-acl@0.1.1-rc.2.patch",
     "@deepseek-ai/dsh-client-ui-directory-picker-browse@npm:0.1.1-rc.2": "patch:@deepseek-ai/dsh-client-ui-directory-picker-browse@npm%3A0.1.1-rc.2#./patches/dsh-client-ui-directory-picker-browse@0.1.1-rc.2.patch",

--- a/patches/dsh-sandbox@0.1.1-rc.2.patch
+++ b/patches/dsh-sandbox@0.1.1-rc.2.patch
@@ -1,0 +1,11 @@
+diff --git a/lib/index.js b/lib/index.js
+--- a/lib/index.js
++++ b/lib/index.js
+@@ -91,6 +91,7 @@
+ */
+ async function approveEscalation(request, approval) {
+ 	const { requestedMode: mode, effectiveMode, justification, subject } = request;
++	if (mode === effectiveMode) return effectiveMode;
+ 	if (!(WIDER_MODES[effectiveMode] ?? []).includes(mode)) throw new Error(`sandbox escalation to "${mode}" is not strictly wider than this call's current "${effectiveMode}" mode`);
+ 	if (approval.approver === void 0) throw new Error(`sandbox escalation to "${mode}" requires approval, but no approval service is composed`);
+ 	if (approval.agent === void 0) throw new Error(`sandbox escalation to "${mode}" requires approval, but the call has no agent to route it through`);

--- a/yarn.lock
+++ b/yarn.lock
@@ -3164,6 +3164,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@deepseek-ai/dsh-sandbox@patch:@deepseek-ai/dsh-sandbox@npm%3A0.1.1-rc.2#./patches/dsh-sandbox@0.1.1-rc.2.patch::locator=deepseek-harness-desktop%40workspace%3A.":
+  version: 0.1.1-rc.2
+  resolution: "@deepseek-ai/dsh-sandbox@patch:@deepseek-ai/dsh-sandbox@npm%3A0.1.1-rc.2#./patches/dsh-sandbox@0.1.1-rc.2.patch::version=0.1.1-rc.2&hash=d1ca54&locator=deepseek-harness-desktop%40workspace%3A."
+  peerDependencies:
+    "@deepseek-ai/cordis": ^4.0.1
+    "@deepseek-ai/dsh-invariants": ^0.1.1-rc.2
+    "@deepseek-ai/dsh-llm": ^0.1.1-rc.2
+    "@deepseek-ai/dsh-session": ^0.1.1-rc.2
+  checksum: 10c0/5672d0a7be6c08e2811329bfd68952d4be20d595c3f3f3186182a75ad5d014aedce65e0200a8ab7be16c2942c4e5b8ea20094b6eec75eb641718076e37faa919
+  languageName: node
+  linkType: hard
+
 "@deepseek-ai/dsh-schedule@npm:^0.1.1-rc.2":
   version: 0.1.1-rc.2
   resolution: "@deepseek-ai/dsh-schedule@npm:0.1.1-rc.2"


### PR DESCRIPTION
## Summary

- patch the pinned `@deepseek-ai/dsh-sandbox@0.1.1-rc.2` runtime so requesting the already-effective sandbox mode is idempotent
- preserve the existing fail-closed behavior for narrowing or unknown modes and approval for actual widening
- pin both exact and caret dependency resolutions to the patch and add a runtime regression for the reported `danger-full-access == danger-full-access` case

## Why

A model can repeat the active advertised permission mode. That does not expand authority, but the current strict-wider-only check rejects it and wastes the tool turn. The same call already runs under that standing mode when `sandbox_permissions` is omitted.

Fixes #684

## Verification

- `dsh-plugin-desktop/tests/package.spec.ts`: 45/45 passed
- focused runtime regression: same-mode `danger-full-access` returns without an approver or agent; a narrowing request under `danger-full-access` still fails
- desktop build passed
- desktop typecheck passed
- `yarn install --immutable` passed
- `git diff --check` passed
- `yarn why @deepseek-ai/dsh-sandbox` confirms the sole installed instance is patched

The broader desktop gate completed with 962 passed and 11 skipped, plus four unrelated Windows/setup failures in untouched tests: two duplicate-drive file-URL fixtures, one lifecycle timing timeout, and one packaged-pnpm fixture exiting 127. Isolated reruns reproduced those failures; none imports or reaches the changed escalation helper.


Related upstream report: https://github.com/deepseek-ai/deepseek-harness/discussions/4742
