### PR TITLE
fix(desktop): expose packaged DSH modules to host plugins

### DIFF
--- a/dsh-plugin-desktop/src/main.ts
+++ b/dsh-plugin-desktop/src/main.ts
@@ -2,7 +2,7 @@
 
 import { app, crashReporter, shell } from 'electron'
 import { randomUUID } from 'node:crypto'
-import { join } from 'node:path'
+import { dirname, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import {
   boot,
@@ -472,6 +472,9 @@ async function start(): Promise<void> {
     if (electronVersion === undefined) {
       throw new Error(`${BIN_NAME}: plugin runtime requires the Electron runtime version`)
     }
+    // Host plugins may resolve DSH-provided packages from the packaged runtime.
+    // Keep an explicit override for local development and custom DSH installs.
+    process.env.DSH_ROOT ??= dirname(packagedDependencyPath(import.meta.url, '@deepseek-ai/dsh/package.json'))
     const pnpmBinPath = packagedDependencyPath(import.meta.url, 'pnpm/bin/pnpm.mjs')
     const pnpmRuntime = installDesktopPnpmRuntime({
       platform: process.platform,


### PR DESCRIPTION
Fixes #696

## Summary

dsh-undo-savepoint resolves DSH-provided packages through its installation path or DSH_ROOT. Desktop bundles @deepseek-ai/dsh-tools but did not set DSH_ROOT, so profile-installed host plugins could not resolve it. This sets DSH_ROOT to the packaged @deepseek-ai/dsh root during runtime bootstrap when unset, while preserving explicit overrides. The fix is limited to Desktop runtime bootstrap; no plugin dependency declaration changes.

## Verification

- typecheck passed
- Desktop build passed
- check:layout bilingual-docs and architecture gates passed; final layout step was blocked because the pinned deepseek-harness submodule was unavailable and network clone stalled
- Desktop tests: 952 passed, 11 skipped, 13 failed due to Windows symlink permissions and existing environment-dependent runtime/build-path assumptions