### PR TITLE
docs: add DeepSeek Harness Handbook to related links

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -206,6 +206,7 @@ Ecosystem projects and developer tools around DeepSeek Harness.
 | dsh-market | Visual plugin market for DeepSeek Harness, with browsing, search, and one-click installation. | [GitHub](https://github.com/dsh-market/dsh-market) |
 | ModLens | Adds OCR, layout, and semantic vision capabilities to DeepSeek Harness and text-only coding agents. | [GitHub](https://github.com/liustack/modlens) · [Website](https://liustack.dev) |
 | DeepSeek Harness Orange Book | Community field manual for DeepSeek Harness. | [GitHub](https://github.com/alchaincyf/deepseek-harness-orange-book) |
+| DeepSeek Harness Handbook | Source-backed Agent/runtime field guide covering plugins, MCP, tools, Sessions, sandboxes, approvals, and troubleshooting, with multilingual coverage. | [GitHub](https://github.com/sandbaseai/deepseek-harness-handbook) · [Website](https://sandbaseai.github.io/deepseek-harness-handbook/) |
 | dsh-web-ui | DeepSeek Harness Web UI plugins and themes. | [GitHub](https://github.com/zhu1090093659/dsh-web-ui) · [Gallery](https://gallery.dsh-market.com) |
 | dsh-TUI | Full-screen interactive terminal interface for DeepSeek Harness. | [GitHub](https://github.com/ccch1mneyyy/dsh-TUI) |
 | dsh-tianshu-tui | Minimalist interactive terminal UI plugin for the DSH web client with a self-developed ANSI rendering core for silky-smooth output; adds TDD, evidence gates, and vision/image module workflows on top of the official UI. | [GitHub](https://github.com/huiliyi37/dsh-tianshu-tui) |

--- a/README.md
+++ b/README.md
@@ -206,6 +206,7 @@ Discord：[加入 DSH Desktop 社区](https://discord.gg/TJeGqKRNM)
 | dsh-market | DeepSeek Harness 内的可视化插件市场，支持浏览、搜索与一键安装插件。 | [GitHub](https://github.com/dsh-market/dsh-market) |
 | ModLens | 为 DeepSeek Harness 和纯文本 Coding Agent 提供 OCR、版面与语义识别能力。 | [GitHub](https://github.com/liustack/modlens) · [官网](https://liustack.dev) |
 | DeepSeek Harness 橙皮书 | DeepSeek Harness 社区实测手册。 | [GitHub](https://github.com/alchaincyf/deepseek-harness-orange-book) |
+| DeepSeek Harness Handbook | 从 Agent/runtime 视角维护的源码验证手册，覆盖插件、MCP、工具、Session、沙箱、审批与故障排查，并提供多语言文档。 | [GitHub](https://github.com/sandbaseai/deepseek-harness-handbook) · [在线站点](https://sandbaseai.github.io/deepseek-harness-handbook/) |
 | dsh-web-ui | DeepSeek Harness Web UI 插件与皮肤合集。 | [GitHub](https://github.com/zhu1090093659/dsh-web-ui) · [展示站](https://gallery.dsh-market.com) |
 | dsh-TUI | DeepSeek Harness 全屏交互式终端界面。 | [GitHub](https://github.com/ccch1mneyyy/dsh-TUI) |
 | dsh-tianshu-tui | DSH Web 端交互式终端极简风格 UI 插件，自研 ANSI 渲染核心、极致丝滑流畅；在官方基础上增加了 TDD、证据门、视觉图像模块等工作流。 | [GitHub](https://github.com/huiliyi37/dsh-tianshu-tui) |


### PR DESCRIPTION
## Summary / 摘要

Add the independent DeepSeek Harness Handbook to both Chinese and English related-links tables so DSH Desktop users can find source-backed Agent/runtime guidance for the same ecosystem.

## Related Issues / 关联 Issue

N/A — documentation discoverability improvement.

## Type / 类型

- [ ] Bug fix / 问题修复
- [ ] Feature / 新功能
- [x] Documentation / 文档
- [ ] Release or packaging / 发布或打包
- [ ] Tests only / 仅测试
- [ ] Other / 其他

## Platforms / 影响平台

- [ ] Windows installer / Windows 安装包
- [ ] Windows portable ZIP / Windows 便携版 ZIP
- [ ] macOS Apple Silicon
- [ ] macOS Intel
- [ ] macOS Universal package / macOS 通用安装包
- [ ] Linux
- [x] Not platform-specific / 与平台无关

## Verification / 验证

- [ ] `corepack yarn check:layout`
- [ ] `corepack yarn typecheck`
- [ ] `corepack yarn test`
- [ ] `corepack yarn check`
- [ ] Platform package smoke / 平台打包或启动冒烟
- [x] Manual test / 人工测试 — reviewed both README tables and verified both links resolve to the handbook repository and hosted site.

## Release Notes / 发布说明

N/A — two documentation-only related-link rows; no application behavior or release assets change.
