### PR TITLE
fix(desktop): preserve profile client occupant state

### DIFF
--- a/dsh-plugin-desktop/src/profile.ts
+++ b/dsh-plugin-desktop/src/profile.ts
@@ -965,11 +965,10 @@ export function prepareDesktopProfile(
         throw new Error(`${BIN_NAME}: ${mode} desktop mode must use ${packageName} in the ${id} row`)
       }
     }
-    patches.push(
-      { id: 'ui-layout', disabled: true },
-      { id: 'ui-sidebar', disabled: false },
-      { id: 'ui-conversation', disabled: false },
-    )
+    // Desktop owns only the replacement root layout. Preserve the final
+    // profile state of its documented occupants so a client bundle can disable
+    // the stock Sidebar or Conversation and register a compatible replacement.
+    patches.push({ id: 'ui-layout', disabled: true })
   }
   const presets = rows.get(AGENT_PRESETS_ROW_ID)
   if (presets !== undefined) {

--- a/dsh-plugin-desktop/tests/profile.spec.ts
+++ b/dsh-plugin-desktop/tests/profile.spec.ts
@@ -720,8 +720,8 @@ virtualStoreDirMaxLength: 60
       config: expect.objectContaining({ dshHome: home }),
     }))
     expect(rows.find(row => row.id === 'ui-layout')?.disabled).toBe(true)
-    expect(rows.find(row => row.id === 'ui-sidebar')?.disabled).toBe(false)
-    expect(rows.find(row => row.id === 'ui-conversation')?.disabled).toBe(false)
+    expect(rows.find(row => row.id === 'ui-sidebar')?.disabled).toBeFalsy()
+    expect(rows.find(row => row.id === 'ui-conversation')?.disabled).toBeFalsy()
   })
 
   it('keeps legacy browser intent but clamps LAN exposure when compatibility mode is selected', () => {
@@ -770,8 +770,8 @@ virtualStoreDirMaxLength: 60
       windowsMaterial: 'mica',
     }))
     expect(rows.find(row => row.id === 'ui-layout')?.disabled).toBe(true)
-    expect(rows.find(row => row.id === 'ui-sidebar')?.disabled).toBe(false)
-    expect(rows.find(row => row.id === 'ui-conversation')?.disabled).toBe(false)
+    expect(rows.find(row => row.id === 'ui-sidebar')?.disabled).toBeFalsy()
+    expect(rows.find(row => row.id === 'ui-conversation')?.disabled).toBeFalsy()
     expect(rows.find(row => row.id === 'desktop-shell')).toEqual(expect.objectContaining({
       config: expect.objectContaining({
         mode: 'extended',
@@ -780,6 +780,32 @@ virtualStoreDirMaxLength: 60
       }),
     }))
   })
