### PR TITLE
fix(desktop): run bundled ripgrep from unpacked ASAR path

### DIFF
--- a/package.json
+++ b/package.json
@@ -127,7 +127,7 @@
     "@deepseek-ai/dsh-tool-bash": "file:vendor/dsh-runtime/0.1.2-alpha.1/deepseek-ai-dsh-tool-bash-0.1.2-alpha.1.tgz",
     "@deepseek-ai/dsh-tool-call-timeout-policy": "file:vendor/dsh-runtime/0.1.2-alpha.1/deepseek-ai-dsh-tool-call-timeout-policy-0.1.2-alpha.1.tgz",
     "@deepseek-ai/dsh-tool-fs": "file:vendor/dsh-runtime/0.1.2-alpha.1/deepseek-ai-dsh-tool-fs-0.1.2-alpha.1.tgz",
-    "@deepseek-ai/dsh-tool-fs-search": "file:vendor/dsh-runtime/0.1.2-alpha.1/deepseek-ai-dsh-tool-fs-search-0.1.2-alpha.1.tgz",
+    "@deepseek-ai/dsh-tool-fs-search": "patch:@deepseek-ai/dsh-tool-fs-search@file%3Avendor/dsh-runtime/0.1.2-alpha.1/deepseek-ai-dsh-tool-fs-search-0.1.2-alpha.1.tgz#./patches/dsh-tool-fs-search@0.1.2-alpha.1.patch",
     "@deepseek-ai/dsh-tool-goal": "file:vendor/dsh-runtime/0.1.2-alpha.1/deepseek-ai-dsh-tool-goal-0.1.2-alpha.1.tgz",
     "@deepseek-ai/dsh-tool-jobs": "file:vendor/dsh-runtime/0.1.2-alpha.1/deepseek-ai-dsh-tool-jobs-0.1.2-alpha.1.tgz",
     "@deepseek-ai/dsh-tool-pwsh": "file:vendor/dsh-runtime/0.1.2-alpha.1/deepseek-ai-dsh-tool-pwsh-0.1.2-alpha.1.tgz",

--- a/patches/dsh-tool-fs-search@0.1.2-alpha.1.patch
+++ b/patches/dsh-tool-fs-search@0.1.2-alpha.1.patch
@@ -1,0 +1,20 @@
+diff --git a/lib/index.js b/lib/index.js
+--- a/lib/index.js
++++ b/lib/index.js
+@@ -106,5 +106,8 @@ function completeStdout(toolName, stdout, rawOutputMaxBytes) {
+ 	throw new SearchError(`${toolName} produced more raw output than the subprocess seam retained within the ${rawOutputMaxBytes}-byte cap; ${narrow}`, "SEARCH_RAW_OUTPUT_OVERFLOW");
+ }
+ let rgPathPromise;
++function unpackedAsarPath(filename) {
++	return filename.replace(/([\\/])app\.asar\1/u, "$1app.asar.unpacked$1");
++}
+ /**
+ * The packaged ripgrep binary path, resolved lazily once per process.
+@@ -123,6 +126,6 @@ function resolveRgPath() {
+ 		const executableSidecar = process.platform === "win32" ? join(executable.dir, `${executable.name}-rg.exe`) : `${process.execPath}-rg`;
+ 		if ("pkg" in process && existsSync(executableSidecar)) return executableSidecar;
+-		return (await import("@vscode/ripgrep")).rgPath;
++		return unpackedAsarPath((await import("@vscode/ripgrep")).rgPath);
+ 	});
+ 	return rgPathPromise;
+ }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4201,6 +4201,27 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@deepseek-ai/dsh-tool-fs-search@patch:@deepseek-ai/dsh-tool-fs-search@file%3Avendor/dsh-runtime/0.1.2-alpha.1/deepseek-ai-dsh-tool-fs-search-0.1.2-alpha.1.tgz#./patches/dsh-tool-fs-search@0.1.2-alpha.1.patch::locator=deepseek-harness-desktop%40workspace%3A.":
+  version: 0.1.2-alpha.1
+  resolution: "@deepseek-ai/dsh-tool-fs-search@patch:@deepseek-ai/dsh-tool-fs-search@file%3Avendor/dsh-runtime/0.1.2-alpha.1/deepseek-ai-dsh-tool-fs-search-0.1.2-alpha.1.tgz%23vendor/dsh-runtime/0.1.2-alpha.1/deepseek-ai-dsh-tool-fs-search-0.1.2-alpha.1.tgz%3A%3Ahash=68e39a&locator=deepseek-harness-desktop%2540workspace%253A.#./patches/dsh-tool-fs-search@0.1.2-alpha.1.patch::version=0.1.2-alpha.1&hash=f77204&locator=deepseek-harness-desktop%40workspace%3A."
+  dependencies:
+    "@deepseek-ai/schemastery": "npm:^3.18.1"
+    "@vscode/ripgrep": "npm:^1.18.0"
+  peerDependencies:
+    "@deepseek-ai/cordis": ^4.0.1
+    "@deepseek-ai/dsh-invariants": ^0.1.2-alpha.1
+    "@deepseek-ai/dsh-llm": ^0.1.2-alpha.1
+    "@deepseek-ai/dsh-output-retention": ^0.1.2-alpha.1
+    "@deepseek-ai/dsh-session": ^0.1.2-alpha.1
+    "@deepseek-ai/dsh-spill": ^0.1.2-alpha.1
+    "@deepseek-ai/dsh-subprocess": ^0.1.2-alpha.1
+    "@deepseek-ai/dsh-system-prompt": ^0.1.2-alpha.1
+    "@deepseek-ai/dsh-timeout": ^0.1.2-alpha.1
+    "@deepseek-ai/dsh-tools": ^0.1.2-alpha.1
+  checksum: 10c0/7fd1f392c7f9f90efbb64c0477a99c12f707c9bb2b12d11fd831d530fa37a98f8825dcd9f4f1089d85a7e5b25317fe477f74015a6459a6d670c7bbeee78a2084
+  languageName: node
+  linkType: hard
+
 "@deepseek-ai/dsh-tool-fs@file:vendor/dsh-runtime/0.1.2-alpha.1/deepseek-ai-dsh-tool-fs-0.1.2-alpha.1.tgz::locator=deepseek-harness-desktop%40workspace%3A.":
   version: 0.1.2-alpha.1
   resolution: "@deepseek-ai/dsh-tool-fs@file:vendor/dsh-runtime/0.1.2-alpha.1/deepseek-ai-dsh-tool-fs-0.1.2-alpha.1.tgz#vendor/dsh-runtime/0.1.2-alpha.1/deepseek-ai-dsh-tool-fs-0.1.2-alpha.1.tgz::hash=40be3e&locator=deepseek-harness-desktop%40workspace%3A."


### PR DESCRIPTION
## What changed

On Windows Electron builds, the bundled `glob` and `grep` tools receive an `@vscode/ripgrep` path under `app.asar`. Windows cannot launch a native executable from that virtual path, although the same binary is available under `app.asar.unpacked`.

This Desktop-only fix applies a Yarn patch to the currently vendored `@deepseek-ai/dsh-tool-fs-search` package and converts that dependency path before spawning ripgrep. The pkg sidecar path and ordinary Node behavior are unchanged.

This is the quick Desktop option for anywhere-labs/dsh-desktop#713. It is an alternative to the upstream fix; once the upstream package includes the fix, this patch can be removed.