### PR TITLE
fix(desktop): harden packaged startup and window lifecycle

### DIFF
--- a/dsh-plugin-desktop/scripts/verify-cli-runtime.mjs
+++ b/dsh-plugin-desktop/scripts/verify-cli-runtime.mjs
@@ -12,6 +12,10 @@ const packageRoot = new URL('../', import.meta.url)
 const desktopCli = fileURLToPath(new URL('lib/desktop-cli.js', packageRoot))
 const dshAppBootPackage = fileURLToPath(new URL('node_modules/@deepseek-ai/dsh-app-boot/', packageRoot))
 const dshAtomicWritePackage = fileURLToPath(new URL('node_modules/@deepseek-ai/dsh-atomic-write/', packageRoot))
+const dshHomePathsPackage = fileURLToPath(new URL('node_modules/@deepseek-ai/dsh-home-paths/', packageRoot))
+const semverPackage = fileURLToPath(new URL('node_modules/semver/', packageRoot))
+const cordisLoaderPackage = fileURLToPath(new URL('node_modules/@deepseek-ai/cordis-plugin-loader/', packageRoot))
+const cosmokitPackage = fileURLToPath(new URL('node_modules/@deepseek-ai/cosmokit/', packageRoot))
 const dshPackage = fileURLToPath(new URL('node_modules/@deepseek-ai/dsh/', packageRoot))
 const pnpmCli = fileURLToPath(new URL('node_modules/pnpm/bin/pnpm.mjs', packageRoot))
 const dshVersion = JSON.parse(readFileSync(new URL('node_modules/@deepseek-ai/dsh/package.json', packageRoot), 'utf8')).version
