### PR TITLE
fix(mac): avoid deep-path node-pty spawn failures

### DIFF
--- a/.yarn/patches/node-pty-npm-1.2.0-beta.15-b1c6ee3543.patch
+++ b/.yarn/patches/node-pty-npm-1.2.0-beta.15-b1c6ee3543.patch
@@ -1,0 +1,19 @@
+diff --git a/lib/unixTerminal.js b/lib/unixTerminal.js
+index af2d24c39deb60e77ad16e6b864f37a7ef58881c..cb00e99a546d0e7a8dbae4e4ee7e6d16bb9bd25a 100644
+--- a/lib/unixTerminal.js
++++ b/lib/unixTerminal.js
+@@ -32,6 +32,14 @@ var helperPath = native.dir + '/spawn-helper';
+ helperPath = path.resolve(__dirname, helperPath);
+ helperPath = helperPath.replace('app.asar', 'app.asar.unpacked');
+ helperPath = helperPath.replace('node_modules.asar', 'node_modules.asar.unpacked');
++// Electron packagers can stage a short macOS helper path outside app.asar.
++// This avoids posix_spawn failures on macOS 26 without changing plain Node.
++if (process.platform === 'darwin' && typeof process.resourcesPath === 'string') {
++    var shortHelperPath = path.join(process.resourcesPath, 'pty', process.arch, 'spawn-helper');
++    if (fs.existsSync(shortHelperPath)) {
++        helperPath = shortHelperPath;
++    }
++}
+ var DEFAULT_FILE = 'sh';
+ var DEFAULT_NAME = 'xterm';
+ var DESTROY_SOCKET_TIMEOUT_MS = 200;

--- a/dsh-plugin-desktop/package.json
+++ b/dsh-plugin-desktop/package.json
@@ -359,6 +359,16 @@
       "icon": "build/app-icon-mac.png",
       "mergeASARs": false,
       "notarize": true,
+      "extraResources": [
+        {
+          "from": "node_modules/node-pty/prebuilds/darwin-arm64/spawn-helper",
+          "to": "pty/arm64/spawn-helper"
+        },
+        {
+          "from": "node_modules/node-pty/prebuilds/darwin-x64/spawn-helper",
+          "to": "pty/x64/spawn-helper"
+        }
+      ],
       "signIgnore": [
         "\\.(?:pak|dat|wasm)$"
       ],

--- a/dsh-plugin-desktop/scripts/mac-universal.ts
+++ b/dsh-plugin-desktop/scripts/mac-universal.ts
@@ -65,6 +65,24 @@ export const MACOS_UNIVERSAL_NATIVE_ENTRIES = [
   },
 ] as const satisfies readonly { readonly arch: MacUniversalArch; readonly path: string }[]
 
