### PR TITLE
fix(desktop): scrub the materializer environment of injection vectors

### DIFF
--- a/dsh-plugin-desktop-beta/src/profile-materializer.ts
+++ b/dsh-plugin-desktop-beta/src/profile-materializer.ts
@@ -5,6 +5,7 @@ import type { ChildProcess, SpawnOptions } from 'node:child_process'
 import { delimiter, isAbsolute } from 'node:path'
 import { pathToFileURL } from 'node:url'
 import { PNPM_IGNORE_MINIMUM_RELEASE_AGE } from './pnpm-policy.ts'
+import { scrubbedParentEnv } from '@deepseek-ai/dsh-subprocess'
 
 const ELECTRON_HEADERS_URL = 'https://electronjs.org/headers'
 const DEFAULT_TIMEOUT_MS = 120_000
@@ -27,6 +28,8 @@ export interface ProfileMaterializerOptions {
   readonly maxOutputBytes?: number
   /** Permit a one-time Profile migration to reconcile stale lockfile settings. */
   readonly updateLockfile?: boolean
+  /** Injectable only for headless tests; production scrubs the parent environment. */
+  readonly scrubParent?: () => NodeJS.ProcessEnv
   /** Injectable only for headless tests; production uses node:child_process.spawn. */
   readonly spawn?: ProfileMaterializerSpawn
 }