@@ -162,6 +166,10 @@ function runFlatProfileDshEntry() {
   const desktopPackage = join(root, 'node_modules', 'dsh-plugin-desktop')
   const linkedAppBootPackage = join(root, 'node_modules', '@deepseek-ai', 'dsh-app-boot')
   const linkedAtomicWritePackage = join(root, 'node_modules', '@deepseek-ai', 'dsh-atomic-write')
+  const linkedHomePathsPackage = join(root, 'node_modules', '@deepseek-ai', 'dsh-home-paths')
+  const linkedSemverPackage = join(root, 'node_modules', 'semver')
+  const linkedCordisLoaderPackage = join(root, 'node_modules', '@deepseek-ai', 'cordis-plugin-loader')
+  const linkedCosmokitPackage = join(root, 'node_modules', '@deepseek-ai', 'cosmokit')
   const linkedDshPackage = join(root, 'node_modules', '@deepseek-ai', 'dsh')
   try {
     mkdirSync(join(root, 'node_modules', '@deepseek-ai'), { recursive: true })
@@ -169,7 +177,12 @@ function runFlatProfileDshEntry() {
     cpSync(fileURLToPath(new URL('package.json', packageRoot)), join(desktopPackage, 'package.json'))
     symlinkSync(dshAppBootPackage, linkedAppBootPackage, process.platform === 'win32' ? 'junction' : 'dir')
     symlinkSync(dshAtomicWritePackage, linkedAtomicWritePackage, process.platform === 'win32' ? 'junction' : 'dir')
+    symlinkSync(dshHomePathsPackage, linkedHomePathsPackage, process.platform === 'win32' ? 'junction' : 'dir')
+    symlinkSync(semverPackage, linkedSemverPackage, process.platform === 'win32' ? 'junction' : 'dir')
+    symlinkSync(cordisLoaderPackage, linkedCordisLoaderPackage, process.platform === 'win32' ? 'junction' : 'dir')
+    symlinkSync(cosmokitPackage, linkedCosmokitPackage, process.platform === 'win32' ? 'junction' : 'dir')
     symlinkSync(dshPackage, linkedDshPackage, process.platform === 'win32' ? 'junction' : 'dir')
+    const profileHome = join(root, 'home')
     runElectronEntry(
       'flat profile dsh plugin help',
       ['--expose-internals'],
@@ -177,6 +190,14 @@ function runFlatProfileDshEntry() {
       ['plugin', '--help'],
       undefined,
       { DSH_DESKTOP_DEFAULT_PROFILE: 'desktop' },
+    )
+    runElectronEntry(
+      'profile dsh web help',
+      ['--expose-internals'],
+      join(desktopPackage, 'lib', 'desktop-cli.js'),
+      ['web', '--help'],
+      /^Usage: dsh --profile web/u,
+      { DSH_HOME: profileHome },
     )
   } finally {
     rmSync(root, { recursive: true, force: true })

--- a/dsh-plugin-desktop/scripts/verify-profile-boot.mjs
+++ b/dsh-plugin-desktop/scripts/verify-profile-boot.mjs
@@ -5,6 +5,7 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { boot } from '@deepseek-ai/dsh-app-boot'
+import { credentialRef } from '@deepseek-ai/dsh-credentials'
 import { provideCmdline } from '@deepseek-ai/dsh-cmdline'
 import {
   createLaunchEnvironmentSnapshot,
@@ -35,6 +36,13 @@ let nativeThemeSource = 'system'
 const trayItems = []
 
 try {
+  writeFileSync(join(home, '.credentials.yaml'), [
+    '# Issue 672: versioned credentials must remain readable after upgrade',
+    'version: 1',
+    'refs:',
+    '  DSH_CREDENTIAL_SMOKE: fixture-token',
+    '',
+  ].join('\n'), { mode: 0o600 })
   writeFileSync(join(home, 'settings.yaml'), [
     'dsh-desktop:',
     '  mode: advanced',
@@ -54,6 +62,14 @@ try {
     hostServicePluginDir,
     { recursive: true, force: false, errorOnExist: true },
   )
+  const isolatedProfilePatches = prepared.patches.map(patch => ({
+    ...patch,
+    ...(patch.insert === undefined ? {} : {
+      insert: patch.insert.map(entry => entry.id === 'credentials'
+        ? { ...entry, config: { ...(entry.config ?? {}), dshHome: home } }
+        : entry),
+    }),
+  }))
   const patches = [
     // Deliberately compose the consumer before the desktop-pnpm provider row.
     // Its required injection must keep it pending until that service mounts.
@@ -63,7 +79,7 @@ try {
         name: HOST_SERVICE_PLUGIN_NAME,
       }],
     },
-    ...prepared.patches,
+    ...isolatedProfilePatches,
   ]
   const packageRoot = new URL('../', import.meta.url)
   const pnpmBinPath = fileURLToPath(new URL('node_modules/pnpm/bin/pnpm.mjs', packageRoot))
@@ -163,6 +179,11 @@ try {
     prepared.bareModuleBaseUrl,
   )
   await runtime.mountScheduled()
+
+  const credential = await ctx.credentials.resolve(credentialRef('DSH_CREDENTIAL_SMOKE'))
+  if (credential?.value !== 'fixture-token') {
+    throw new Error('versioned credentials fixture was not resolved by the assembled Host')
+  }
 
   if (ctx.get('desktopPnpm') === undefined) {
     throw new Error('assembled desktop profile is missing the desktop pnpm Host capability')

--- a/dsh-plugin-desktop/src/desktop-cli.ts
+++ b/dsh-plugin-desktop/src/desktop-cli.ts
@@ -1,6 +1,9 @@
 /** Private RunAsNode bootstrap for the packaged DeepSeek Harness CLI. */
 
+import { join } from 'node:path'
 import { fileURLToPath, pathToFileURL } from 'node:url'
+import { resolveProfileDir } from '@deepseek-ai/dsh-app-boot'
+import { resolveDshHome } from '@deepseek-ai/dsh-home-paths'
 import { packagedDependencyPath } from './packaged-runtime-path.ts'
 import { assertDesktopProfileName } from './profile-manager.ts'
 import { withoutForwardedDesktopPnpmPolicy } from './pnpm-policy.ts'
@@ -28,6 +31,104 @@ export function withDefaultDesktopProfile(argv: readonly string[], profileName: 
   return ['--profile', profileName, ...argv]
 }
 
+/** Resolver installer seam used by unit tests; production uses the Desktop hook. */
+export type ProfilePackageResolverInstaller = (profileBaseUrl: string) => (() => void) | Promise<() => void>
+
+async function defaultProfilePackageResolverInstaller(profileBaseUrl: string): Promise<() => void> {
+  const { installProfilePackageResolver } = await import('./module-resolution.ts')
+  return installProfilePackageResolver(profileBaseUrl)
+}
+
+/** Return a validated profile name, or undefined so the upstream parser owns the error. */
+function validatedProfileName(value: string | undefined): string | undefined {
+  if (value === undefined || value.length === 0) return undefined
+  try {
+    assertDesktopProfileName(value)
+    return value
+  } catch {
+    return undefined
+  }
+}
+
+/**
+ * Find the profile that the DSH parser will boot from its final argv.
+ * Only launcher-owned options before pass-through arguments are inspected.
+ */
+export function profileBootNameFromArgv(argv: readonly string[]): string | undefined {
+  const first = argv[0]
+  if (first === 'plugin') return undefined
+
+  const webAlias = first === 'web'
+  let profileName: string | undefined = webAlias ? 'web' : undefined
+  let index = webAlias ? 1 : 0
+  if (!webAlias && first !== undefined && !first.startsWith('-')) return undefined
+
+  while (index < argv.length) {
+    const argument = argv[index]
+    if (argument === undefined || argument === '--') break
+    if (argument === '--dump-config' || argument === '--dump-default-config') return undefined
+
+    if (argument === '--patch') {
+      const patch = argv[index + 1]
+      if (patch === undefined || patch === '--' || patch.length === 0) return undefined
+      index += 2
+      continue
+    }
+    if (argument.startsWith('--patch=')) {
+      if (argument.length === '--patch='.length) return undefined
+      index += 1
+      continue
+    }
+
+    // The web alias owns only patch and dump flags; every other token belongs
+    // to the web app and must not change its profile selection.
+    if (webAlias) return profileName
+
+    if (argument === '--profile') {
+      const candidate = validatedProfileName(argv[index + 1])
+      if (candidate === undefined || argv[index + 1] === '--') return undefined
+      if (profileName !== undefined && profileName !== candidate) return undefined
+      profileName = candidate
+      index += 2
+      continue
+    }
+
+    if (argument.startsWith('--profile=')) {
+      const candidate = validatedProfileName(argument.slice('--profile='.length))
+      if (candidate === undefined) return undefined
+      if (profileName !== undefined && profileName !== candidate) return undefined
+      profileName = candidate
+      index += 1
+      continue
+    }
+
+    // An unknown option or positional argument starts the pass-through app argv.
+    return profileName
+  }
+  return profileName
+}
+
+/** Construct the same profile package anchor used by the GUI resolver. */
+export function desktopCliProfilePackageUrl(
+  profileName: string,
+  environment: NodeJS.ProcessEnv = process.env,
+): string {
+  assertDesktopProfileName(profileName)
+  const home = resolveDshHome(undefined, environment)
+  return pathToFileURL(join(resolveProfileDir(profileName, home), 'package.json')).href
+}
+
+/** Install the narrow Profile overlay resolver only for a real profile boot. */
+export async function installCliProfileResolver(
+  argv: readonly string[],
+  environment: NodeJS.ProcessEnv,
+  installResolver: ProfilePackageResolverInstaller = defaultProfilePackageResolverInstaller,
+): Promise<(() => void) | undefined> {
+  const profileName = profileBootNameFromArgv(argv)
+  if (profileName === undefined) return undefined
+  return await installResolver(desktopCliProfilePackageUrl(profileName, environment))
+}
+
 function takeDefaultProfile(environment: NodeJS.ProcessEnv): string | undefined {
   let profileName: string | undefined
   for (const key of Object.keys(environment)) {
@@ -50,14 +151,22 @@ export async function runDesktopDshCli(
   environment: NodeJS.ProcessEnv = process.env,
   load: (url: string) => Promise<unknown> = url => import(url),
   argv: string[] = process.argv,
+  installResolver: ProfilePackageResolverInstaller = defaultProfilePackageResolverInstaller,
 ): Promise<void> {
   const profileName = takeDefaultProfile(environment)
   clearElectronRunAsNode(environment)
   const selected = profileName === undefined
     ? argv.slice(2)
     : withDefaultDesktopProfile(argv.slice(2), profileName)
-  argv.splice(2, argv.length - 2, ...withoutForwardedDesktopPnpmPolicy(selected))
-  await load(DSH_ENTRY_URL)
+  const forwarded = withoutForwardedDesktopPnpmPolicy(selected)
+  argv.splice(2, argv.length - 2, ...forwarded)
+  const releaseResolver = await installCliProfileResolver(forwarded, environment, installResolver)
+  try {
+    await load(DSH_ENTRY_URL)
+  } catch (cause) {
+    releaseResolver?.()
+    throw cause
+  }
 }
 
 function isDirectExecution(): boolean {

--- a/dsh-plugin-desktop/src/electron-reveal.ts
+++ b/dsh-plugin-desktop/src/electron-reveal.ts
@@ -4,11 +4,11 @@ import type { BrowserWindow } from 'electron'
 /**
  * Return whether an activation event needs to bring the application forward.
  *
- * macOS emits activation events while a visible window is already in front of
- * the user.  Treating every activation as a reveal would steal focus from the
- * application the user just selected, so callers should use this guard for
- * app-level activation events and reserve revealApplication for explicit UI
- * actions such as a tray click or a ready-to-show event.
+ * The app-level `activate` event is an explicit macOS Dock/relaunch path.
+ * Broader lifecycle notifications such as `did-become-active` are deliberately
+ * not reveal signals: treating them as one would restore a window while the
+ * user is working in another application.  Other callers should reserve
+ * revealApplication for explicit UI actions such as a tray click or menu item.
  */
 export function applicationNeedsReveal(
   window: Pick<BrowserWindow, 'isMinimized' | 'isVisible'>,

--- a/dsh-plugin-desktop/src/electron-shell-generation.ts
+++ b/dsh-plugin-desktop/src/electron-shell-generation.ts
@@ -350,8 +350,7 @@ export class ElectronShellGeneration {
       }
     }
 
-    app.on('activate', activate)
-    if (platform.platform === 'darwin') app.on('did-become-active', activate)
+    if (platform.platform === 'darwin') app.on('activate', activate)
     window.on('close', close)
     window.on('focus', clearAttention)
     window.on('move', scheduleWindowStateWrite)
@@ -379,8 +378,7 @@ export class ElectronShellGeneration {
     let tray: Tray | undefined
     let removeRendererAccessHeader: (() => void) | undefined
     this.cleanupListeners = () => {
-      app.off('activate', activate)
-      if (platform.platform === 'darwin') app.off('did-become-active', activate)
+      if (platform.platform === 'darwin') app.off('activate', activate)
       window.off('close', close)
       window.off('focus', clearAttention)
       window.off('move', scheduleWindowStateWrite)

--- a/dsh-plugin-desktop/src/main.ts
+++ b/dsh-plugin-desktop/src/main.ts
@@ -419,8 +419,7 @@ async function start(): Promise<void> {
     }
     return false
   }
-  app.on('activate', () => { showPreHostSurface() })
-  if (process.platform === 'darwin') app.on('did-become-active', () => { showPreHostSurface() })
+  if (process.platform === 'darwin') app.on('activate', () => { showPreHostSurface() })
   app.on('second-instance', (_event, argv) => {
     if (isDesktopInstallerQuitRequest(argv, process.platform)) {
       requestQuit(0)

--- a/dsh-plugin-desktop/src/startup-recovery-window.ts
+++ b/dsh-plugin-desktop/src/startup-recovery-window.ts
@@ -280,12 +280,10 @@ export class DesktopStartupRecoveryWindow {
     const activate = (): void => {
       if (applicationNeedsReveal(window)) show()
     }
-    app.on('activate', activate)
-    if (process.platform === 'darwin') app.on('did-become-active', activate)
+    if (process.platform === 'darwin') app.on('activate', activate)
     window.once('ready-to-show', show)
     window.on('closed', () => {
-      app.off('activate', activate)
-      if (process.platform === 'darwin') app.off('did-become-active', activate)
+      if (process.platform === 'darwin') app.off('activate', activate)
       this.window = undefined
       this.finish('quit')
     })

--- a/dsh-plugin-desktop/tests/desktop-cli.spec.ts
+++ b/dsh-plugin-desktop/tests/desktop-cli.spec.ts
@@ -5,6 +5,8 @@ import { pathToFileURL } from 'node:url'
 import { describe, expect, it, vi } from 'vitest'
 import {
   clearElectronRunAsNode,
+  desktopCliProfilePackageUrl,
+  profileBootNameFromArgv,
   runDesktopDshCli,
   withDefaultDesktopProfile,
 } from '../src/desktop-cli.ts'
@@ -104,6 +106,111 @@ describe('packaged dsh bootstrap', () => {
       'update',
     ])
     expect(() => withDefaultDesktopProfile([], '../desktop')).toThrow('invalid desktop profile name')
+  })
+
+  it('identifies only launcher-owned profile boots', () => {
+    expect(profileBootNameFromArgv(['web'])).toBe('web')
+    expect(profileBootNameFromArgv(['web', '--help'])).toBe('web')
+    expect(profileBootNameFromArgv(['web', '--profile', 'inner-app'])).toBe('web')
+    expect(profileBootNameFromArgv(['web', '--profile=inner-app'])).toBe('web')
+    expect(profileBootNameFromArgv(['web', '--dump-config'])).toBeUndefined()
+    expect(profileBootNameFromArgv(['--profile', 'work', '--resume', 'abc'])).toBe('work')
+    expect(profileBootNameFromArgv(['--profile=work', '--patch', 'extra.yml'])).toBe('work')
+    expect(profileBootNameFromArgv(['plugin', '--profile', 'work', 'add', 'plugin'])).toBeUndefined()
+    expect(profileBootNameFromArgv(['--profile', 'work', '--', '--profile', 'other'])).toBe('work')
+    expect(profileBootNameFromArgv(['--profile', '../work'])).toBeUndefined()
+    expect(profileBootNameFromArgv(['--profile', 'work', '--profile', 'other'])).toBeUndefined()
+    expect(profileBootNameFromArgv(['--profile', 'work', '--patch='])).toBeUndefined()
+    expect(profileBootNameFromArgv(['--profile', 'work', '--dump-default-config'])).toBeUndefined()
+  })
+
+  it('installs the resolver against the selected DSH_HOME profile anchor', async () => {
+    const home = mkdtempSync(join(tmpdir(), 'dsh-desktop-cli-home-'))
+    try {
+      const environment = {
+        DSH_HOME: home,
+        DSH_DESKTOP_DEFAULT_PROFILE: 'desktop',
+      }
+      const argv = ['/Applications/DSH Desktop', '/app.asar/lib/desktop-cli.js']
+      const installResolver = vi.fn(() => vi.fn())
+      const load = vi.fn(async () => {})
+
+      await runDesktopDshCli(environment, load, argv, installResolver)
+
+      expect(installResolver).toHaveBeenCalledWith(desktopCliProfilePackageUrl('desktop', { DSH_HOME: home }))
+      expect(installResolver).toHaveBeenCalledWith(pathToFileURL(join(home, 'profiles', 'desktop', 'package.json')).href)
+      expect(load).toHaveBeenCalledOnce()
+    } finally {
+      rmSync(home, { recursive: true, force: true })
+    }
+  })
+
+  it('awaits resolver installation before importing the packaged CLI', async () => {
+    const events: string[] = []
+
+    await runDesktopDshCli(
+      {},
+      async () => { events.push('load') },
+      ['/Applications/DSH Desktop', '/app.asar/lib/desktop-cli.js', '--profile', 'work'],
+      async () => {
+        events.push('install')
+        await Promise.resolve()
+        events.push('ready')
+        return () => {}
+      },
+    )
+
+    expect(events).toEqual(['install', 'ready', 'load'])
+  })
+
+  it('keeps the resolver installed after a successful profile boot', async () => {
+    const releaseResolver = vi.fn()
+    const installResolver = vi.fn(() => releaseResolver)
+
+    await runDesktopDshCli(
+      {},
+      async () => {},
+      ['/Applications/DSH Desktop', '/app.asar/lib/desktop-cli.js', '--profile', 'work'],
+      installResolver,
+    )
+
+    expect(releaseResolver).not.toHaveBeenCalled()
+  })
+
+  it('does not install the resolver for plugin management or config dumps', async () => {
+    const installResolver = vi.fn(() => vi.fn())
+    const load = vi.fn(async () => {})
+
+    await runDesktopDshCli(
+      { DSH_DESKTOP_DEFAULT_PROFILE: 'desktop' },
+      load,
+      ['/Applications/DSH Desktop', '/app.asar/lib/desktop-cli.js', '--dump-config'],
+      installResolver,
+    )
+    await runDesktopDshCli(
+      { DSH_DESKTOP_DEFAULT_PROFILE: 'desktop' },
+      load,
+      ['/Applications/DSH Desktop', '/app.asar/lib/desktop-cli.js', 'plugin', 'add', 'plugin'],
+      installResolver,
+    )
+
+    expect(installResolver).not.toHaveBeenCalled()
+  })
+
+  it('releases the resolver when importing the packaged CLI fails', async () => {
+    const releaseResolver = vi.fn()
+    const installResolver = vi.fn(() => releaseResolver)
+    const failure = new Error('boot failed')
+    const load = vi.fn(async () => { throw failure })
+
+    await expect(runDesktopDshCli(
+      {},
+      load,
+      ['/Applications/DSH Desktop', '/app.asar/lib/desktop-cli.js', '--profile', 'work'],
+      installResolver,
+    )).rejects.toBe(failure)
+
+    expect(releaseResolver).toHaveBeenCalledOnce()
   })
 
   it('uses the physical unpacked dependency tree only inside an Electron package', () => {

--- a/dsh-plugin-desktop/tests/desktop-installer-quit.spec.ts
+++ b/dsh-plugin-desktop/tests/desktop-installer-quit.spec.ts
@@ -43,4 +43,17 @@ describe('Desktop installer quit request', () => {
     expect(show).toBeGreaterThan(secondQuit)
     expect(main.slice(secondQuit, show)).toContain('requestQuit(0)')
   })
+
+  it('routes only explicit macOS activation through native surface reveal', () => {
+    const main = readFileSync(join(process.cwd(), 'src', 'main.ts'), 'utf8')
+    const generation = readFileSync(join(process.cwd(), 'src', 'electron-shell-generation.ts'), 'utf8')
+    const recovery = readFileSync(join(process.cwd(), 'src', 'startup-recovery-window.ts'), 'utf8')
+
+    expect(main).toContain("if (process.platform === 'darwin') app.on('activate', () => { showPreHostSurface() })")
+    expect(main).not.toContain('did-become-active')
+    expect(generation).toContain("if (platform.platform === 'darwin') app.on('activate', activate)")
+    expect(generation).not.toContain('did-become-active')
+    expect(recovery).toContain("if (process.platform === 'darwin') app.on('activate', activate)")
+    expect(recovery).not.toContain('did-become-active')
+  })
 })

--- a/dsh-plugin-desktop/tests/electron-runtime.spec.ts
+++ b/dsh-plugin-desktop/tests/electron-runtime.spec.ts
@@ -1103,7 +1103,7 @@ describe('Electron desktop runtime', () => {
     await release()
   })
 
-  it('shows and hides one native window through ready, activation, tray, and close events', async () => {
+  it('shows and hides one native window through ready, tray, and close events', async () => {
     vi.spyOn(process, 'platform', 'get').mockReturnValue('win32')
     const { ElectronDesktopRuntime } = await import('../src/electron-runtime.ts')
     const runtime = new ElectronDesktopRuntime(async () => {})
@@ -1113,13 +1113,12 @@ describe('Electron desktop runtime', () => {
 
     const window = electron.browserWindows[0]
     const ready = window?.once.mock.calls.find(([event]) => event === 'ready-to-show')?.[1]
-    const activate = electron.app.on.mock.calls.find(([event]) => event === 'activate')?.[1]
     const trayClick = electron.trays[0]?.on.mock.calls.find(([event]) => event === 'click')?.[1]
     const close = electron.browserWindowOn.mock.calls.find(([event]) => event === 'close')?.[1]
     expect(ready).toEqual(expect.any(Function))
-    expect(activate).toEqual(expect.any(Function))
     expect(trayClick).toEqual(expect.any(Function))
     expect(close).toEqual(expect.any(Function))
+    expect(electron.app.on.mock.calls.some(([event]) => event === 'activate')).toBe(false)
 
     expect(window?.show).toHaveBeenCalledOnce()
     expect(window?.focus).toHaveBeenCalledOnce()
@@ -1127,12 +1126,10 @@ describe('Electron desktop runtime', () => {
     window?.isVisible.mockReturnValue(true)
     ready()
     window?.isMinimized.mockReturnValue(true)
-    activate()
-    window?.isMinimized.mockReturnValue(false)
     trayClick()
     expect(window?.restore).toHaveBeenCalledOnce()
-    expect(window?.show).toHaveBeenCalledTimes(3)
-    expect(window?.focus).toHaveBeenCalledTimes(3)
+    expect(window?.show).toHaveBeenCalledTimes(2)
+    expect(window?.focus).toHaveBeenCalledTimes(2)
 
     const closeEvent = { preventDefault: vi.fn() }
     close(closeEvent)
@@ -1285,7 +1282,7 @@ describe('Electron desktop runtime', () => {
     expect(electron.browserWindowOff).toHaveBeenCalledWith('focus', expect.any(Function))
   })
 
-  it('restores a hidden macOS application before revealing its window without stealing focus when already visible', async () => {
+  it('uses explicit macOS activation for hidden and minimized window reveals', async () => {
     vi.spyOn(process, 'platform', 'get').mockReturnValue('darwin')
     const { ElectronDesktopRuntime } = await import('../src/electron-runtime.ts')
     const runtime = new ElectronDesktopRuntime(async () => {})
@@ -1295,15 +1292,14 @@ describe('Electron desktop runtime', () => {
 
     const window = electron.browserWindows[0]
     const activate = electron.app.on.mock.calls.find(([event]) => event === 'activate')?.[1]
-    const didBecomeActive = electron.app.on.mock.calls.find(([event]) => event === 'did-become-active')?.[1]
     expect(activate).toEqual(expect.any(Function))
-    expect(didBecomeActive).toEqual(expect.any(Function))
+    expect(electron.app.on.mock.calls.some(([event]) => event === 'did-become-active')).toBe(false)
 
     electron.app.isHidden.mockReturnValue(true)
     window?.isVisible.mockReturnValue(false)
     const appShowCount = electron.app.show.mock.calls.length
     const focusCountBeforeReveal = window?.focus.mock.calls.length ?? 0
-    didBecomeActive()
+    activate()
     expect(electron.app.show).toHaveBeenCalledTimes(appShowCount + 1)
     expect((electron.app.show.mock.invocationCallOrder.at(-1) ?? Infinity))
       .toBeLessThan(window?.show.mock.invocationCallOrder.at(-1) ?? Infinity)
@@ -1311,12 +1307,18 @@ describe('Electron desktop runtime', () => {
 
     electron.app.isHidden.mockReturnValue(false)
     window?.isVisible.mockReturnValue(true)
+    window?.isMinimized.mockReturnValue(true)
+    const restoreCount = window?.restore.mock.calls.length ?? 0
+    const showCount = window?.show.mock.calls.length ?? 0
     const focusCount = window?.focus.mock.calls.length ?? 0
     activate()
-    expect(window?.focus).toHaveBeenCalledTimes(focusCount)
+    expect(window?.restore).toHaveBeenCalledTimes(restoreCount + 1)
+    expect(window?.show).toHaveBeenCalledTimes(showCount + 1)
+    expect(window?.focus).toHaveBeenCalledTimes(focusCount + 1)
 
     await release()
-    expect(electron.app.off).toHaveBeenCalledWith('did-become-active', expect.any(Function))
+    expect(electron.app.off).toHaveBeenCalledWith('activate', expect.any(Function))
+    expect(electron.app.off.mock.calls.some(([event]) => event === 'did-become-active')).toBe(false)
   })
 
   it('releases the window and tray when post-load startup wiring fails', async () => {


### PR DESCRIPTION
## 概要

本 PR 汇总当前已完成并推送的三个独立 Desktop remediation 提交。每个问题仍保留独立 commit，本文不自动关闭对应 Issue，便于逐项 review 与回溯。

## #694 — Windows packaged CLI Profile boot

- 在加载打包的 `@deepseek-ai/dsh/lib/bin.js` 前，为真实 Profile boot 安装与 GUI 一致的 Profile package resolver。
- 保留 web alias、显式/default Profile、`DSH_HOME`、plugin、dump 和 pass-through 参数边界；非法/冲突 Profile 不静默降级。
- 导入失败释放 resolver，成功 boot 保持 resolver 生效。

## #672 — versioned credentials compatibility

- 通过隔离临时 `DSH_HOME` 的真实 Host/Profile smoke，验证 `version: 1 + refs:` 凭据格式在当前 runtime 中可读。
- flat -> versioned 迁移继续由 `dsh-credentials-local` 负责；Desktop 不重复预处理、不创建 secret backup、不绕过 lock/atomic-write/权限校验。
- 这是兼容性验证与回归覆盖，不把旧版 2.0.1 的已发布安装包声称为已被本地提交改写。

## #681 — passive activation focus theft

- 只在 macOS 保留文档化的 `app activate`（Dock/relaunch）唤起路径。
- 移除 `did-become-active` 的 reveal 监听，并取消 Windows/Linux 的未文档化 app-level `activate` 恢复路径，避免最小化/隐藏窗口被 restore/show/focus。
- 托盘点击、托盘/应用菜单 Open Desktop、通知点击和 `second-instance` 等显式唤起路径保持不变。

## 验证

- `electron-runtime`、`startup-recovery-window`、`desktop-installer-quit`：93 tests passed。
- `package`/`packaged-runtime`：82 tests passed。
- #672 CLI/Profile 与 #694 packaged CLI gates：已通过既有 targeted smoke、typecheck、build。
- 当前提交已通过 Desktop typecheck、build、`git diff --check`，并逐项保留为独立 commit。

## 范围与限制

- 未修改 `deepseek-harness`、真实 Profile 配置、凭据、运行时状态或已安装第三方插件源码。
- #681 仍需 macOS/Windows 实机验证原生焦点仲裁；#672/#694 的线上 Issue 保持 OPEN。
- 相关 Issue：#694、#672、#681（Refs only，不自动关闭）。