+/** Short resource paths used by node-pty on macOS to avoid deep-path posix_spawn failures. */
+export const MACOS_SHORT_NODE_PTY_HELPERS = [
+  {
+    arch: 'arm64',
+    path: 'pty/arm64/spawn-helper',
+    source: 'node_modules/node-pty/prebuilds/darwin-arm64/spawn-helper',
+  },
+  {
+    arch: 'x86_64',
+    path: 'pty/x64/spawn-helper',
+    source: 'node_modules/node-pty/prebuilds/darwin-x64/spawn-helper',
+  },
+] as const satisfies readonly {
+  readonly arch: MacUniversalArch
+  readonly path: string
+  readonly source: string
+}[]
+
 /** Generated host-architecture files that must never shadow the prebuilt pair. */
 export const FORBIDDEN_MACOS_UNIVERSAL_ENTRIES = [
   'node_modules/node-pty/build/Release/pty.node',

--- a/dsh-plugin-desktop/scripts/verify-mac-release.ts
+++ b/dsh-plugin-desktop/scripts/verify-mac-release.ts
@@ -5,7 +5,10 @@ import { mkdtempSync, readdirSync, rmdirSync, statSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { basename, dirname, join, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
-import { MACOS_UNIVERSAL_NATIVE_ENTRIES } from './mac-universal.ts'
+import {
+  MACOS_SHORT_NODE_PTY_HELPERS,
+  MACOS_UNIVERSAL_NATIVE_ENTRIES,
+} from './mac-universal.ts'
 
 /** Injectable filesystem and command boundaries for release verification. */
 export interface MacReleaseVerificationOptions {
@@ -82,6 +85,10 @@ export function verifyMacRelease(
     const unpackedRoot = join(appPath, 'Contents', 'Resources', 'app.asar.unpacked')
     for (const entry of MACOS_UNIVERSAL_NATIVE_ENTRIES) {
       options.run('lipo', [join(unpackedRoot, entry.path), '-verify_arch', entry.arch])
+    }
+    const resourcesRoot = join(appPath, 'Contents', 'Resources')
+    for (const entry of MACOS_SHORT_NODE_PTY_HELPERS) {
+      options.run('lipo', [join(resourcesRoot, entry.path), '-verify_arch', entry.arch])
     }
     options.run('codesign', ['--verify', '--deep', '--strict', '--verbose=2', appPath])
     options.run('spctl', ['--assess', '--type', 'execute', '--verbose=4', appPath])

--- a/dsh-plugin-desktop/scripts/verify-mac-smoke.ts
+++ b/dsh-plugin-desktop/scripts/verify-mac-smoke.ts
@@ -5,7 +5,10 @@ import { existsSync, mkdtempSync, readdirSync, rmdirSync, statSync } from 'node:
 import { tmpdir } from 'node:os'
 import { basename, dirname, join, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
-import { MACOS_UNIVERSAL_NATIVE_ENTRIES } from './mac-universal.ts'
+import {
+  MACOS_SHORT_NODE_PTY_HELPERS,
+  MACOS_UNIVERSAL_NATIVE_ENTRIES,
+} from './mac-universal.ts'
 
 /** Injectable filesystem and command boundaries for smoke verification. */
 export interface MacSmokeVerificationOptions {
@@ -140,6 +143,19 @@ export function verifyMacSmoke(
         throw new Error(`universal application has a non-executable node-pty helper: ${nativePath}`)
       }
       options.run('lipo', [nativePath, '-verify_arch', entry.arch])
+    }
+
+    const resourcesRoot = join(appPath, 'Contents', 'Resources')
+    for (const entry of MACOS_SHORT_NODE_PTY_HELPERS) {
+      const helperPath = join(resourcesRoot, entry.path)
+      if (!options.exists(helperPath)) {
+        throw new Error(`universal application is missing short node-pty helper ${helperPath}`)
+      }
+      const helperStat = options.stat(helperPath)
+      if (!helperStat.isFile || helperStat.size === 0 || (helperStat.mode & 0o111) === 0) {
+        throw new Error(`universal application has an invalid short node-pty helper: ${helperPath}`)
+      }
+      options.run('lipo', [helperPath, '-verify_arch', entry.arch])
     }
   } catch (cause) {
     failure = cause

--- a/dsh-plugin-desktop/scripts/verify-packaged-runtime.ts
+++ b/dsh-plugin-desktop/scripts/verify-packaged-runtime.ts
@@ -9,6 +9,7 @@ import { listPackage } from '@electron/asar'
 import AdmZip from 'adm-zip'
 import {
   FORBIDDEN_MACOS_UNIVERSAL_ENTRIES,
+  MACOS_SHORT_NODE_PTY_HELPERS,
   MACOS_UNIVERSAL_NATIVE_ENTRIES,
 } from './mac-universal.ts'
 
@@ -395,6 +396,17 @@ export function verifyPackagedRuntime(
     throw new Error(
       `dsh-plugin-desktop: packaged runtime at ${unpackedRoot} is missing required physical entries: ${missing.join(', ')}`,
     )
+  }
+  if (context.electronPlatformName === 'darwin') {
+    const resourcesRoot = dirname(resolvePackagedAsarPath(context))
+    const missingShortHelpers = MACOS_SHORT_NODE_PTY_HELPERS
+      .filter(entry => !exists(join(resourcesRoot, entry.path)))
+      .map(entry => entry.path)
+    if (missingShortHelpers.length > 0) {
+      throw new Error(
+        `dsh-plugin-desktop: macOS resources at ${resourcesRoot} are missing short node-pty helpers: ${missingShortHelpers.join(', ')}`,
+      )
+    }
   }
   if (context.electronPlatformName === 'darwin' && context.arch === 4) {
     const forbidden = FORBIDDEN_MACOS_UNIVERSAL_ENTRIES

--- a/dsh-plugin-desktop/tests/mac-universal.spec.ts
+++ b/dsh-plugin-desktop/tests/mac-universal.spec.ts
@@ -1,11 +1,27 @@
 import { join, resolve } from 'node:path'
 import { describe, expect, it, vi } from 'vitest'
 import {
+  MACOS_SHORT_NODE_PTY_HELPERS,
   MACOS_UNIVERSAL_NATIVE_ENTRIES,
   prepareMacUniversalRuntime,
 } from '../scripts/mac-universal.ts'
 
 describe('universal macOS native runtime preparation', () => {
+  it('stages short node-pty helpers for Apple Silicon and Intel without user paths', () => {
+    expect(MACOS_SHORT_NODE_PTY_HELPERS).toEqual([
+      {
+        arch: 'arm64',
+        path: 'pty/arm64/spawn-helper',
+        source: 'node_modules/node-pty/prebuilds/darwin-arm64/spawn-helper',
+      },
+      {
+        arch: 'x86_64',
+        path: 'pty/x64/spawn-helper',
+        source: 'node_modules/node-pty/prebuilds/darwin-x64/spawn-helper',
+      },
+    ])
+  })
+
   it('requires every CPU-specific file and repairs both node-pty helpers', () => {
     const chmod = vi.fn()
     const desktopRoot = resolve('/desktop')

--- a/dsh-plugin-desktop/tests/package.spec.ts
+++ b/dsh-plugin-desktop/tests/package.spec.ts
@@ -15,6 +15,7 @@ import { dirname, join } from 'node:path'
 import { fileURLToPath, pathToFileURL } from 'node:url'
 import sharp from 'sharp'
 import { describe, expect, it } from 'vitest'
+import { MACOS_SHORT_NODE_PTY_HELPERS } from '../scripts/mac-universal.ts'
 
 const packageRoot = new URL('../', import.meta.url)
 const workspaceRoot = new URL('../', packageRoot)
@@ -35,6 +36,7 @@ const manifest = JSON.parse(readFileSync(new URL('package.json', packageRoot), '
     toolsets?: Record<string, unknown>
     files?: unknown
     mac?: {
+      extraResources?: unknown
       extendInfo?: unknown
       hardenedRuntime?: unknown
       icon?: unknown
@@ -60,6 +62,11 @@ const workspaceManifest = JSON.parse(readFileSync(new URL('package.json', worksp
   scripts?: Record<string, unknown>
 }
 const ciWorkflow = readFileSync(new URL('.github/workflows/ci.yml', workspaceRoot), 'utf8')
+const nodePtyPatchName = readdirSync(new URL('.yarn/patches/', workspaceRoot))
+  .filter(name => name.startsWith('node-pty-npm-1.2.0-beta.15-') && name.endsWith('.patch'))
+const nodePtyPatch = nodePtyPatchName.length === 1
+  ? readFileSync(new URL(`.yarn/patches/${nodePtyPatchName[0]}`, workspaceRoot), 'utf8')
+  : ''
 
 describe('published package surface', () => {
   it('runs desktop and community market typechecks from the root command', () => {
@@ -663,6 +670,12 @@ describe('published package surface', () => {
     ])
     expect(manifest.build?.mac?.icon).toBe('build/app-icon-mac.png')
     expect(manifest.build?.mac?.mergeASARs).toBe(false)
+    expect(manifest.build?.mac?.extraResources).toEqual(
+      MACOS_SHORT_NODE_PTY_HELPERS.map(entry => ({
+        from: entry.source,
+        to: entry.path,
+      })),
+    )
     expect(manifest.build?.mac?.signIgnore).toEqual(['\\.(?:pak|dat|wasm)$'])
     expect(manifest.build?.win?.icon).toBe('build/app-icon.png')
     expect(manifest.build?.win?.target).toEqual([{
@@ -742,6 +755,15 @@ describe('published package surface', () => {
     }))
     expect(manifest.build?.files).toContain('!node_modules/node-pty/build/**')
     expect(manifest.devDependencies?.['@electron/asar']).toBe('3.4.1')
+  })
+
+  it('patches node-pty to prefer packaged short helpers without user-specific paths', () => {
+    expect(nodePtyPatchName).toHaveLength(1)
+    expect(workspaceManifest.resolutions?.['node-pty@npm:1.2.0-beta.15'])
+      .toContain(nodePtyPatchName[0])
+    expect(nodePtyPatch).toContain('process.resourcesPath')
+    expect(nodePtyPatch).toContain("'pty', process.arch, 'spawn-helper'")
+    expect(nodePtyPatch).not.toContain('/Users/')
   })
 
   it('runs platform package gates before reusing native packaging outputs', () => {

--- a/dsh-plugin-desktop/tests/verify-mac-release.spec.ts
+++ b/dsh-plugin-desktop/tests/verify-mac-release.spec.ts
@@ -4,7 +4,10 @@ import {
   verifyMacRelease,
   type MacReleaseVerificationOptions,
 } from '../scripts/verify-mac-release.ts'
-import { MACOS_UNIVERSAL_NATIVE_ENTRIES } from '../scripts/mac-universal.ts'
+import {
+  MACOS_SHORT_NODE_PTY_HELPERS,
+  MACOS_UNIVERSAL_NATIVE_ENTRIES,
+} from '../scripts/mac-universal.ts'
 
 function options(overrides: Partial<MacReleaseVerificationOptions> = {}) {
   const calls: Array<{ command: string; args: readonly string[] }> = []
@@ -51,6 +54,13 @@ describe('macOS release artifact verification', () => {
         command: 'lipo',
         args: [
           join(appPath, 'Contents', 'Resources', 'app.asar.unpacked', entry.path),
+          '-verify_arch', entry.arch,
+        ],
+      })),
+      ...MACOS_SHORT_NODE_PTY_HELPERS.map(entry => ({
+        command: 'lipo',
+        args: [
+          join(appPath, 'Contents', 'Resources', entry.path),
           '-verify_arch', entry.arch,
         ],
       })),

--- a/dsh-plugin-desktop/tests/verify-mac-smoke.spec.ts
+++ b/dsh-plugin-desktop/tests/verify-mac-smoke.spec.ts
@@ -6,7 +6,10 @@ import {
   verifyMacSmoke,
   type MacSmokeVerificationOptions,
 } from '../scripts/verify-mac-smoke.ts'
-import { MACOS_UNIVERSAL_NATIVE_ENTRIES } from '../scripts/mac-universal.ts'
+import {
+  MACOS_SHORT_NODE_PTY_HELPERS,
+  MACOS_UNIVERSAL_NATIVE_ENTRIES,
+} from '../scripts/mac-universal.ts'
 
 const temporaryRoots: string[] = []
 
@@ -43,6 +46,13 @@ function fixture(): AppFixture {
       chmodSync(path, 0o755)
       modeOverrides.set(path, 0o755)
     }
+  }
+  for (const entry of MACOS_SHORT_NODE_PTY_HELPERS) {
+    const path = join(resources, entry.path)
+    mkdirSync(join(path, '..'), { recursive: true })
+    writeFileSync(path, 'short helper')
+    chmodSync(path, 0o755)
+    modeOverrides.set(path, 0o755)
   }
   return { root, infoPlist, executable, appAsar, modeOverrides }
 }
@@ -123,6 +133,10 @@ describe('macOS DMG smoke artifact verification', () => {
         command: 'lipo',
         args: [join(`${value.appAsar}.unpacked`, entry.path), '-verify_arch', entry.arch],
       })),
+      ...MACOS_SHORT_NODE_PTY_HELPERS.map(entry => ({
+        command: 'lipo',
+        args: [join(value.root, 'DSH Desktop.app', 'Contents', 'Resources', entry.path), '-verify_arch', entry.arch],
+      })),
       { command: 'hdiutil', args: ['detach', value.root] },
     ])
     expect(harness.removeMountPoint).toHaveBeenCalledWith(value.root)
@@ -178,5 +192,37 @@ describe('macOS DMG smoke artifact verification', () => {
 
     expectSmokeFailure(harness, 'app.asar')
     expect(harness.removeMountPoint).toHaveBeenCalledWith(value.root)
+  })
+
+  it('rejects a missing or non-executable short node-pty helper', () => {
+    const missingFixture = fixture()
+    const missing = join(
+      missingFixture.root,
+      'DSH Desktop.app',
+      'Contents',
+      'Resources',
+      MACOS_SHORT_NODE_PTY_HELPERS[0].path,
+    )
+    rmSync(missing)
+    const missingHarness = options(
+      { makeMountPoint: () => missingFixture.root },
+      missingFixture.modeOverrides,
+    )
+    expectSmokeFailure(missingHarness, 'missing short node-pty helper')
+
+    const modeFixture = fixture()
+    const nonExecutable = join(
+      modeFixture.root,
+      'DSH Desktop.app',
+      'Contents',
+      'Resources',
+      MACOS_SHORT_NODE_PTY_HELPERS[1].path,
+    )
+    modeFixture.modeOverrides.set(nonExecutable, 0o644)
+    const modeHarness = options(
+      { makeMountPoint: () => modeFixture.root },
+      modeFixture.modeOverrides,
+    )
+    expectSmokeFailure(modeHarness, 'invalid short node-pty helper')
   })
 })

--- a/dsh-plugin-desktop/tests/verify-packaged-runtime.spec.ts
+++ b/dsh-plugin-desktop/tests/verify-packaged-runtime.spec.ts
@@ -21,7 +21,10 @@ import {
   type PackagedRuntimeContext,
   type PackagedDiagnosticWorkerLauncher,
 } from '../scripts/verify-packaged-runtime.ts'
-import { FORBIDDEN_MACOS_UNIVERSAL_ENTRIES } from '../scripts/mac-universal.ts'
+import {
+  FORBIDDEN_MACOS_UNIVERSAL_ENTRIES,
+  MACOS_SHORT_NODE_PTY_HELPERS,
+} from '../scripts/mac-universal.ts'
 
 function context(
   appOutDir: string,
@@ -145,6 +148,7 @@ describe('packaged desktop runtime verification', () => {
     expect(exists).toHaveBeenCalledTimes(
       REQUIRED_UNPACKED_RUNTIME_ENTRIES.length
         + (platform === 'win32' ? REQUIRED_WINDOWS_X64_NODE_PTY_ENTRIES.length : 0)
+        + (platform === 'darwin' ? MACOS_SHORT_NODE_PTY_HELPERS.length : 0)
         + completeArchiveEntries().length,
     )
     expect(resolvePackage.mock.calls.map(([specifier]) => specifier))
@@ -179,9 +183,26 @@ describe('packaged desktop runtime verification', () => {
     expect(exists).toHaveBeenCalledTimes(
       REQUIRED_UNPACKED_RUNTIME_ENTRIES.length
         + REQUIRED_MACOS_UNIVERSAL_ENTRIES.length
+        + MACOS_SHORT_NODE_PTY_HELPERS.length
         + FORBIDDEN_MACOS_UNIVERSAL_ENTRIES.length
         + completeArchiveEntries().length,
     )
+  })
+
+  it('requires short node-pty helpers for both universal macOS architectures', () => {
+    const runtimeContext = context('/build', 'darwin', 4)
+    const unpackedRoot = resolvePackagedUnpackedRoot(runtimeContext)
+    const resourcesRoot = join('/build', 'DSH Desktop.app', 'Contents', 'Resources')
+    const missing = MACOS_SHORT_NODE_PTY_HELPERS[0].path
+
+    expect(() => verifyPackagedRuntime(
+      runtimeContext,
+      () => completeArchiveEntries(),
+      filename => filename !== join(resourcesRoot, missing)
+        && !FORBIDDEN_MACOS_UNIVERSAL_ENTRIES
+          .some(entry => filename === join(unpackedRoot, entry)),
+      completePackageResolver(unpackedRoot),
+    )).toThrow(`missing short node-pty helpers: ${missing}`)
   })
 
   it('rejects any ASAR-declared unpacked dependency missing from the physical tree', () => {

--- a/package.json
+++ b/package.json
@@ -259,7 +259,8 @@
     "@deepseek-ai/dsh-tool-terminal": "file:vendor/dsh-runtime/0.1.2-alpha.1/deepseek-ai-dsh-tool-terminal-0.1.2-alpha.1.tgz",
     "@deepseek-ai/dsh-typert-generator": "file:vendor/dsh-runtime/0.1.2-alpha.1/deepseek-ai-dsh-typert-generator-0.1.2-alpha.1.tgz",
     "@deepseek-ai/dsh-web-search-exa": "file:vendor/dsh-runtime/0.1.2-alpha.1/deepseek-ai-dsh-web-search-exa-0.1.2-alpha.1.tgz",
-    "@deepseek-ai/dsh-web-search-perplexity": "file:vendor/dsh-runtime/0.1.2-alpha.1/deepseek-ai-dsh-web-search-perplexity-0.1.2-alpha.1.tgz"
+    "@deepseek-ai/dsh-web-search-perplexity": "file:vendor/dsh-runtime/0.1.2-alpha.1/deepseek-ai-dsh-web-search-perplexity-0.1.2-alpha.1.tgz",
+    "node-pty@npm:1.2.0-beta.15": "patch:node-pty@npm%3A1.2.0-beta.15#~/.yarn/patches/node-pty-npm-1.2.0-beta.15-b1c6ee3543.patch"
   },
   "dependenciesMeta": {
     "@deepseek-ai/dsh-subprocess-local": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -12513,6 +12513,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"node-pty@patch:node-pty@npm%3A1.2.0-beta.15#~/.yarn/patches/node-pty-npm-1.2.0-beta.15-b1c6ee3543.patch":
+  version: 1.2.0-beta.15
+  resolution: "node-pty@patch:node-pty@npm%3A1.2.0-beta.15#~/.yarn/patches/node-pty-npm-1.2.0-beta.15-b1c6ee3543.patch::version=1.2.0-beta.15&hash=cb15bc"
+  dependencies:
+    node-addon-api: "npm:^7.1.0"
+    node-gyp: "npm:latest"
+  checksum: 10c0/aeb2e7bc5bf710304a4fb69f6aaa6fc50c69e3ecb4fefb4eb4c86be8dcea6564899778b11da2a51616a609b1953143770d595a0974dd76dabb6786f37906f277
+  languageName: node
+  linkType: hard
+
 "node-releases@npm:^2.0.53":
   version: 2.0.53
   resolution: "node-releases@npm:2.0.53"


### PR DESCRIPTION
## Summary / 摘要

**English**

- Stage both Darwin `spawn-helper` binaries at short, architecture-specific resource paths:
  - `Contents/Resources/pty/arm64/spawn-helper`
  - `Contents/Resources/pty/x64/spawn-helper`
- Patch `node-pty@1.2.0-beta.15` to prefer the matching helper under `process.resourcesPath` in packaged macOS Electron builds, while preserving the original fallback for plain Node and other platforms.
- Require the short helpers in packaged-runtime, unsigned DMG, and signed-release verification, including missing and non-executable failure cases.

**中文**

- 在 macOS App 的短路径资源目录中同时放置两种架构的 `spawn-helper`：
  - `Contents/Resources/pty/arm64/spawn-helper`
  - `Contents/Resources/pty/x64/spawn-helper`
- 为 `node-pty@1.2.0-beta.15` 增加兼容补丁：在打包后的 macOS Electron 环境中，优先使用 `process.resourcesPath` 下与当前架构匹配的 helper；普通 Node、其他平台或短路径资源不存在时仍沿用原有逻辑。
- 在打包产物校验、未签名 DMG 冒烟和正式签名发布校验中检查短路径 helper，并覆盖文件缺失、不可执行等失败场景。

## Root Cause / 根因

**English**

On macOS 26, `node-pty` can return `posix_spawn failed: No such file or directory` even when the deeply nested helper exists, has mode `0755`, and matches the host architecture. The shell itself can be spawned normally, and the exact same helper binary succeeds when invoked from a shorter path. This isolates the failure to the deeply nested helper path passed to `posix_spawn`, rather than a missing shell, an architecture mismatch, or a sandbox permission problem.

**中文**

在 macOS 26 上，即使深层目录中的 `spawn-helper` 文件真实存在、权限为 `0755`，并且架构与当前机器一致，`node-pty` 仍可能返回 `posix_spawn failed: No such file or directory`。系统可以正常启动 shell；把完全相同的 helper 二进制放到更短路径后，PTY 也可以正常启动。因此可以将故障定位为传给 `posix_spawn` 的 helper 路径过深，而不是 shell 缺失、CPU 架构错误或 DSH 沙箱权限问题。

## Implementation and Compatibility / 实现与兼容性

**English**

- The fix contains no username, home-directory, or machine-specific path.
- Every Apple Silicon model selects the shared `arm64` helper through `process.arch`.
- Intel Macs select the `x64` helper; an Apple Silicon process running under Rosetta also selects `x64`.
- The Universal application carries both helpers, while only the matching helper is used at runtime.
- Windows, Linux, and ordinary non-Electron Node environments retain the existing behavior.

**中文**

- 修复中不包含用户名、用户目录或任何本机专用路径。
- 所有 Apple Silicon（M 系列）机器都会通过 `process.arch` 选择通用的 `arm64` helper。
- Intel Mac 选择 `x64` helper；Apple Silicon 在 Rosetta 下运行 x64 进程时同样选择 `x64`。
- Universal App 同时携带两种 helper，但运行时只使用与当前进程架构匹配的一种。
- Windows、Linux 以及普通的非 Electron Node 环境保持原有行为。

## Related Issues / 关联 Issue

Fixes #91
Fixes #357

## Type / 类型

- [x] Bug fix / 问题修复
- [ ] Feature / 新功能
- [ ] Documentation / 文档
- [x] Release or packaging / 发布或打包
- [ ] Tests only / 仅测试
- [ ] Other / 其他

## Platforms / 影响平台

- [ ] Windows installer / Windows 安装包
- [ ] Windows portable ZIP / Windows 便携版 ZIP
- [x] macOS Apple Silicon
- [x] macOS Intel
- [x] macOS Universal package / macOS 通用安装包
- [ ] Linux
- [ ] Not platform-specific / 与平台无关

## Verification / 验证

- [x] `corepack yarn check:layout`
- [x] `corepack yarn typecheck`
- [x] `corepack yarn test`
- [x] `corepack yarn check`
- [x] Platform package smoke / 平台打包或启动冒烟
- [x] Manual test / 人工测试

**Additional verification on macOS 26.5 arm64 / 在 macOS 26.5 arm64 上的附加验证**

- Targeted macOS packaging tests: 89 passed, 1 skipped. / macOS 打包相关定向测试：89 项通过，1 项跳过。
- Built the arm64 directory package with `yarn workspace dsh-plugin-desktop package:dir`. / 使用该命令成功构建 arm64 目录版 App。
- Confirmed both short helpers are present, executable, and have the expected Mach-O architecture. / 确认 arm64 与 x64 短路径 helper 均存在、可执行，且 Mach-O 架构正确。
- Copied the packaged App to an installed-style short path and spawned `/bin/zsh` through its patched `node-pty`; observed `PACKAGED_PTY_OK` with exit code 0. / 将打包后的 App 放到模拟安装短路径，通过补丁后的 `node-pty` 启动 `/bin/zsh`，成功输出 `PACKAGED_PTY_OK`，退出码为 0。
- Full Desktop test suite: 990 passed, 4 skipped. / Desktop 全量测试：990 项通过，4 项跳过。

## Release Notes / 发布说明

**English:** Fix persistent Bash and other PTY-backed commands failing with `posix_spawn failed` on macOS 26 by shipping and selecting a short-path helper for both Apple Silicon and Intel builds.

**中文：** 通过在 Apple Silicon 与 Intel 构建中携带并自动选择短路径 `spawn-helper`，修复 macOS 26 上持久 Bash 及其他 PTY 命令报 `posix_spawn failed`、无法执行的问题。
