### PR TITLE
fix(win): extend installer quit grace to 60 seconds

### DIFF
--- a/dsh-plugin-desktop/build/installer.nsh
+++ b/dsh-plugin-desktop/build/installer.nsh
@@ -24,8 +24,8 @@ Var pid
     IntOp $R1 $R1 + 1
     ; Slow disks, antivirus hooks, and a large physical runtime can keep the
     ; process alive after Cordis disposal begins. Give the orderly handoff a
-    ; full 30 seconds before escalating to the scoped forced-close path.
-    ${if} $R1 < 60
+    ; full 60 seconds before escalating to the scoped forced-close path.
+    ${if} $R1 < 120
       Sleep 500
       Goto dsh_installer_wait_for_exit
     ${endIf}

--- a/dsh-plugin-desktop/tests/installer-nsh.spec.ts
+++ b/dsh-plugin-desktop/tests/installer-nsh.spec.ts
@@ -25,7 +25,7 @@ describe('Windows NSIS running-app handoff', () => {
   it('waits for graceful disposal before using the scoped builder fallback', () => {
     const script = readFileSync(join(process.cwd(), 'build', 'installer.nsh'), 'utf8')
 
-    expect(script).toContain('$R1 < 60')
+    expect(script).toContain('$R1 < 120')
     expect(script).toContain('Sleep 500')
     expect(script).toContain('!insertmacro KILL_PROCESS "${APP_EXECUTABLE_FILENAME}" 0')
     expect(script).toContain('!insertmacro KILL_PROCESS "${APP_EXECUTABLE_FILENAME}" 1')


### PR DESCRIPTION
## Summary

- extend the NSIS graceful installer quit handoff from 30 seconds to 60 seconds
- update the Windows NSIS contract test to enforce the new bound

This gives slow disks, antivirus hooks, and large runtimes more time to finish orderly shutdown before the scoped forced-close fallback.

## Validation

- `corepack yarn workspace dsh-plugin-desktop test tests/installer-nsh.spec.ts --run` (2 passed)
