### PR TITLE
fix(desktop): clear Windows backdrop when material is off

### DIFF
--- a/dsh-plugin-desktop/src/electron-platform.ts
+++ b/dsh-plugin-desktop/src/electron-platform.ts
@@ -3,6 +3,7 @@ import type { BrowserWindow, MenuItemConstructorOptions, NativeImage } from 'ele
 import { macApplicationMenuTemplate, nativeMenuLocale } from './native-menu.ts'
 import type { DesktopPlatform } from './runtime.ts'
 import type { DesktopWindowMaterial } from './window-material.ts'
+import { windowsSupportsSystemBackdrop } from './window-material.ts'
 import type { DesktopDownloadPlatform } from './update-download.ts'
 
 /** Native presentation and capability differences selected once at startup. */
@@ -18,7 +19,11 @@ export interface ElectronPlatformStrategy {
   ): void
   refreshApplicationMenu(applicationMenuItems: readonly MenuItemConstructorOptions[]): void
   configureWindow(window: BrowserWindow): void
-  refreshThemeMaterial(window: BrowserWindow, material: DesktopWindowMaterial): void
+  refreshThemeMaterial(
+    window: BrowserWindow,
+    material: DesktopWindowMaterial,
+    windowsBuild: number | undefined,
+  ): void
 }
 
 class WindowsPlatformStrategy implements ElectronPlatformStrategy {
@@ -39,8 +44,13 @@ class WindowsPlatformStrategy implements ElectronPlatformStrategy {
     window.removeMenu()
   }
 
-  refreshThemeMaterial(window: BrowserWindow, material: DesktopWindowMaterial): void {
-    if (material === 'mica') window.setBackgroundMaterial(material)
+  refreshThemeMaterial(
+    window: BrowserWindow,
+    material: DesktopWindowMaterial,
+    windowsBuild: number | undefined,
+  ): void {
+    if (!windowsSupportsSystemBackdrop(windowsBuild)) return
+    window.setBackgroundMaterial(material === 'mica' ? 'mica' : 'none')
   }
 }
 
@@ -75,7 +85,11 @@ class MacPlatformStrategy implements ElectronPlatformStrategy {
 
   configureWindow(_window: BrowserWindow): void {}
 
-  refreshThemeMaterial(_window: BrowserWindow, _material: DesktopWindowMaterial): void {}
+  refreshThemeMaterial(
+    _window: BrowserWindow,
+    _material: DesktopWindowMaterial,
+    _windowsBuild: number | undefined,
+  ): void {}
 }
 
 class LinuxPlatformStrategy implements ElectronPlatformStrategy {
@@ -94,7 +108,11 @@ class LinuxPlatformStrategy implements ElectronPlatformStrategy {
 
   configureWindow(_window: BrowserWindow): void {}
 
-  refreshThemeMaterial(_window: BrowserWindow, _material: DesktopWindowMaterial): void {}
+  refreshThemeMaterial(
+    _window: BrowserWindow,
+    _material: DesktopWindowMaterial,
+    _windowsBuild: number | undefined,
+  ): void {}
 }
 
 /** Select the only platform adapter used by one Electron runtime generation. */

--- a/dsh-plugin-desktop/src/electron-shell-generation.ts
+++ b/dsh-plugin-desktop/src/electron-shell-generation.ts
@@ -219,7 +219,7 @@ export class ElectronShellGeneration {
     window.accessibleTitle = spec.windowTitle
     platform.configureWindow(window)
     const refreshNativeMaterial = (): void => {
-      platform.refreshThemeMaterial(window, spec.material)
+      platform.refreshThemeMaterial(window, spec.material, spec.windowsBuild)
     }
     this.refreshNativeMaterial = refreshNativeMaterial
     refreshNativeMaterial()

--- a/dsh-plugin-desktop/src/window-options.ts
+++ b/dsh-plugin-desktop/src/window-options.ts
@@ -134,9 +134,10 @@ function customChromeWindowOptions(
       : custom
   }
   if (platform === 'win32') {
+    // Omitting the option leaves DWM free to choose AUTO, which can retain a
+    // Mica backdrop even when the Desktop preference is explicitly off.
     const systemMaterial = windowsSupportsSystemBackdrop(spec.windowsBuild)
-      && spec.material === 'mica'
-      ? 'mica' as const
+      ? spec.material === 'mica' ? 'mica' as const : 'none' as const
       : undefined
     return {
       ...options,
@@ -147,7 +148,7 @@ function customChromeWindowOptions(
         symbolColor: '#7f858f',
         height: geometry.titlebarHeight,
       },
-      ...(systemMaterial === undefined ? {} : { backgroundColor: '#00000000' }),
+      ...(systemMaterial === 'mica' ? { backgroundColor: '#00000000' } : {}),
       ...(systemMaterial === undefined ? {} : { backgroundMaterial: systemMaterial }),
       hasShadow: true,
       roundedCorners: true,

--- a/dsh-plugin-desktop/tests/electron-platform.spec.ts
+++ b/dsh-plugin-desktop/tests/electron-platform.spec.ts
@@ -48,7 +48,7 @@ describe('electronPlatformStrategy', () => {
 
     strategy.configureApplication(icon, 'DSH Desktop')
     strategy.configureWindow(window as never)
-    strategy.refreshThemeMaterial(window as never, 'mica')
+    strategy.refreshThemeMaterial(window as never, 'mica', 22_621)
 
     expect(electron.app.dock.setIcon).not.toHaveBeenCalled()
     expect(electron.Menu.setApplicationMenu).not.toHaveBeenCalled()
@@ -56,6 +56,19 @@ describe('electronPlatformStrategy', () => {
     expect(window.setBackgroundMaterial.mock.calls).toEqual([
       ['mica'],
     ])
+  })
+
+  it('clears the Windows backdrop only when the system supports native materials', () => {
+    const strategy = electronPlatformStrategy('win32')
+    const window = createWindow()
+
+    strategy.refreshThemeMaterial(window as never, 'off', 22_621)
+    expect(window.setBackgroundMaterial).toHaveBeenCalledOnce()
+    expect(window.setBackgroundMaterial).toHaveBeenCalledWith('none')
+
+    window.setBackgroundMaterial.mockClear()
+    strategy.refreshThemeMaterial(window as never, 'off', 22_000)
+    expect(window.setBackgroundMaterial).not.toHaveBeenCalled()
   })
 
   it('selects the macOS adapter and configures its native application chrome', () => {
@@ -70,7 +83,7 @@ describe('electronPlatformStrategy', () => {
 
     strategy.configureApplication(icon, 'DSH Desktop')
     strategy.configureWindow(window as never)
-    strategy.refreshThemeMaterial(window as never, 'transparent')
+    strategy.refreshThemeMaterial(window as never, 'transparent', undefined)
 
     expect(electron.app.dock.setIcon).toHaveBeenCalledWith(icon)
     expect(electron.Menu.buildFromTemplate).toHaveBeenCalledTimes(1)
@@ -90,7 +103,7 @@ describe('electronPlatformStrategy', () => {
 
     strategy.configureApplication({} as never, 'DSH Desktop')
     strategy.configureWindow(window as never)
-    strategy.refreshThemeMaterial(window as never, 'off')
+    strategy.refreshThemeMaterial(window as never, 'off', undefined)
 
     expect(electron.app.dock.setIcon).not.toHaveBeenCalled()
     expect(electron.Menu.setApplicationMenu).not.toHaveBeenCalled()

--- a/dsh-plugin-desktop/tests/electron-runtime.spec.ts
+++ b/dsh-plugin-desktop/tests/electron-runtime.spec.ts
@@ -2237,6 +2237,7 @@ describe('Electron desktop runtime', () => {
     }))
     expect(electron.browserWindowOptions[0]).not.toHaveProperty('transparent')
     expect(electron.browserWindowOptions[0]).not.toHaveProperty('backgroundMaterial')
+    expect(electron.browserWindows[0]?.setBackgroundMaterial).not.toHaveBeenCalled()
     expect(electron.menuTemplates[0]).toEqual(expect.arrayContaining([
       expect.objectContaining({ label: 'Switch to Enhanced Mode', enabled: true }),
     ]))
@@ -2244,7 +2245,7 @@ describe('Electron desktop runtime', () => {
     await release()
   })
 
-  it('does not install a native backdrop when Windows material is off', async () => {
+  it('clears the native backdrop when Windows material is off', async () => {
     vi.spyOn(process, 'platform', 'get').mockReturnValue('win32')
     electron.nativeTheme.themeSource = 'light'
     const { ElectronDesktopRuntime } = await import('../src/electron-runtime.ts')
@@ -2261,14 +2262,18 @@ describe('Electron desktop runtime', () => {
 
     expect(electron.browserWindowOptions[0]).toEqual(expect.objectContaining({
       backgroundColor: '#202124',
+      backgroundMaterial: 'none',
       roundedCorners: true,
       thickFrame: true,
     }))
     expect(electron.browserWindowOptions[0]).not.toHaveProperty('transparent')
     const window = electron.browserWindows[0]
+    expect(window?.setBackgroundMaterial).toHaveBeenCalledOnce()
+    expect(window?.setBackgroundMaterial).toHaveBeenCalledWith('none')
     window?.setBackgroundMaterial.mockClear()
     runtime.setThemeSource('light')
-    expect(window?.setBackgroundMaterial).not.toHaveBeenCalled()
+    expect(window?.setBackgroundMaterial).toHaveBeenCalledOnce()
+    expect(window?.setBackgroundMaterial).toHaveBeenCalledWith('none')
 
     await release()
   })

--- a/dsh-plugin-desktop/tests/window-options.spec.ts
+++ b/dsh-plugin-desktop/tests/window-options.spec.ts
@@ -171,6 +171,23 @@ describe('compatibility BrowserWindow options', () => {
     expect(options).not.toHaveProperty('backgroundMaterial')
   })
 
+  it('explicitly disables the system backdrop when material is off on supported Windows builds', () => {
+    const options = advancedWindowOptions(
+      { ...spec, mode: 'advanced', material: 'off', windowsBuild: 22_621 },
+      {} as NativeImage,
+      'win32',
+      preload,
+    )
+
+    expect(options).toEqual(expect.objectContaining({
+      backgroundColor: '#202124',
+      backgroundMaterial: 'none',
+      roundedCorners: true,
+      thickFrame: true,
+    }))
+    expect(options).not.toHaveProperty('transparent')
+  })
+
   it('uses the taller native caption and capability-gated material in extended mode', () => {
     const extended = {
       ...spec,


### PR DESCRIPTION
## Summary / 摘要

- Explicitly set `backgroundMaterial: 'none'` on Windows 11 build 22621 and newer when the configured window material is `off`.
- Reapply the disabled native backdrop after window creation and theme refreshes.
- Keep the disabled-material window opaque and preserve the existing capability gate for older Windows versions.
- Add regression coverage for supported and unsupported Windows builds.

在 Windows 11 build 22621 及以上版本中，当窗口材质设置为 `off` 时，显式设置 `backgroundMaterial: 'none'`，避免 DWM 继续自动保留 Mica 背景。同时在窗口创建和主题刷新链路中重新应用该状态，并补充新旧 Windows build 的回归测试。

## Related Issues / 关联 Issue

Fixes #722

## Type / 类型

- [x] Bug fix / 问题修复
- [ ] Feature / 新功能
- [ ] Documentation / 文档
- [ ] Release or packaging / 发布或打包
- [ ] Tests only / 仅测试
- [ ] Other / 其他

## Platforms / 影响平台

- [x] Windows installer / Windows 安装包
- [x] Windows portable ZIP / Windows 便携版 ZIP
- [ ] macOS Apple Silicon
- [ ] macOS Intel
- [ ] macOS Universal package / macOS 通用安装包
- [ ] Linux
- [ ] Not platform-specific / 与平台无关

## Verification / 验证

- [x] Targeted tests: 82 passed
- [x] `corepack yarn workspace dsh-plugin-desktop typecheck`
- [x] `corepack yarn workspace dsh-plugin-desktop build`
- [x] `git diff --check`
- [ ] `corepack yarn check` — reached the Desktop test phase, then stopped on existing Windows environment failures involving symlink/temp-directory `EPERM`, a missing Electron binary, and pnpm fixture PATH resolution
- [ ] Native Windows 11 DWM validation — current test host is Windows 10 build 19045

## Release Notes / 发布说明

Fixed Windows 11 continuing to display a Mica backdrop after the window material setting was turned off.
