### PR TITLE
fix(desktop): spawn packaged ripgrep from app.asar.unpacked on Windows

### DIFF
--- a/.yarn/patches/@vscode-ripgrep-npm-1.18.0-641e268f90.patch
+++ b/.yarn/patches/@vscode-ripgrep-npm-1.18.0-641e268f90.patch
@@ -1,0 +1,32 @@
+diff --git a/lib/index.js b/lib/index.js
+index fcbf79a0af3e6dd5e138705b8e18c9458ca7a8c4..643e7ae6bd6bcfa37588bb01411107bfec2da461 100644
+--- a/lib/index.js
++++ b/lib/index.js
+@@ -1,4 +1,6 @@
+ import { createRequire } from 'node:module';
++import { existsSync } from 'node:fs';
++import { sep } from 'node:path';
+ 
+ const require = createRequire(import.meta.url);
+ 
+@@ -16,4 +18,20 @@ try {
+     );
+ }
+ 
++// Electron packs the application into an asar archive, so require.resolve
++// above returns a virtual path inside app.asar. child_process.spawn cannot
++// execute a binary from inside an asar (it fails with ENOENT), while
++// electron-builder keeps files marked "unpacked" on disk next to the archive
++// under app.asar.unpacked. Redirect to the physical copy when it exists so
++// consumers that spawn ripgrep work in packaged builds, most notably on
++// Windows. Outside packaged asar builds this is a no-op: the marker path
++// segment never appears and resolved is returned unchanged.
++const asarMarker = `${sep}app.asar${sep}`;
++if (resolved.includes(asarMarker)) {
++    const unpacked = resolved.replace(asarMarker, `${sep}app.asar.unpacked${sep}`);
++    if (existsSync(unpacked)) {
++        resolved = unpacked;
++    }
++}
++
+ export const rgPath = resolved;

--- a/package.json
+++ b/package.json
@@ -53,7 +53,8 @@
     "dshmarket@npm:1.17.1": "patch:dshmarket@npm%3A1.17.1#./.yarn/patches/dshmarket-npm-1.17.1-d9fe6da08c.patch",
     "koffi@npm:^3.1.0": "3.1.5",
     "@deepseek-ai/dsh-client-ui-settings-general@npm:0.1.1-rc.2": "patch:@deepseek-ai/dsh-client-ui-settings-general@npm%3A0.1.1-rc.2#./.yarn/patches/@deepseek-ai-dsh-client-ui-settings-general-npm-0.1.1-rc.2-ef120ba0cf.patch",