@@ -93,6 +96,67 @@ function inheritedPath(): string {
   if (exact !== undefined || process.platform !== 'win32') return exact ?? ''
   return Object.entries(process.env)
     .find(([key]) => key.toUpperCase() === 'PATH')?.[1] ?? ''
+}
+
+const MATERIALIZER_ENV_KEYS = [
+  'PATH',
+  'NODE',
+  'ELECTRON_RUN_AS_NODE',
+  'DSH_HOME',
+  'CI',
+  'npm_config_runtime',
+  'npm_config_target',
+  'npm_config_disturl',
+] as const
+
+/**
+ * Environment keys that inject code, resolution paths, trust anchors, or
+ * package sources into the install subprocess. The child runs the Electron
+ * binary with ELECTRON_RUN_AS_NODE=1, so NODE_OPTIONS/NODE_PATH would load
+ * attacker-chosen modules; the LD_ and DYLD_ families hijack native library
+ * loading; NODE_EXTRA_CA_CERTS and the SSL_CERT_ pair retarget TLS trust;
+ * the npm_config_ entries redirect dependency resolution. The shared
+ * scrubbedParentEnv does not strip these yet; removed here until it does.
+ */
+const MATERIALIZER_STRIPPED_ENV_KEYS = new Set([
+  'NODE_OPTIONS',
+  'NODE_PATH',
+  'NODE_EXTRA_CA_CERTS',
+  'LD_PRELOAD',
+  'LD_LIBRARY_PATH',
+  'DYLD_INSERT_LIBRARIES',
+  'DYLD_LIBRARY_PATH',
+  'DYLD_FRAMEWORK_PATH',
+  'SSL_CERT_FILE',
+  'SSL_CERT_DIR',
+  'npm_config_registry',
+  'npm_config_userconfig',
+  'npm_config_cafile',
+  'npm_config_strict_ssl',
+].map(key => key.toUpperCase()))
+
+/**
+ * Start from the credential-scrubbed parent environment, like the pnpm
+ * subprocess path does, so secrets and DSH-private entries never reach the
+ * install subprocess. Node loader-injection variables are removed outright.
+ * On Windows, where environment keys match case-insensitively, drop inherited
+ * spellings that collide with an explicit override to avoid handing spawn
+ * duplicate keys.
+ */
+function materializerParentEnv(scrubParent: () => NodeJS.ProcessEnv): NodeJS.ProcessEnv {
+  const parent = { ...scrubParent() }
+  for (const inherited of Object.keys(parent)) {
+    if (MATERIALIZER_STRIPPED_ENV_KEYS.has(inherited.toUpperCase())) delete parent[inherited]
+  }
+  if (process.platform === 'win32') {
+    const explicit = new Set(MATERIALIZER_ENV_KEYS.map(key => key.toUpperCase()))
+    for (const inherited of Object.keys(parent)) {
+      if (explicit.has(inherited.toUpperCase()) && !(MATERIALIZER_ENV_KEYS as readonly string[]).includes(inherited)) {
+        delete parent[inherited]
+      }
+    }
+  }
+  return parent
 }
 
 function assertAbsolutePath(label: string, value: string): void {
@@ -172,7 +236,7 @@ export async function materializeProfile(
   ] as const
   const path = inheritedPath()
   const environment: NodeJS.ProcessEnv = {
-    ...process.env,
+    ...materializerParentEnv(options.scrubParent ?? scrubbedParentEnv),
     PATH: path.length === 0 ? options.nodeBinDir : `${options.nodeBinDir}${delimiter}${path}`,
     NODE: options.nodeShimPath,
     ELECTRON_RUN_AS_NODE: '1',

--- a/dsh-plugin-desktop-beta/src/profile-materializer.ts
+++ b/dsh-plugin-desktop-beta/src/profile-materializer.ts
@@ -146,7 +146,13 @@ const MATERIALIZER_STRIPPED_ENV_KEYS = new Set([
 function materializerParentEnv(scrubParent: () => NodeJS.ProcessEnv): NodeJS.ProcessEnv {
   const parent = { ...scrubParent() }
   for (const inherited of Object.keys(parent)) {
-    if (MATERIALIZER_STRIPPED_ENV_KEYS.has(inherited.toUpperCase())) delete parent[inherited]
+    const upper = inherited.toUpperCase()
+    // The packaged package manager is pnpm, which additionally resolves its
+    // own PNPM_CONFIG_* family (for example pnpm_config_global_pnpmfile can
+    // load an attacker-chosen hook module that --frozen-lockfile does not
+    // stop). No explicit key below uses that family, so strip the whole
+    // prefix rather than enumerate it.
+    if (MATERIALIZER_STRIPPED_ENV_KEYS.has(upper) || upper.startsWith('PNPM_CONFIG_')) delete parent[inherited]
   }
   if (process.platform === 'win32') {
     const explicit = new Set(MATERIALIZER_ENV_KEYS.map(key => key.toUpperCase()))

--- a/dsh-plugin-desktop-beta/tests/profile-materializer.spec.ts
+++ b/dsh-plugin-desktop-beta/tests/profile-materializer.spec.ts
@@ -115,6 +115,115 @@ describe('profile materializer', () => {
     ])
   })
 
+  it('scrubs credential-like and DSH-private entries from the inherited environment', async () => {
+    const savedNodeOptions = process.env.NODE_OPTIONS
+    const savedNodePath = process.env.NODE_PATH
+    process.env.DESKTOP_TEST_MARKET_TOKEN = 'secret-token'
+    process.env.DSH_INTERNAL_NOTE = 'internal'
+    process.env.NODE_OPTIONS = '--require=/tmp/payload.js'
+    process.env.NODE_PATH = '/tmp/rogue-modules'
+    process.env.LD_PRELOAD = '/tmp/rogue.so'
+    process.env.DYLD_INSERT_LIBRARIES = '/tmp/rogue.dylib'
+    process.env.NODE_EXTRA_CA_CERTS = '/tmp/rogue-ca.pem'
+    process.env.npm_config_registry = 'https://evil-registry.example'
+    const child = fakeChild()
+    let spawnOptions: SpawnOptions | undefined
+    const spawn = vi.fn((_command: string, _args: readonly string[], selectedOptions: SpawnOptions) => {
+      spawnOptions = selectedOptions
+      return child as unknown as ChildProcess
+    }) as unknown as ProfileMaterializerSpawn
+    try {
+      const resultPromise = materializeProfile(options(spawn))
+      child.stdout.end('installed\n')
+      child.stderr.end('')
+      child.emit('close', 0, null)
+      await resultPromise
+    } finally {
+      delete process.env.DESKTOP_TEST_MARKET_TOKEN
+      delete process.env.DSH_INTERNAL_NOTE
+      if (savedNodeOptions === undefined) delete process.env.NODE_OPTIONS
+      else process.env.NODE_OPTIONS = savedNodeOptions
+      if (savedNodePath === undefined) delete process.env.NODE_PATH
+      else process.env.NODE_PATH = savedNodePath
+      delete process.env.LD_PRELOAD
+      delete process.env.DYLD_INSERT_LIBRARIES
+      delete process.env.NODE_EXTRA_CA_CERTS
+      delete process.env.npm_config_registry
+    }
+    const environment = spawnOptions?.env as NodeJS.ProcessEnv
+    expect(environment.DESKTOP_TEST_MARKET_TOKEN).toBeUndefined()
+    expect(environment.DSH_INTERNAL_NOTE).toBeUndefined()
+    expect(environment.NODE_OPTIONS).toBeUndefined()
+    expect(environment.NODE_PATH).toBeUndefined()
+    expect(environment.LD_PRELOAD).toBeUndefined()
+    expect(environment.DYLD_INSERT_LIBRARIES).toBeUndefined()
+    expect(environment.NODE_EXTRA_CA_CERTS).toBeUndefined()
+    expect(environment.npm_config_registry).toBeUndefined()
+    expect(environment.ELECTRON_RUN_AS_NODE).toBe('1')
+    expect(environment.NODE).toBe('/private/node-bin/node')
+  })
+
+  it('strips the whole PNPM_CONFIG_ family that the packaged pnpm would resolve', async () => {
+    const child = fakeChild()
+    let spawnOptions: SpawnOptions | undefined
+    const spawn = vi.fn((_command: string, _args: readonly string[], selectedOptions: SpawnOptions) => {
+      spawnOptions = selectedOptions
+      return child as unknown as ChildProcess
+    }) as unknown as ProfileMaterializerSpawn
+    const scrubParent = vi.fn(() => ({
+      // pnpm resolves its own config family: a global pnpmfile loads an
+      // attacker-chosen module that --frozen-lockfile does not stop.
+      pnpm_config_global_pnpmfile: '/tmp/payload-pnpmfile.cjs',
+      pnpm_config_registry: 'https://evil-registry.example',
+      Pnpm_Config_Cafile: '/tmp/rogue-ca.pem',
+      pnpm_config_fetch_retries: '9',
+      // the explicit npm-prefixed build flags must survive untouched
+      npm_config_runtime: 'electron',
+    } as NodeJS.ProcessEnv))
+    const resultPromise = materializeProfile({ ...options(spawn), scrubParent })
+    child.stdout.end('installed\n')
+    child.stderr.end('')
+    child.emit('close', 0, null)
+    await resultPromise
+    const environment = spawnOptions?.env ?? {}
+    expect(environment.pnpm_config_global_pnpmfile).toBeUndefined()
+    expect(environment.pnpm_config_registry).toBeUndefined()
+    expect(environment.Pnpm_Config_Cafile).toBeUndefined()
+    expect(environment.pnpm_config_fetch_retries).toBeUndefined()
+    expect(environment.npm_config_runtime).toBe('electron')
+  })
+
+  it('drops case-variant duplicates of the explicit keys on Windows', async () => {
+    const platformSpy = vi.spyOn(process, 'platform', 'get').mockReturnValue('win32')
+    const child = fakeChild()
+    let observed: NodeJS.ProcessEnv | undefined
+    const spawn = vi.fn((_command: string, _args: readonly string[], selectedOptions: SpawnOptions) => {
+      observed = selectedOptions.env
+      return child as unknown as ChildProcess
+    }) as unknown as ProfileMaterializerSpawn
+    try {
+      const resultPromise = materializeProfile({
+        ...options(spawn),
+        scrubParent: () => ({ Path: '/inherited', dsh_home: '/rogue', HOME: '/home/test' } as NodeJS.ProcessEnv),
+      })
+      child.stdout.end('installed\n')
+      child.stderr.end('')
+      child.emit('close', 0, null)
+      await resultPromise
+    } finally {
+      platformSpy.mockRestore()
+    }
+    // Windows matches environment keys case-insensitively; the inherited
+    // spellings of explicit overrides must be dropped while unrelated
+    // entries survive and the explicit values win.
+    expect(observed).toBeDefined()
+    expect('Path' in (observed ?? {})).toBe(false)
+    expect(observed?.dsh_home).toBeUndefined()
+    expect(observed?.HOME).toBe('/home/test')
+    expect(observed?.DSH_HOME).toBe('/Users/test/.dsh')
+    expect(observed?.PATH).toBe(`/private/node-bin${delimiter}${process.env.PATH ?? ''}`)
+  })
+
   it('rejects a non-zero package-manager exit and preserves bounded diagnostics', async () => {
     const child = fakeChild()
     const spawn = vi.fn(() => child as unknown as ChildProcess) as unknown as ProfileMaterializerSpawn

--- a/dsh-plugin-desktop/src/profile-materializer.ts
+++ b/dsh-plugin-desktop/src/profile-materializer.ts
@@ -5,6 +5,7 @@ import type { ChildProcess, SpawnOptions } from 'node:child_process'
 import { delimiter, isAbsolute } from 'node:path'
 import { pathToFileURL } from 'node:url'
 import { PNPM_IGNORE_MINIMUM_RELEASE_AGE } from './pnpm-policy.ts'
+import { scrubbedParentEnv } from '@deepseek-ai/dsh-subprocess'
 
 const ELECTRON_HEADERS_URL = 'https://electronjs.org/headers'
 const DEFAULT_TIMEOUT_MS = 120_000
@@ -27,6 +28,8 @@ export interface ProfileMaterializerOptions {
   readonly maxOutputBytes?: number
   /** Permit a one-time Profile migration to reconcile stale lockfile settings. */
   readonly updateLockfile?: boolean
+  /** Injectable only for headless tests; production scrubs the parent environment. */
+  readonly scrubParent?: () => NodeJS.ProcessEnv
   /** Injectable only for headless tests; production uses node:child_process.spawn. */
   readonly spawn?: ProfileMaterializerSpawn
 }
@@ -93,6 +96,37 @@ function inheritedPath(): string {
   if (exact !== undefined || process.platform !== 'win32') return exact ?? ''
   return Object.entries(process.env)
     .find(([key]) => key.toUpperCase() === 'PATH')?.[1] ?? ''
+}
+
+const MATERIALIZER_ENV_KEYS = [
+  'PATH',
+  'NODE',
+  'ELECTRON_RUN_AS_NODE',
+  'DSH_HOME',
+  'CI',
+  'npm_config_runtime',
+  'npm_config_target',
+  'npm_config_disturl',
+] as const
+
+/**
+ * Start from the credential-scrubbed parent environment, like the pnpm
+ * subprocess path does, so secrets and DSH-private entries never reach the
+ * install subprocess. On Windows, where environment keys match
+ * case-insensitively, drop inherited spellings that collide with an explicit
+ * override to avoid handing spawn duplicate keys.
+ */
+function materializerParentEnv(scrubParent: () => NodeJS.ProcessEnv): NodeJS.ProcessEnv {
+  const parent = { ...scrubParent() }
+  if (process.platform === 'win32') {
+    const explicit = new Set(MATERIALIZER_ENV_KEYS.map(key => key.toUpperCase()))
+    for (const inherited of Object.keys(parent)) {
+      if (explicit.has(inherited.toUpperCase()) && !(MATERIALIZER_ENV_KEYS as readonly string[]).includes(inherited)) {
+        delete parent[inherited]
+      }
+    }
+  }
+  return parent
 }
 
 function assertAbsolutePath(label: string, value: string): void {
@@ -172,7 +206,7 @@ export async function materializeProfile(
   ] as const
   const path = inheritedPath()
   const environment: NodeJS.ProcessEnv = {
-    ...process.env,
+    ...materializerParentEnv(options.scrubParent ?? scrubbedParentEnv),
     PATH: path.length === 0 ? options.nodeBinDir : `${options.nodeBinDir}${delimiter}${path}`,
     NODE: options.nodeShimPath,
     ELECTRON_RUN_AS_NODE: '1',

--- a/dsh-plugin-desktop/src/profile-materializer.ts
+++ b/dsh-plugin-desktop/src/profile-materializer.ts
@@ -110,14 +110,27 @@ const MATERIALIZER_ENV_KEYS = [
 ] as const
 
 /**
+ * Environment keys that inject modules or resolution paths into a Node
+ * runtime. The child runs the Electron binary with ELECTRON_RUN_AS_NODE=1,
+ * so an inherited NODE_OPTIONS (--require, --import) or NODE_PATH would
+ * execute attacker-chosen code inside the install subprocess. The shared
+ * scrubbedParentEnv does not strip them yet; removed here until it does.
+ */
+const MATERIALIZER_STRIPPED_ENV_KEYS = new Set(['NODE_OPTIONS', 'NODE_PATH'].map(key => key.toUpperCase()))
+
+/**
  * Start from the credential-scrubbed parent environment, like the pnpm
  * subprocess path does, so secrets and DSH-private entries never reach the
- * install subprocess. On Windows, where environment keys match
- * case-insensitively, drop inherited spellings that collide with an explicit
- * override to avoid handing spawn duplicate keys.
+ * install subprocess. Node loader-injection variables are removed outright.
+ * On Windows, where environment keys match case-insensitively, drop inherited
+ * spellings that collide with an explicit override to avoid handing spawn
+ * duplicate keys.
  */
 function materializerParentEnv(scrubParent: () => NodeJS.ProcessEnv): NodeJS.ProcessEnv {
   const parent = { ...scrubParent() }
+  for (const inherited of Object.keys(parent)) {
+    if (MATERIALIZER_STRIPPED_ENV_KEYS.has(inherited.toUpperCase())) delete parent[inherited]
+  }
   if (process.platform === 'win32') {
     const explicit = new Set(MATERIALIZER_ENV_KEYS.map(key => key.toUpperCase()))
     for (const inherited of Object.keys(parent)) {

--- a/dsh-plugin-desktop/src/profile-materializer.ts
+++ b/dsh-plugin-desktop/src/profile-materializer.ts
@@ -110,13 +110,30 @@ const MATERIALIZER_ENV_KEYS = [
 ] as const
 
 /**
- * Environment keys that inject modules or resolution paths into a Node
- * runtime. The child runs the Electron binary with ELECTRON_RUN_AS_NODE=1,
- * so an inherited NODE_OPTIONS (--require, --import) or NODE_PATH would
- * execute attacker-chosen code inside the install subprocess. The shared
- * scrubbedParentEnv does not strip them yet; removed here until it does.
+ * Environment keys that inject code, resolution paths, trust anchors, or
+ * package sources into the install subprocess. The child runs the Electron
+ * binary with ELECTRON_RUN_AS_NODE=1, so NODE_OPTIONS/NODE_PATH would load
+ * attacker-chosen modules; the LD_ and DYLD_ families hijack native library
+ * loading; NODE_EXTRA_CA_CERTS and the SSL_CERT_ pair retarget TLS trust;
+ * the npm_config_ entries redirect dependency resolution. The shared
+ * scrubbedParentEnv does not strip these yet; removed here until it does.
  */
-const MATERIALIZER_STRIPPED_ENV_KEYS = new Set(['NODE_OPTIONS', 'NODE_PATH'].map(key => key.toUpperCase()))
+const MATERIALIZER_STRIPPED_ENV_KEYS = new Set([
+  'NODE_OPTIONS',
+  'NODE_PATH',
+  'NODE_EXTRA_CA_CERTS',
+  'LD_PRELOAD',
+  'LD_LIBRARY_PATH',
+  'DYLD_INSERT_LIBRARIES',
+  'DYLD_LIBRARY_PATH',
+  'DYLD_FRAMEWORK_PATH',
+  'SSL_CERT_FILE',
+  'SSL_CERT_DIR',
+  'npm_config_registry',
+  'npm_config_userconfig',
+  'npm_config_cafile',
+  'npm_config_strict_ssl',
+].map(key => key.toUpperCase()))
 
 /**
  * Start from the credential-scrubbed parent environment, like the pnpm

--- a/dsh-plugin-desktop/src/profile-materializer.ts
+++ b/dsh-plugin-desktop/src/profile-materializer.ts
@@ -146,7 +146,13 @@ const MATERIALIZER_STRIPPED_ENV_KEYS = new Set([
 function materializerParentEnv(scrubParent: () => NodeJS.ProcessEnv): NodeJS.ProcessEnv {
   const parent = { ...scrubParent() }
   for (const inherited of Object.keys(parent)) {
-    if (MATERIALIZER_STRIPPED_ENV_KEYS.has(inherited.toUpperCase())) delete parent[inherited]
+    const upper = inherited.toUpperCase()
+    // The packaged package manager is pnpm, which additionally resolves its
+    // own PNPM_CONFIG_* family (for example pnpm_config_global_pnpmfile can
+    // load an attacker-chosen hook module that --frozen-lockfile does not
+    // stop). No explicit key below uses that family, so strip the whole
+    // prefix rather than enumerate it.
+    if (MATERIALIZER_STRIPPED_ENV_KEYS.has(upper) || upper.startsWith('PNPM_CONFIG_')) delete parent[inherited]
   }
   if (process.platform === 'win32') {
     const explicit = new Set(MATERIALIZER_ENV_KEYS.map(key => key.toUpperCase()))

--- a/dsh-plugin-desktop/tests/profile-materializer.spec.ts
+++ b/dsh-plugin-desktop/tests/profile-materializer.spec.ts
@@ -116,8 +116,12 @@ describe('profile materializer', () => {
   })
 
   it('scrubs credential-like and DSH-private entries from the inherited environment', async () => {
+    const savedNodeOptions = process.env.NODE_OPTIONS
+    const savedNodePath = process.env.NODE_PATH
     process.env.DESKTOP_TEST_MARKET_TOKEN = 'secret-token'
     process.env.DSH_INTERNAL_NOTE = 'internal'
+    process.env.NODE_OPTIONS = '--require=/tmp/payload.js'
+    process.env.NODE_PATH = '/tmp/rogue-modules'
     const child = fakeChild()
     let spawnOptions: SpawnOptions | undefined
     const spawn = vi.fn((_command: string, _args: readonly string[], selectedOptions: SpawnOptions) => {
@@ -133,10 +137,16 @@ describe('profile materializer', () => {
     } finally {
       delete process.env.DESKTOP_TEST_MARKET_TOKEN
       delete process.env.DSH_INTERNAL_NOTE
+      if (savedNodeOptions === undefined) delete process.env.NODE_OPTIONS
+      else process.env.NODE_OPTIONS = savedNodeOptions
+      if (savedNodePath === undefined) delete process.env.NODE_PATH
+      else process.env.NODE_PATH = savedNodePath
     }
     const environment = spawnOptions?.env as NodeJS.ProcessEnv
     expect(environment.DESKTOP_TEST_MARKET_TOKEN).toBeUndefined()
     expect(environment.DSH_INTERNAL_NOTE).toBeUndefined()
+    expect(environment.NODE_OPTIONS).toBeUndefined()
+    expect(environment.NODE_PATH).toBeUndefined()
     expect(environment.ELECTRON_RUN_AS_NODE).toBe('1')
     expect(environment.NODE).toBe('/private/node-bin/node')
   })

--- a/dsh-plugin-desktop/tests/profile-materializer.spec.ts
+++ b/dsh-plugin-desktop/tests/profile-materializer.spec.ts
@@ -122,6 +122,10 @@ describe('profile materializer', () => {
     process.env.DSH_INTERNAL_NOTE = 'internal'
     process.env.NODE_OPTIONS = '--require=/tmp/payload.js'
     process.env.NODE_PATH = '/tmp/rogue-modules'
+    process.env.LD_PRELOAD = '/tmp/rogue.so'
+    process.env.DYLD_INSERT_LIBRARIES = '/tmp/rogue.dylib'
+    process.env.NODE_EXTRA_CA_CERTS = '/tmp/rogue-ca.pem'
+    process.env.npm_config_registry = 'https://evil-registry.example'
     const child = fakeChild()
     let spawnOptions: SpawnOptions | undefined
     const spawn = vi.fn((_command: string, _args: readonly string[], selectedOptions: SpawnOptions) => {
@@ -141,12 +145,20 @@ describe('profile materializer', () => {
       else process.env.NODE_OPTIONS = savedNodeOptions
       if (savedNodePath === undefined) delete process.env.NODE_PATH
       else process.env.NODE_PATH = savedNodePath
+      delete process.env.LD_PRELOAD
+      delete process.env.DYLD_INSERT_LIBRARIES
+      delete process.env.NODE_EXTRA_CA_CERTS
+      delete process.env.npm_config_registry
     }
     const environment = spawnOptions?.env as NodeJS.ProcessEnv
     expect(environment.DESKTOP_TEST_MARKET_TOKEN).toBeUndefined()
     expect(environment.DSH_INTERNAL_NOTE).toBeUndefined()
     expect(environment.NODE_OPTIONS).toBeUndefined()
     expect(environment.NODE_PATH).toBeUndefined()
+    expect(environment.LD_PRELOAD).toBeUndefined()
+    expect(environment.DYLD_INSERT_LIBRARIES).toBeUndefined()
+    expect(environment.NODE_EXTRA_CA_CERTS).toBeUndefined()
+    expect(environment.npm_config_registry).toBeUndefined()
     expect(environment.ELECTRON_RUN_AS_NODE).toBe('1')
     expect(environment.NODE).toBe('/private/node-bin/node')
   })

--- a/dsh-plugin-desktop/tests/profile-materializer.spec.ts
+++ b/dsh-plugin-desktop/tests/profile-materializer.spec.ts
@@ -163,6 +163,37 @@ describe('profile materializer', () => {
     expect(environment.NODE).toBe('/private/node-bin/node')
   })
 
+  it('drops case-variant duplicates of the explicit keys on Windows', async () => {
+    const platformSpy = vi.spyOn(process, 'platform', 'get').mockReturnValue('win32')
+    const child = fakeChild()
+    let observed: NodeJS.ProcessEnv | undefined
+    const spawn = vi.fn((_command: string, _args: readonly string[], selectedOptions: SpawnOptions) => {
+      observed = selectedOptions.env
+      return child as unknown as ChildProcess
+    }) as unknown as ProfileMaterializerSpawn
+    try {
+      const resultPromise = materializeProfile({
+        ...options(spawn),
+        scrubParent: () => ({ Path: '/inherited', dsh_home: '/rogue', HOME: '/home/test' } as NodeJS.ProcessEnv),
+      })
+      child.stdout.end('installed\n')
+      child.stderr.end('')
+      child.emit('close', 0, null)
+      await resultPromise
+    } finally {
+      platformSpy.mockRestore()
+    }
+    // Windows matches environment keys case-insensitively; the inherited
+    // spellings of explicit overrides must be dropped while unrelated
+    // entries survive and the explicit values win.
+    expect(observed).toBeDefined()
+    expect('Path' in (observed ?? {})).toBe(false)
+    expect(observed?.dsh_home).toBeUndefined()
+    expect(observed?.HOME).toBe('/home/test')
+    expect(observed?.DSH_HOME).toBe('/Users/test/.dsh')
+    expect(observed?.PATH).toBe(`/private/node-bin${delimiter}${process.env.PATH ?? ''}`)
+  })
+
   it('rejects a non-zero package-manager exit and preserves bounded diagnostics', async () => {
     const child = fakeChild()
     const spawn = vi.fn(() => child as unknown as ChildProcess) as unknown as ProfileMaterializerSpawn

--- a/dsh-plugin-desktop/tests/profile-materializer.spec.ts
+++ b/dsh-plugin-desktop/tests/profile-materializer.spec.ts
@@ -115,6 +115,32 @@ describe('profile materializer', () => {
     ])
   })
 
+  it('scrubs credential-like and DSH-private entries from the inherited environment', async () => {
+    process.env.DESKTOP_TEST_MARKET_TOKEN = 'secret-token'
+    process.env.DSH_INTERNAL_NOTE = 'internal'
+    const child = fakeChild()
+    let spawnOptions: SpawnOptions | undefined
+    const spawn = vi.fn((_command: string, _args: readonly string[], selectedOptions: SpawnOptions) => {
+      spawnOptions = selectedOptions
+      return child as unknown as ChildProcess
+    }) as unknown as ProfileMaterializerSpawn
+    try {
+      const resultPromise = materializeProfile(options(spawn))
+      child.stdout.end('installed\n')
+      child.stderr.end('')
+      child.emit('close', 0, null)
+      await resultPromise
+    } finally {
+      delete process.env.DESKTOP_TEST_MARKET_TOKEN
+      delete process.env.DSH_INTERNAL_NOTE
+    }
+    const environment = spawnOptions?.env as NodeJS.ProcessEnv
+    expect(environment.DESKTOP_TEST_MARKET_TOKEN).toBeUndefined()
+    expect(environment.DSH_INTERNAL_NOTE).toBeUndefined()
+    expect(environment.ELECTRON_RUN_AS_NODE).toBe('1')
+    expect(environment.NODE).toBe('/private/node-bin/node')
+  })
+
   it('rejects a non-zero package-manager exit and preserves bounded diagnostics', async () => {
     const child = fakeChild()
     const spawn = vi.fn(() => child as unknown as ChildProcess) as unknown as ProfileMaterializerSpawn

--- a/dsh-plugin-desktop/tests/profile-materializer.spec.ts
+++ b/dsh-plugin-desktop/tests/profile-materializer.spec.ts
@@ -163,6 +163,36 @@ describe('profile materializer', () => {
     expect(environment.NODE).toBe('/private/node-bin/node')
   })
 
+  it('strips the whole PNPM_CONFIG_ family that the packaged pnpm would resolve', async () => {
+    const child = fakeChild()
+    let spawnOptions: SpawnOptions | undefined
+    const spawn = vi.fn((_command: string, _args: readonly string[], selectedOptions: SpawnOptions) => {
+      spawnOptions = selectedOptions
+      return child as unknown as ChildProcess
+    }) as unknown as ProfileMaterializerSpawn
+    const scrubParent = vi.fn(() => ({
+      // pnpm resolves its own config family: a global pnpmfile loads an
+      // attacker-chosen module that --frozen-lockfile does not stop.
+      pnpm_config_global_pnpmfile: '/tmp/payload-pnpmfile.cjs',
+      pnpm_config_registry: 'https://evil-registry.example',
+      Pnpm_Config_Cafile: '/tmp/rogue-ca.pem',
+      pnpm_config_fetch_retries: '9',
+      // the explicit npm-prefixed build flags must survive untouched
+      npm_config_runtime: 'electron',
+    } as NodeJS.ProcessEnv))
+    const resultPromise = materializeProfile({ ...options(spawn), scrubParent })
+    child.stdout.end('installed\n')
+    child.stderr.end('')
+    child.emit('close', 0, null)
+    await resultPromise
+    const environment = spawnOptions?.env ?? {}
+    expect(environment.pnpm_config_global_pnpmfile).toBeUndefined()
+    expect(environment.pnpm_config_registry).toBeUndefined()
+    expect(environment.Pnpm_Config_Cafile).toBeUndefined()
+    expect(environment.pnpm_config_fetch_retries).toBeUndefined()
+    expect(environment.npm_config_runtime).toBe('electron')
+  })
+
   it('drops case-variant duplicates of the explicit keys on Windows', async () => {
     const platformSpy = vi.spyOn(process, 'platform', 'get').mockReturnValue('win32')
     const child = fakeChild()


### PR DESCRIPTION
## Summary

Profile recovery replays a trusted checkpoint lockfile with `pnpm install --frozen-lockfile`, so the dependency integrity chain looks closed: pnpm verifies every tarball against the lockfile's embedded sha512. But the materializer spawned that install with the **entire inherited `process.env`**, which reopens the chain from the environment side. A desktop process running with injected environment keys — or a launcher script that exports them — can redirect or subvert the "verified" install without touching the lockfile:

- `npm_config_registry` + `npm_config_cafile`/`NODE_EXTRA_CA_CERTS`/`npm_config_strict_ssl=false` point pnpm at an attacker registry whose metadata supplies its *own* self-consistent integrity hashes — the frozen-lockfile gate then verifies the attacker's tarball against the attacker's hash and passes.
- The child is the Electron binary under `ELECTRON_RUN_AS_NODE=1`, so `NODE_OPTIONS`/`NODE_PATH` load attacker-chosen modules into the install process directly.
- `LD_PRELOAD`/`LD_LIBRARY_PATH`/`DYLD_*` hijack native library loading; `SSL_CERT_FILE`/`SSL_CERT_DIR` retarget TLS trust.
- `npm_config_userconfig` smuggles in an arbitrary config file that re-opens every switch above.

This PR closes the environment side of the install chain:

1. **Credential-scrubbed base.** The child environment now starts from `scrubbedParentEnv` (from `@deepseek-ai/dsh-subprocess`), the same base the pnpm subprocess path uses, so secrets and DSH-private entries never reach the install subprocess either.
2. **Injection-key stripping.** Fourteen loader/trust/registry keys (`NODE_OPTIONS`, `NODE_PATH`, `NODE_EXTRA_CA_CERTS`, `LD_PRELOAD`, `LD_LIBRARY_PATH`, `DYLD_INSERT_LIBRARIES`, `DYLD_LIBRARY_PATH`, `DYLD_FRAMEWORK_PATH`, `SSL_CERT_FILE`, `SSL_CERT_DIR`, `npm_config_registry`, `npm_config_userconfig`, `npm_config_cafile`, `npm_config_strict_ssl`) are removed outright, matched case-insensitively so lowercase and mixed-case spellings cannot slip through. The shared `scrubbedParentEnv` does not strip these families yet; this list is removed at the call site until it does.
3. **Windows case-variant dedup.** Windows matches environment keys case-insensitively. Inherited spellings that collide with an explicit override (`Path` vs `PATH`, `dsh_home` vs `DSH_HOME`) are dropped so spawn never receives duplicate keys where the inherited spelling could win.
4. **No behavior change for the legitimate path.** The explicit key set (`PATH` with `nodeBinDir` prepended, `NODE`, `ELECTRON_RUN_AS_NODE`, `DSH_HOME`, `CI`, the four `npm_config_*` build flags) is unchanged.

## Commits

1. `fix(desktop): scrub the inherited environment for profile materialization`
2. `fix(desktop): strip Node loader-injection variables from materialization`
3. `fix(desktop): strip loader, TLS-trust, and registry vectors from materialization`
4. `test(desktop): pin the Windows case-variant dedup of materializer env keys`

## Testing

- New regressions pin both halves: credential/DSH-private scrubbing plus injection-vector stripping through a real `materializeProfile` spawn capture, and the Windows case-variant dedup under a mocked `win32` platform with an injected parent environment (`scrubParent` seam — no `process.env` mutation).
- Independently re-verified beyond the committed specs: every one of the fourteen stripped keys is removed (including the seven the committed spec does not name individually), case-variant spellings (`node_options`, `Npm_Config_Cafile`) are stripped on non-Windows too, unrelated keys (`HOME`, `TERM`) survive, and the explicit overrides still win.
- `corepack yarn typecheck` clean; profile-materializer suite 7/7; full `dsh-plugin-desktop` suite matches a clean `origin/master` baseline exactly (every delta was pre-existing upstream or disk-speed flake, confirmed by re-run).
- `@deepseek-ai/dsh-subprocess` resolves from the published `0.1.1-rc.2` (yarn.lock-pinned), not the submodule checkout, so the import adds no build-time coupling.

## Remarks for maintainers

- The strip list is a compile-time constant (`MATERIALIZER_STRIPPED_ENV_KEYS`) kept beside the explicit allow-list, so the environment policy is reviewable in one place.
- The market install boundary (`pnpm.ts`) already spawns with a pure allow-list environment; after this PR the recovery materializer — previously the one spawn path that inherited the raw parent environment — is tightened to the same standard.
- Once `scrubbedParentEnv` in `@deepseek-ai/dsh-subprocess` strips these families itself, the call-site list can shrink to the difference; that upstream package change is tracked separately (`SENSITIVE_ENV_PATTERN` currently does not cover `NODE_OPTIONS`-style keys).
- Signature-level verification of recovered artifacts remains out of scope here; this PR closes the environment-injection side of the chain.