+
+  it.each(['advanced', 'extended'] as const)(
+    'preserves explicitly disabled root occupants in %s mode',
+    (mode) => {
+      const home = temporaryHome()
+      writeFileSync(join(home, 'settings.yaml'), [
+        'dsh-desktop:',
+        `  mode: ${mode}`,
+        '',
+      ].join('\n'))
+      writeFileSync(join(home, 'cordis.patch.yml'), [
+        '- id: ui-sidebar',
+        '  disabled: true',
+        '- id: ui-conversation',
+        '  disabled: true',
+        '',
+      ].join('\n'))
+
+      const prepared = prepareDesktopProfile(undefined, home, 'darwin')
+      const rows = composeEntries([prepared.patches])
+
+      expect(rows.find(row => row.id === 'ui-layout')?.disabled).toBe(true)
+      expect(rows.find(row => row.id === 'ui-sidebar')?.disabled).toBe(true)
+      expect(rows.find(row => row.id === 'ui-conversation')?.disabled).toBe(true)
+    },
+  )
 
   it('reads JSON settings and defaults an absent desktop namespace to compatibility', () => {
     const home = temporaryHome()


### PR DESCRIPTION
## Summary / 摘要

**English**

- Keep Desktop ownership limited to the replacement root layout in `advanced` and `extended` modes.
- Preserve the final profile-composed enabled/disabled state of `ui-sidebar` and `ui-conversation` instead of forcing both stock occupants back on.
- Add regression coverage for explicitly disabled Sidebar and Conversation occupants in both Desktop presentation modes.

**中文**

- 将 Desktop 在 `advanced`、`extended` 模式下的接管范围限制为根布局 `ui-layout`。
- 保留 profile 最终合成得到的 `ui-sidebar`、`ui-conversation` 启用/禁用状态，不再强制重新启用两个官方 occupant。
- 为两种 Desktop 展示模式补充显式禁用 Sidebar、Conversation 后仍被保留的回归测试。

## Root Cause / 根因

**English**

A client bundle can replace the documented single `sidebar` slot by disabling the stock `ui-sidebar` row and registering a compatible occupant. DSH Desktop composed all profile and bundle patches correctly, but then appended launcher-owned patches that unconditionally set `ui-sidebar` and `ui-conversation` to `disabled: false` in `advanced` and `extended` modes.

That late override reactivated the stock Sidebar after a replacement bundle had explicitly disabled it. Both the stock component and the replacement then registered the single `sidebar` slot at priority 0, causing renderer startup to fail.

**中文**

客户端插件可以通过禁用官方 `ui-sidebar` 条目、再注册兼容 occupant 的方式替换公开的单例 `sidebar` 插槽。DSH Desktop 虽然先正确合成了全部 profile 与 bundle 补丁，但随后又在 `advanced`、`extended` 模式追加启动器补丁，无条件把 `ui-sidebar`、`ui-conversation` 设置为 `disabled: false`。

这个末尾覆盖重新激活了已被替换插件显式禁用的官方 Sidebar。官方组件与替换组件随后同时以 priority 0 注册单例 `sidebar`，导致 Renderer 启动失败。

## Behavior / 行为变化

**English**

- With no profile override, the stock Sidebar and Conversation remain enabled as before.
- An explicit profile or bundle disable is now preserved, allowing a compatible replacement occupant to load.
- Desktop still disables the stock `ui-layout`, because the advanced/extended shell owns the replacement root layout.
- Compatibility mode is unchanged.

**中文**

- profile 未做覆盖时，官方 Sidebar 与 Conversation 仍和以前一样保持启用。
- profile 或 bundle 显式禁用 occupant 时，现在会保留该选择，从而允许兼容的替换实现加载。
- Desktop 仍会禁用官方 `ui-layout`，因为 advanced/extended shell 继续拥有替换后的根布局。
- compatibility 模式行为不变。

## Related / 关联

- Reproduced with `@michengai/dsh-codex-ui@0.2.92`, which disables the stock `ui-sidebar` and registers its replacement through the published slot contract.
- Plugin discussion / 插件介绍：deepseek-ai/deepseek-harness#4941

## Type / 类型

- [x] Bug fix / 问题修复
- [ ] Feature / 新功能
- [ ] Documentation / 文档
- [ ] Release or packaging / 发布或打包
- [ ] Tests only / 仅测试
- [ ] Other / 其他

## Platforms / 影响平台

- [x] Windows installer / Windows 安装包
- [x] Windows portable ZIP / Windows 便携版 ZIP
- [x] macOS Apple Silicon
- [x] macOS Intel
- [x] macOS Universal package / macOS 通用安装包
- [ ] Linux
- [ ] Not platform-specific / 与平台无关

## Verification / 验证

- [x] `corepack yarn check:layout`
- [x] `corepack yarn typecheck`
- [x] `corepack yarn test`
- [x] `corepack yarn check`
- [x] Manual test / 人工测试

Additional verification / 附加验证：

- Profile composition tests: 42 passed. / Profile 合成测试：42 项通过。
- Full Desktop test suite: 988 passed, 4 skipped. / Desktop 全量测试：988 项通过，4 项跳过。
- Applied the equivalent patch to DSH Desktop 2.0.4 on macOS with `@michengai/dsh-codex-ui@0.2.92`; the application completed renderer startup and the Codex UI sidebar rendered successfully. / 在 macOS 的 DSH Desktop 2.0.4 与 Codex UI 0.2.92 上应用等价补丁后，Renderer 正常启动，Codex UI 侧边栏成功渲染。

## Release Notes / 发布说明

**English:** Advanced and extended Desktop modes now respect profile plugins that explicitly disable the stock Sidebar or Conversation to provide compatible replacements.

**中文：** Desktop 的 advanced、extended 模式现在会尊重 profile 插件对官方 Sidebar 或 Conversation 的显式禁用，从而允许兼容的替换实现正常加载。