-    "@deepseek-ai/dsh-client-ui-settings-general@npm:^0.1.1-rc.2": "patch:@deepseek-ai/dsh-client-ui-settings-general@npm%3A0.1.1-rc.2#./.yarn/patches/@deepseek-ai-dsh-client-ui-settings-general-npm-0.1.1-rc.2-ef120ba0cf.patch"
+    "@deepseek-ai/dsh-client-ui-settings-general@npm:^0.1.1-rc.2": "patch:@deepseek-ai/dsh-client-ui-settings-general@npm%3A0.1.1-rc.2#./.yarn/patches/@deepseek-ai-dsh-client-ui-settings-general-npm-0.1.1-rc.2-ef120ba0cf.patch",
+    "@vscode/ripgrep@npm:^1.18.0": "patch:@vscode/ripgrep@npm%3A1.18.0#~/.yarn/patches/@vscode-ripgrep-npm-1.18.0-641e268f90.patch"
   },
   "dependenciesMeta": {
     "@deepseek-ai/dsh-subprocess-local": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -7001,7 +7001,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@vscode/ripgrep@npm:^1.18.0":
+"@vscode/ripgrep@npm:1.18.0":
   version: 1.18.0
   resolution: "@vscode/ripgrep@npm:1.18.0"
   dependencies:
@@ -7043,6 +7043,51 @@ __metadata:
     "@vscode/ripgrep-win32-x64":
       optional: true
   checksum: 10c0/163b64cbc864888392616d28df6ff1cbf3c10078f218d2a1f070c25b42cf20c7013b7bf4bbd87a0235d6379d01d17a9a3a7bdb310cb35f1f2d0977418739742d
+  languageName: node
+  linkType: hard
+
+"@vscode/ripgrep@patch:@vscode/ripgrep@npm%3A1.18.0#~/.yarn/patches/@vscode-ripgrep-npm-1.18.0-641e268f90.patch":
+  version: 1.18.0
+  resolution: "@vscode/ripgrep@patch:@vscode/ripgrep@npm%3A1.18.0#~/.yarn/patches/@vscode-ripgrep-npm-1.18.0-641e268f90.patch::version=1.18.0&hash=745fa2"
+  dependencies:
+    "@vscode/ripgrep-darwin-arm64": "npm:1.18.0"
+    "@vscode/ripgrep-darwin-x64": "npm:1.18.0"
+    "@vscode/ripgrep-linux-arm": "npm:1.18.0"
+    "@vscode/ripgrep-linux-arm64": "npm:1.18.0"
+    "@vscode/ripgrep-linux-ia32": "npm:1.18.0"
+    "@vscode/ripgrep-linux-ppc64": "npm:1.18.0"
+    "@vscode/ripgrep-linux-riscv64": "npm:1.18.0"
+    "@vscode/ripgrep-linux-s390x": "npm:1.18.0"
+    "@vscode/ripgrep-linux-x64": "npm:1.18.0"
+    "@vscode/ripgrep-win32-arm64": "npm:1.18.0"
+    "@vscode/ripgrep-win32-ia32": "npm:1.18.0"
+    "@vscode/ripgrep-win32-x64": "npm:1.18.0"
+  dependenciesMeta:
+    "@vscode/ripgrep-darwin-arm64":
+      optional: true
+    "@vscode/ripgrep-darwin-x64":
+      optional: true
+    "@vscode/ripgrep-linux-arm":
+      optional: true
+    "@vscode/ripgrep-linux-arm64":
+      optional: true
+    "@vscode/ripgrep-linux-ia32":
+      optional: true
+    "@vscode/ripgrep-linux-ppc64":
+      optional: true
+    "@vscode/ripgrep-linux-riscv64":
+      optional: true
+    "@vscode/ripgrep-linux-s390x":
+      optional: true
+    "@vscode/ripgrep-linux-x64":
+      optional: true
+    "@vscode/ripgrep-win32-arm64":
+      optional: true
+    "@vscode/ripgrep-win32-ia32":
+      optional: true
+    "@vscode/ripgrep-win32-x64":
+      optional: true
+  checksum: 10c0/d23b2452a4ebffcbf7f3ca4b0b4345f0fa22d0c67fe388cc362825137279123840db1191d83edef4b5ca75ec243a72be1960c8413558d1b711a9d5642e9be9e4
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Problem

On Windows installs, every `grep` and `glob` search-tool call fails unconditionally:

```
Error: grep could not start its search command (ripgrep launch failed)
```

## Root cause

1. The packaged app ships ripgrep via `@vscode/ripgrep` + `@vscode/ripgrep-win32-x64`. In the asar-packaged build the binary is marked unpacked, so it physically exists only at `resources/app.asar.unpacked/node_modules/@vscode/ripgrep-win32-x64/bin/rg.exe`.
2. The `@vscode/ripgrep` shim (`lib/index.js`) resolves the binary with `require.resolve("@vscode/ripgrep-win32-x64/bin/rg.exe")`. Inside Electron this resolves, but the returned path is the **virtual** path inside `app.asar` — `require.resolve` never rewrites results to the unpacked location.
3. `child_process.spawn` is not asar-aware: a path under `app.asar` does not exist on the real Windows filesystem, so the spawn fails with ENOENT. (Electron only patches `execFile`/`fork` for asar, not `spawn`.)
4. Consumers such as `@deepseek-ai/dsh-tool-fs-search`'s `grep`/`glob` tools wrap the launch failure as `SEARCH_FAILED` and have no fallback to a system `rg` on PATH, so the failure is deterministic on every Windows install.

Evidence from a Windows x64 install (Desktop 2.0.3):

- `fs.existsSync("resources/app.asar/node_modules/@vscode/ripgrep-win32-x64/bin/rg.exe")` → `false` (the archive is a file, not a directory)
- `fs.existsSync("resources/app.asar.unpacked/node_modules/@vscode/ripgrep-win32-x64/bin/rg.exe")` → `true`; the unpacked binary runs fine standalone
- `spawn(virtualPath)` outside Electron reproduces the ENOENT exactly
- macOS/Linux and dev (unpackaged) runs are unaffected — the marker path never appears there

## Fix

A dependency patch for `@vscode/ripgrep` (registered through `resolutions`, same mechanism as the existing `dsh-client-ui-settings-general` patch): after resolution, if the resolved path contains the `app.asar` path segment **and** the corresponding `app.asar.unpacked` copy exists on disk, redirect `rgPath` to the physical copy.

- No-op outside packaged asar builds (marker never appears), so macOS, Linux, and dev workflows are unaffected
- `scripts/mac-universal.ts` only stitches `node_modules/@vscode/ripgrep-darwin-*` paths and is unaffected
- Fixes every in-app consumer that spawns `rgPath` — including the closed-source `@deepseek-ai/dsh-tool-fs-search` package, which is why the fix belongs at the dependency level in this repo

## Verification

- Generated through the standard `yarn patch` / `yarn patch-commit` flow; `yarn install --mode=update-lockfile` settles `yarn.lock`
- Applied the generated patch file to the published `@vscode/ripgrep@1.18.0` tarball (`git apply` clean), then exercised it in a simulated packaged layout (`app.asar/` + `app.asar.unpacked/` twins, stub binary inside the archive, real `rg.exe` in the unpacked twin): `rgPath` redirects to the unpacked copy and `spawnSync(rgPath, ["--version"])` returns `ripgrep 15.0.0`, exit 0
- Live A/B on a Windows install with the equivalent fix applied in place: `grep` and `glob` worked again immediately after restart (they had failed on every call before)
- No dependency added, removed, or re-versioned, so `THIRD_PARTY_NOTICES.md` is unchanged (`@vscode/ripgrep` 1.18.0 was already listed)

Full `yarn check` gate deferred to CI (the change is data-only: one resolution pair, the lockfile, and one patch file).
