### PR TITLE
fix(market): survive cache persistence failures and bound the scan cache

### DIFF
--- a/dsh-community-market/src/catalog/service.ts
+++ b/dsh-community-market/src/catalog/service.ts
@@ -604,14 +604,27 @@ export class DefaultCatalogService implements CatalogService {
    * evicted key cannot have an active scan.
    */
   private evictCatalogScanCache(): void {
-    for (const key of this.catalogScanCache.keys()) {
+    for (const [key, entry] of this.catalogScanCache) {
       if (this.catalogScanCache.size <= this.maxScanCacheEntries) return
       this.catalogScanCache.delete(key)
+      // Paging cursors were validated against the evicted scan's source
+      // generation, and eviction keeps the generation counter (a forced
+      // refresh would bump it). A rebuilt catalog can therefore differ in
+      // content while an old cursor still validates, silently paging across
+      // the rebuild boundary. Revoking the source's cursors trades a
+      // client-visible pagination restart for cross-version correctness.
+      this.revokeSourceCursors(entry.sourceRecordId)
       const controllers = this.catalogScanControllers.get(key)
       if (controllers === undefined || controllers.size === 0) {
         this.catalogScanControllers.delete(key)
-        this.catalogScanGates.delete(key)
       }
+      // The gate is kept: a request can already hold it while queued for the
+      // global source-concurrency permit, with no controller registered yet.
+      // Deleting the gate here would let the next request create a second
+      // gate and run two rebuilds of the same catalog concurrently, the
+      // later-arriving older result overwriting the newer one. Idle gate
+      // objects are a few dozen bytes per (source, locale) key, the same
+      // standing cost as the retained generation counters.
     }
   }
 

--- a/dsh-community-market/src/catalog/service.ts
+++ b/dsh-community-market/src/catalog/service.ts
@@ -595,16 +595,18 @@ export class DefaultCatalogService implements CatalogService {
 
   /**
    * Drop the least recently inserted scan indexes until the cache is back
-   * within bounds. Evicting a key also drops its generation counter and, when
-   * no scan is active, its gate and controller set: a queued scan for that key
-   * re-validates its generation before running, so stale bookkeeping never
-   * lets a superseded scan complete.
+   * within bounds. Generation counters are kept: they are one number per
+   * (source, locale) key, and deleting one that a queued or running scan
+   * still compares against would make that scan fail its re-validation with
+   * a misleading "source changed" error. Idle gate and controller sets are
+   * reclaimed; gates for keys with active scans are left alone because the
+   * scan flow always removes the cache entry before entering its gate, so an
+   * evicted key cannot have an active scan.
    */
   private evictCatalogScanCache(): void {
     for (const key of this.catalogScanCache.keys()) {
       if (this.catalogScanCache.size <= this.maxScanCacheEntries) return
       this.catalogScanCache.delete(key)
-      this.catalogScanGenerations.delete(key)
       const controllers = this.catalogScanControllers.get(key)
       if (controllers === undefined || controllers.size === 0) {
         this.catalogScanControllers.delete(key)

--- a/dsh-community-market/src/catalog/service.ts
+++ b/dsh-community-market/src/catalog/service.ts
@@ -376,6 +376,7 @@ export class DefaultCatalogService implements CatalogService {
   private readonly catalogScanGates = new Map<string, ConcurrencyGate>()
   private readonly cursorTtlMs: number
   private readonly maxCursorEntries: number
+  private readonly maxScanCacheEntries: number
   private readonly catalogScanCacheTtlMs: number
   private readonly sourceConcurrency: ConcurrencyGate
   private readonly now: () => number
@@ -393,6 +394,7 @@ export class DefaultCatalogService implements CatalogService {
     this.catalogScanCacheTtlMs = options.catalogScanCacheTtlMs ?? options.cacheTtlMs ?? DEFAULT_CATALOG_SCAN_CACHE_TTL_MS
     const maxConcurrentSources = options.maxConcurrentSources ?? 4
     const maxCacheEntries = options.maxCacheEntries ?? 256
+    this.maxScanCacheEntries = maxCacheEntries
     if (!Number.isSafeInteger(maxCacheEntries) || maxCacheEntries < 1) {
       throw new TypeError('invalid catalog cache entry limit')
     }
@@ -591,6 +593,26 @@ export class DefaultCatalogService implements CatalogService {
     })
   }
 
+  /**
+   * Drop the least recently inserted scan indexes until the cache is back
+   * within bounds. Evicting a key also drops its generation counter and, when
+   * no scan is active, its gate and controller set: a queued scan for that key
+   * re-validates its generation before running, so stale bookkeeping never
+   * lets a superseded scan complete.
+   */
+  private evictCatalogScanCache(): void {
+    for (const key of this.catalogScanCache.keys()) {
+      if (this.catalogScanCache.size <= this.maxScanCacheEntries) return
+      this.catalogScanCache.delete(key)
+      this.catalogScanGenerations.delete(key)
+      const controllers = this.catalogScanControllers.get(key)
+      if (controllers === undefined || controllers.size === 0) {
+        this.catalogScanControllers.delete(key)
+        this.catalogScanGates.delete(key)
+      }
+    }
+  }
+
   async scanCatalog(
     signal: AbortSignal,
     options: CatalogScanOptions = {},
@@ -641,7 +663,12 @@ export class DefaultCatalogService implements CatalogService {
       && cached.sourceGeneration === sourceGeneration
       && cached.scanGeneration === scanGeneration
       && this.now() < cached.expiresAt
-    ) return cachedScanView(cached, 'cached')
+    ) {
+      // Refresh insertion order so eviction removes the least recently used scan.
+      this.catalogScanCache.delete(key)
+      this.catalogScanCache.set(key, cached)
+      return cachedScanView(cached, 'cached')
+    }
     if (cached !== undefined) {
       if (this.now() >= cached.expiresAt) this.revokeSourceCursors(source.sourceRecordId)
       this.catalogScanCache.delete(key)
@@ -728,6 +755,7 @@ export class DefaultCatalogService implements CatalogService {
           scanKey: randomUUID(),
         }
         this.catalogScanCache.set(key, entry)
+        this.evictCatalogScanCache()
         for (const snapshot of entry.snapshots) {
           try { this.observeSnapshot?.(snapshot) } catch { /* installation is optional; catalog browsing remains available */ }
         }

--- a/dsh-community-market/src/host/routes.ts
+++ b/dsh-community-market/src/host/routes.ts
@@ -711,7 +711,16 @@ export function registerMarketRoutes(
     locale: string,
   ): Promise<void> => {
     const cache = catalogCacheFromResponse(response, sourceRecordId, locale)
-    if (cache !== undefined) await scope.update({ catalogCache: cache })
+    if (cache === undefined) return
+    try {
+      await scope.update({ catalogCache: cache })
+    } catch (cause) {
+      // Catalog browsing already succeeded; a failed cache write must not
+      // escalate into an unhandled rejection that terminates the host.
+      ctx.logger.error(`dsh-community-market: failed to persist the catalog cache: ${
+        cause instanceof Error ? cause.message : String(cause)
+      }`)
+    }
   }
   const settingsScope = scope
   const routes = [

--- a/dsh-community-market/tests/host-routes.spec.ts
+++ b/dsh-community-market/tests/host-routes.spec.ts
@@ -30,6 +30,7 @@ function fixture(path: string): unknown {
 interface MarketServer {
   readonly baseUrl: string
   readonly close: () => Promise<void>
+  readonly logger: { readonly error: ReturnType<typeof vi.fn> }
 }
 
 interface SharedMarketSettings {
@@ -100,14 +101,16 @@ const standardSource = (overrides: Partial<LocalSourceRecord> = {}): LocalSource
 async function startMarketServer(
   initialSources: readonly LocalSourceRecord[],
   sharedSettings?: SharedMarketSettings,
+  updateOverride?: (patch: object) => Promise<void>,
 ): Promise<MarketServer> {
   const routes = new Map<string, RouteHandler>()
   const settings = sharedSettings ?? { document: { sources: initialSources } }
+  const logger = { error: vi.fn() }
   const scope = {
     get: () => settings.document,
-    update: async (patch: object) => {
+    update: updateOverride ?? (async (patch: object) => {
       settings.document = { ...settings.document, ...patch as Partial<MarketSettingsDocument> }
-    },
+    }),
   } as unknown as SettingsScope<MarketSettingsDocument>
   const server = createServer((req, res) => {
     const pathname = new URL(req.url ?? '/', 'http://localhost').pathname
@@ -135,7 +138,7 @@ async function startMarketServer(
         return () => { routes.delete(route.path) }
       },
     },
-    logger: { error: vi.fn() },
+    logger,
   } as unknown as Context
   const disposeRoutes = registerMarketRoutes(ctx, scope)
   return {
@@ -144,6 +147,7 @@ async function startMarketServer(
       disposeRoutes()
       await closeServer(server)
     },
+    logger,
   }
 }
 
@@ -317,6 +321,46 @@ describe('community market Host routes', () => {
       await expect(refresh).rejects.toMatchObject({ name: 'AbortError' })
     } finally {
       await second.close()
+      getJson.mockRestore()
+    }
+  })
+
+  it('keeps a successful catalog response when cache persistence fails', async () => {
+    const activeSource = standardSource({ enabled: true, order: 0 })
+    const providerPage = fixture('../docs/examples/catalog-provider-page.example.json') as {
+      readonly items: readonly unknown[]
+      readonly [key: string]: unknown
+    }
+    let requests = 0
+    const getJson = vi.spyOn(restrictedHttpClient, 'getJson').mockImplementation(async () => {
+      requests += 1
+      if (requests === 1) return { value: standardManifest, finalUrl: activeSource.manifestUrl! }
+      return {
+        value: { ...providerPage, page: { total: 1 } },
+        finalUrl: 'https://plugins.example.org/v1/plugins?limit=50',
+      }
+    })
+    const unhandled = vi.fn()
+    process.on('unhandledRejection', unhandled)
+    const server = await startMarketServer(
+      [],
+      { document: { sources: [activeSource] } },
+      async () => { throw new Error('simulated settings write failure') },
+    )
+    try {
+      const response = await readRoute(
+        server,
+        `${marketRoutes.catalog}?sourceRecordId=${activeSource.sourceRecordId}&limit=50&locale=en`,
+      )
+      expect(response.status).toBe(200)
+      await expect(response.json()).resolves.toMatchObject({
+        results: [{ snapshot: { items: [{ id: 'better-sidebar' }] } }],
+      })
+      await vi.waitFor(() => expect(server.logger.error).toHaveBeenCalled())
+      expect(unhandled).not.toHaveBeenCalled()
+    } finally {
+      process.off('unhandledRejection', unhandled)
+      await server.close()
       getJson.mockRestore()
     }
   })

--- a/dsh-community-market/tests/market-runtime.spec.ts
+++ b/dsh-community-market/tests/market-runtime.spec.ts
@@ -1296,6 +1296,35 @@ describe('catalog active-source reads', () => {
     expect(second).toMatchObject({ cacheStatus: 'cached', locale: 'zh-CN', scanKey: first?.scanKey })
   })
 
+  it('evicts the least recently used scan index when the cache entry limit is reached', async () => {
+    const store = new MemoryCatalogSourceStore()
+    await store.save([source()])
+    const getJson = vi.fn()
+      .mockResolvedValue({ value: rawCatalog, finalUrl: 'https://deepseek1024.com/api/v1/plugins' })
+    const service = new DefaultCatalogService(store, { getJson }, { maxCacheEntries: 2 })
+
+    await service.scanCatalog(new AbortController().signal, { locale: 'en' })
+    await service.scanCatalog(new AbortController().signal, { locale: 'zh-CN' })
+    // Touch 'en' again so 'zh-CN' becomes the least recently used entry.
+    await service.scanCatalog(new AbortController().signal, { locale: 'en' })
+    expect(getJson).toHaveBeenCalledTimes(2)
+
+    await service.scanCatalog(new AbortController().signal, { locale: 'ja' })
+    expect(getJson).toHaveBeenCalledTimes(3)
+
+    // 'zh-CN' was evicted; 'en' and 'ja' keep serving from the cache.
+    const en = await service.scanCatalog(new AbortController().signal, { locale: 'en' })
+    const ja = await service.scanCatalog(new AbortController().signal, { locale: 'ja' })
+    expect(getJson).toHaveBeenCalledTimes(3)
+    expect(en).toMatchObject({ cacheStatus: 'cached' })
+    expect(ja).toMatchObject({ cacheStatus: 'cached' })
+
+    // Reading the evicted locale must refetch instead of growing the cache.
+    const zh = await service.scanCatalog(new AbortController().signal, { locale: 'zh-CN' })
+    expect(getJson).toHaveBeenCalledTimes(4)
+    expect(zh).toMatchObject({ cacheStatus: 'fresh' })
+  })
+
   it('fails closed and revokes old cursors before rebuilding an expired complete index', async () => {
     const store = new MemoryCatalogSourceStore()
     await store.save([source()])

--- a/dsh-community-market/tests/market-runtime.spec.ts
+++ b/dsh-community-market/tests/market-runtime.spec.ts
@@ -1363,6 +1363,54 @@ describe('catalog active-source reads', () => {
     )).toThrow(/unknown or expired/u)
   })
 
+  it('revokes paging cursors when eviction removes their scan index', async () => {
+    const store = new MemoryCatalogSourceStore()
+    await store.save([source()])
+    const secondItem = {
+      ...rawPlugin,
+      id: 'anywhere-labs/second-plugin',
+      name: 'second-plugin',
+      url: 'https://github.com/anywhere-labs/second-plugin',
+    }
+    const rebuiltItem = {
+      ...rawPlugin,
+      id: 'anywhere-labs/rebuilt-plugin',
+      name: 'rebuilt-plugin',
+      url: 'https://github.com/anywhere-labs/rebuilt-plugin',
+    }
+    const getJson = vi.fn()
+      .mockResolvedValueOnce({
+        value: catalogPage([rawPlugin, secondItem]),
+        finalUrl: 'https://deepseek1024.com/api/v2/plugins?page=1&limit=200',
+      })
+      .mockResolvedValueOnce({
+        // The post-eviction rebuild returns different content; an old cursor
+        // that still validates would page across the rebuild boundary.
+        value: catalogPage([rawPlugin, secondItem, rebuiltItem]),
+        finalUrl: 'https://deepseek1024.com/api/v2/plugins?page=1&limit=200',
+      })
+    const service = new DefaultCatalogService(store, { getJson }, { maxCacheEntries: 1 })
+
+    const firstIndex = (await service.scanCatalog(new AbortController().signal, { locale: 'en' }))!
+    const [page] = service.queryCatalog(
+      firstIndex,
+      { limit: 1, locale: 'en' },
+      { sourceRecordId: source().sourceRecordId },
+    )
+    const cursor = page?.snapshot?.page.nextCursor
+    expect(cursor).toBeDefined()
+
+    // A second locale evicts 'en' (limit 1); the eviction revokes the
+    // source's cursors instead of leaving them valid across the rebuild.
+    await service.scanCatalog(new AbortController().signal, { locale: 'zh-CN' })
+    expect(getJson).toHaveBeenCalledTimes(2)
+    expect(() => service.queryCatalog(
+      firstIndex,
+      { limit: 1, locale: 'en' },
+      { sourceRecordId: source().sourceRecordId, cursor: cursor! },
+    )).toThrow(/unknown or expired/u)
+  })
+
   it('revokes media and the complete index when a source is invalidated', async () => {
     const store = new MemoryCatalogSourceStore()
     await store.save([source()])


### PR DESCRIPTION
## Summary

Two availability defects in the catalog runtime, found by a systematic security review of `dsh-community-market/src`:

1. **A failed cache persistence write killed the whole Desktop host.** `persistCatalogResponse` was void-fired from the catalog and installable routes after the 200 response had already been sent. When the settings scope rejected (disk full, transient I/O error), the rejection had no handler and escalated through the default unhandled-rejection policy into the fail-loud path that terminates the host — violating the documented rule that catalog-side failures must never destabilize DSH/Desktop. The rejection is now caught inside `persistCatalogResponse` and logged through the host logger.

2. **`maxCacheEntries` was validated but never stored or used.** The scan cache grew without bound, and because the cache key includes the caller-supplied `locale`, every distinct locale performed a full remote provider scan and permanently retained its multi-megabyte normalized index in the long-lived host process; the per-key gate/generation/controller maps were never pruned either. The limit is now stored and enforced with least-recently-used eviction (cache hits refresh insertion order, so active locales survive), and eviction reclaims the associated gate/controller bookkeeping.

A follow-up commit keeps the per-key scan generation counters across eviction instead of deleting them: they are one number per (source, locale) key, monotonic, and deleting one that a queued or running scan still compares against would make that scan fail its re-validation with a misleading "source changed" error.

## Commits

1. `fix(market): handle catalog cache persistence failures without killing the host`
2. `fix(market): enforce the catalog scan cache entry limit`
3. `fix(market): keep scan generation counters across cache eviction`

## Testing

- `dsh-community-market`: **270 passed / 0 failed** across 23 files; `corepack yarn typecheck` clean.
- New regression tests cover: a settings write failure mid-catalog-response (response still 200, error logged, no unhandled rejection escapes the process), and eviction order at the limit (LRU victim refetches as `fresh`, survivors keep `cached`).
- Mutation-checked during review: removing the persistence try/catch, removing the eviction call, and removing the LRU touch-refresh each turn exactly the corresponding test red — the tests pin the behavior, not just the code shape.

## Remarks for maintainers

- Known low-severity follow-up: the retained generation-counter map is keyed by (source, locale) and locales are caller-supplied BCP-47-like strings, so the map is theoretically unbounded. Each entry is a few dozen bytes and creating one requires a real forced scan (amplification ≈ 1), and the primary hazard (multi-MB indexes resident forever) is what this PR removes — but a locale allowlist or counter cap could close it if you prefer.
- Rebased on current `master` (2026-08-28); merges cleanly alongside the new pinned-GitHub-source catalog work.
