### PR TITLE
chore(upstream): pin DeepSeek Harness 0.1.2-alpha.1

### DIFF
--- a/upstream.json
+++ b/upstream.json
@@ -1,6 +1,6 @@
 {
   "repository": "https://github.com/deepseek-ai/deepseek-harness.git",
-  "commit": "b150a551b8d465e31e418e1b2eaf5e79bbb7d28e",
-  "sourceVersion": "0.1.1-rc.2",
+  "commit": "cd5ef8148158c3a752a658978873241fdf8e2bbc",
+  "sourceVersion": "0.1.2-alpha.1",
   "runtimePackageVersion": "0.1.1-rc.2"
 }


### PR DESCRIPTION
## Summary

- pin the official DeepSeek Harness source submodule to `dsh-v0.1.2-alpha.1` (`cd5ef8148158c3a752a658978873241fdf8e2bbc`)
- record source version `0.1.2-alpha.1` in `upstream.json`
- keep the Desktop runtime package family on `0.1.1-rc.2` because the alpha.1 npm family is not published; source and runtime provenance remain explicit and independent

## Verification

- `corepack yarn install --immutable`
- `corepack yarn check:layout`
- `corepack yarn upstream:version` (`11.7.0`)
- `corepack yarn check`

## Release note

This tracks the official prerelease source tag only. It does not claim that Desktop is running the unpublished `0.1.2-alpha.1` npm packages.