### PR TITLE
fix(desktop): preserve enhanced sidebar plugin anchors

### DIFF
--- a/dsh-plugin-desktop/src/client/AdvancedFrame.tsx
+++ b/dsh-plugin-desktop/src/client/AdvancedFrame.tsx
@@ -114,12 +114,12 @@ export function DesktopOwnedFrame({ layout, mode, platform, renderSlot, useSessi
       style={{ gridTemplateColumns: `${columns.sidebar}px minmax(0, 1fr) ${columns.details}px` }}
     >
       {mode === 'advanced' && platform === 'darwin' && <div className="dshDesktopMacCaptionRow" aria-hidden="true" />}
-      <aside className="dshDesktopSidebarSurface">
+      <aside className="dshDesktopSidebarSurface" data-pane="sidebar">
         <div className="dshDesktopUpstreamSidebar">
           {renderSlot('sidebar', { collapsed, width: sidebarOwnerWidth })}
         </div>
       </aside>
-      <main className="dshDesktopConversationSurface">{renderSlot('conversation', {})}</main>
+      <main className="dshDesktopConversationSurface" data-pane="conversation">{renderSlot('conversation', {})}</main>
       <aside className="dshDesktopDetailsSurface">{renderSlot('details', {})}</aside>
       {/* Electron resolves app regions in DOM order; Desktop overlays must remain later. */}
       {mode === 'advanced' && platform === 'win32' && <div className="dshDesktopWindowsCaptionRow" aria-hidden="true" />}

--- a/dsh-plugin-desktop/tests/client-environment.spec.ts
+++ b/dsh-plugin-desktop/tests/client-environment.spec.ts
@@ -77,6 +77,13 @@ describe('advanced desktop layout', () => {
     expect(caption).toBeLessThan(overlay)
   })
 
+  it('preserves upstream pane semantics for DOM-based sidebar extensions', () => {
+    const frame = readFileSync(new URL('../src/client/AdvancedFrame.tsx', import.meta.url), 'utf8')
+
+    expect(frame).toContain('<aside className="dshDesktopSidebarSurface" data-pane="sidebar">')
+    expect(frame).toContain('<main className="dshDesktopConversationSurface" data-pane="conversation">')
+  })
+
   it('owns native caption geometry with one fixed macOS drag strip above page content', () => {
     expect(ADVANCED_MACOS_CONTENT_INSET).toBe(20)
     expect(ADVANCED_MACOS_DRAG_REGION_HEIGHT).toBe(32)


### PR DESCRIPTION
## Summary / 摘要

Enhanced mode replaces the upstream root frame. The Desktop-owned sidebar and conversation containers consequently no longer expose the semantic pane anchors that DOM-based extensions use to locate their mount surfaces.

This change restores the upstream-compatible anchors without adding another root owner, a compatibility fallback, or duplicate plugin registration:

- add `data-pane="sidebar"` to the Desktop-owned sidebar surface;
- add `data-pane="conversation"` to the Desktop-owned conversation surface;
- add a regression assertion covering both anchors.

This allows extensions that query `[data-pane="sidebar"]` and `[data-pane="conversation"]` to mount in enhanced mode even though the upstream `sidebarCol` and `centerCol` class structure is replaced by the Desktop frame.

## Related Issues / 关联 Issue

N/A

## Type / 类型

- [x] Bug fix / 问题修复
- [ ] Feature / 新功能
- [ ] Documentation / 文档
- [ ] Release or packaging / 发布或打包
- [ ] Tests only / 仅测试
- [ ] Other / 其他

## Platforms / 影响平台

- [ ] Windows installer / Windows 安装包
- [ ] Windows portable ZIP / Windows 便携版 ZIP
- [ ] macOS Apple Silicon
- [ ] macOS Intel
- [ ] macOS Universal package / macOS 通用安装包
- [ ] Linux
- [x] Not platform-specific / 与平台无关

## Verification / 验证

- [x] `corepack yarn workspace dsh-plugin-desktop test tests/client-environment.spec.ts` (21 tests)
- [x] `corepack yarn workspace dsh-plugin-desktop typecheck`
- [x] `git diff --check`
- [ ] Manual enhanced-mode verification / 增强模式人工验证

## Release Notes / 发布说明

Third-party sidebar extensions that rely on the existing semantic pane contract can render their sidebar rows and associated conversation panels in enhanced mode again. No user configuration or network behavior changes.
