### PR TITLE
fix(desktop): fit main window to small work areas

### DIFF
--- a/dsh-plugin-desktop/src/electron-shell-generation.ts
+++ b/dsh-plugin-desktop/src/electron-shell-generation.ts
@@ -19,9 +19,10 @@ import { prepareTrayIcon } from './tray-icons.ts'
 import { desktopWindowOptions } from './window-options.ts'
 import type { DesktopRendererAccessHeader } from './desktop-browser-access.ts'
 import {
-  fitMainWindowBounds,
+  resolveMainWindowLayout,
   sameMainWindowBounds,
   type MainWindowBounds,
+  type MainWindowLayout,
   type MainWindowStateStore,
 } from './main-window-state.ts'
 
@@ -199,22 +200,28 @@ export class ElectronShellGeneration {
     const origin = new URL(spec.url).origin
     if (platform.platform !== 'linux') nativeTheme.themeSource = spec.readThemeSource()
     let persistedBounds: MainWindowBounds | undefined
-    let restoredBounds: MainWindowBounds | undefined
     try {
       persistedBounds = this.options.mainWindowState.read()
-      if (persistedBounds !== undefined) {
-        const display = screen.getDisplayMatching(persistedBounds)
-        restoredBounds = fitMainWindowBounds(persistedBounds, display.workArea, {
-          width: spec.minWidth,
-          height: spec.minHeight,
-        })
-      }
     } catch (cause) {
       this.options.logError(`dsh-plugin-desktop: failed to restore main-window state: ${cause instanceof Error ? cause.message : String(cause)}`)
     }
+    let windowLayout: MainWindowLayout | undefined
+    try {
+      const display = persistedBounds === undefined
+        ? screen.getPrimaryDisplay()
+        : screen.getDisplayMatching(persistedBounds)
+      windowLayout = resolveMainWindowLayout(
+        persistedBounds,
+        display.workArea,
+        { width: spec.width, height: spec.height },
+        { width: spec.minWidth, height: spec.minHeight },
+      )
+    } catch (cause) {
+      this.options.logError(`dsh-plugin-desktop: failed to fit main window to the display: ${cause instanceof Error ? cause.message : String(cause)}`)
+    }
     const window = new BrowserWindow({
       ...desktopWindowOptions(spec, icon, platform.platform, this.options.preloadPath),
-      ...(restoredBounds ?? {}),
+      ...(windowLayout ?? {}),
     })
     window.accessibleTitle = spec.windowTitle
     platform.configureWindow(window)

--- a/dsh-plugin-desktop/src/main-window-state.ts
+++ b/dsh-plugin-desktop/src/main-window-state.ts
@@ -26,6 +26,16 @@ export interface MainWindowBounds {
   readonly height: number
 }
 
+/** Display-aware dimensions used to construct the main BrowserWindow. */
+export interface MainWindowLayout {
+  readonly x?: number
+  readonly y?: number
+  readonly width: number
+  readonly height: number
+  readonly minWidth: number
+  readonly minHeight: number
+}
+
 interface MainWindowStateV1 {
   readonly version: 1
   readonly bounds: MainWindowBounds
@@ -132,8 +142,14 @@ export function fitMainWindowBounds(
 ): MainWindowBounds {
   const restored = parseBounds(bounds)
   const available = parseBounds(workArea)
-  const minWidth = isPositiveDimension(minimum.width) ? minimum.width : 1
-  const minHeight = isPositiveDimension(minimum.height) ? minimum.height : 1
+  const minWidth = Math.min(
+    isPositiveDimension(minimum.width) ? minimum.width : 1,
+    available.width,
+  )
+  const minHeight = Math.min(
+    isPositiveDimension(minimum.height) ? minimum.height : 1,
+    available.height,
+  )
   const width = Math.max(minWidth, Math.min(restored.width, available.width))
   const height = Math.max(minHeight, Math.min(restored.height, available.height))
   const visibleWidth = Math.max(
@@ -155,6 +171,39 @@ export function fitMainWindowBounds(
     y: Math.min(maxY, Math.max(available.y, restored.y)),
     width,
     height,
+  }
+}
+
+/** Resolve dimensions and native minimums against one selected display. */
+export function resolveMainWindowLayout(
+  savedBounds: MainWindowBounds | undefined,
+  workArea: MainWindowBounds,
+  initial: Pick<MainWindowBounds, 'width' | 'height'>,
+  minimum: Pick<MainWindowBounds, 'width' | 'height'>,
+): MainWindowLayout {
+  const available = parseBounds(workArea)
+  const minWidth = Math.min(
+    isPositiveDimension(minimum.width) ? minimum.width : 1,
+    available.width,
+  )
+  const minHeight = Math.min(
+    isPositiveDimension(minimum.height) ? minimum.height : 1,
+    available.height,
+  )
+  if (savedBounds !== undefined) {
+    return {
+      ...fitMainWindowBounds(savedBounds, available, { width: minWidth, height: minHeight }),
+      minWidth,
+      minHeight,
+    }
+  }
+  const initialWidth = isPositiveDimension(initial.width) ? initial.width : minWidth
+  const initialHeight = isPositiveDimension(initial.height) ? initial.height : minHeight
+  return {
+    width: Math.max(minWidth, Math.min(initialWidth, available.width)),
+    height: Math.max(minHeight, Math.min(initialHeight, available.height)),
+    minWidth,
+    minHeight,
   }
 }
 

--- a/dsh-plugin-desktop/tests/electron-runtime.spec.ts
+++ b/dsh-plugin-desktop/tests/electron-runtime.spec.ts
@@ -240,6 +240,9 @@ const electron = vi.hoisted(() => {
       getDisplayMatching: vi.fn(() => ({
         workArea: { x: 0, y: 0, width: 1920, height: 1080 },
       })),
+      getPrimaryDisplay: vi.fn(() => ({
+        workArea: { x: 0, y: 0, width: 1920, height: 1080 },
+      })),
     },
     shell: {
       openExternal: vi.fn(async () => {}),
@@ -633,14 +636,39 @@ describe('Electron desktop runtime', () => {
     expect(electron.browserWindowOff).toHaveBeenCalledWith('resize', expect.any(Function))
   })
 
-  it('fits stale saved bounds into the current display work area', async () => {
+  it('fits first-launch dimensions and minimums to a small primary work area', async () => {
+    vi.spyOn(process, 'platform', 'get').mockReturnValue('win32')
+    electron.screen.getPrimaryDisplay.mockReturnValueOnce({
+      workArea: { x: -800, y: 24, width: 800, height: 520 },
+    })
+    const { ElectronDesktopRuntime } = await import('../src/electron-runtime.ts')
+    const runtime = new ElectronDesktopRuntime(async () => {})
+    const release = runtime.schedule(spec)
+
+    await runtime.mountScheduled()
+
+    expect(electron.screen.getPrimaryDisplay).toHaveBeenCalledOnce()
+    expect(electron.screen.getDisplayMatching).not.toHaveBeenCalled()
+    expect(electron.browserWindowOptions[0]).toEqual(expect.objectContaining({
+      width: 800,
+      height: 520,
+      minWidth: 800,
+      minHeight: 520,
+    }))
+    expect(electron.browserWindowOptions[0]).not.toHaveProperty('x')
+    expect(electron.browserWindowOptions[0]).not.toHaveProperty('y')
+
+    await release()
+  })
+
+  it('fits stale saved bounds and minimums into the current display work area', async () => {
     vi.spyOn(process, 'platform', 'get').mockReturnValue('darwin')
     const { FileMainWindowStateStore } = await import('../src/main-window-state.ts')
     const store = new FileMainWindowStateStore('/tmp/dsh-desktop-user-data')
     const stale = { x: 5_000, y: -2_000, width: 2_000, height: 1_400 }
     store.write(stale)
     electron.screen.getDisplayMatching.mockReturnValueOnce({
-      workArea: { x: 0, y: 24, width: 1440, height: 876 },
+      workArea: { x: 0, y: 24, width: 800, height: 520 },
     })
     const { ElectronDesktopRuntime } = await import('../src/electron-runtime.ts')
     const runtime = new ElectronDesktopRuntime(async () => {})
@@ -652,8 +680,71 @@ describe('Electron desktop runtime', () => {
     expect(electron.browserWindowOptions[0]).toEqual(expect.objectContaining({
       x: 0,
       y: 24,
-      width: 1440,
-      height: 876,
+      width: 800,
+      height: 520,
+      minWidth: 800,
+      minHeight: 520,
+    }))
+
+    await release()
+  })
+
+  it('uses the first-launch layout after a saved-state read failure', async () => {
+    vi.spyOn(process, 'platform', 'get').mockReturnValue('darwin')
+    electron.screen.getPrimaryDisplay.mockReturnValueOnce({
+      workArea: { x: 0, y: 24, width: 800, height: 520 },
+    })
+    const logger = { error: vi.fn(), errorCause: vi.fn() }
+    const mainWindowState = {
+      read: vi.fn(() => { throw new Error('invalid state') }),
+      write: vi.fn(),
+    }
+    const { ElectronDesktopRuntime } = await import('../src/electron-runtime.ts')
+    const runtime = new ElectronDesktopRuntime(
+      async () => {},
+      undefined,
+      logger,
+      undefined,
+      mainWindowState,
+    )
+    const release = runtime.schedule(spec)
+
+    await runtime.mountScheduled()
+
+    expect(logger.error).toHaveBeenCalledWith(
+      'dsh-plugin-desktop: failed to restore main-window state: invalid state',
+    )
+    expect(electron.screen.getPrimaryDisplay).toHaveBeenCalledOnce()
+    expect(electron.browserWindowOptions[0]).toEqual(expect.objectContaining({
+      width: 800,
+      height: 520,
+      minWidth: 800,
+      minHeight: 520,
+    }))
+
+    await release()
+  })
+
+  it('keeps static window options when the display work area is unavailable', async () => {
+    vi.spyOn(process, 'platform', 'get').mockReturnValue('darwin')
+    electron.screen.getPrimaryDisplay.mockImplementationOnce(() => {
+      throw new Error('screen unavailable')
+    })
+    const logger = { error: vi.fn(), errorCause: vi.fn() }
+    const { ElectronDesktopRuntime } = await import('../src/electron-runtime.ts')
+    const runtime = new ElectronDesktopRuntime(async () => {}, undefined, logger)
+    const release = runtime.schedule(spec)
+
+    await runtime.mountScheduled()
+
+    expect(logger.error).toHaveBeenCalledWith(
+      'dsh-plugin-desktop: failed to fit main window to the display: screen unavailable',
+    )
+    expect(electron.browserWindowOptions[0]).toEqual(expect.objectContaining({
+      width: 1280,
+      height: 840,
+      minWidth: 900,
+      minHeight: 640,
     }))
 
     await release()

--- a/dsh-plugin-desktop/tests/main-window-state.spec.ts
+++ b/dsh-plugin-desktop/tests/main-window-state.spec.ts
@@ -5,6 +5,7 @@ import { afterEach, describe, expect, it } from 'vitest'
 import {
   FileMainWindowStateStore,
   fitMainWindowBounds,
+  resolveMainWindowLayout,
 } from '../src/main-window-state.ts'
 
 const temporaryDirectories: string[] = []
@@ -58,5 +59,46 @@ describe('main-window state', () => {
       workArea,
       minimum,
     )).toEqual({ x: -1440, y: 24, width: 1440, height: 876 })
+  })
+
+  it('lowers restored bounds and native minimums to a small work area', () => {
+    expect(resolveMainWindowLayout(
+      { x: 120, y: 80, width: 1280, height: 840 },
+      { x: 0, y: 0, width: 800, height: 520 },
+      { width: 1280, height: 840 },
+      { width: 900, height: 640 },
+    )).toEqual({
+      x: 0,
+      y: 0,
+      width: 800,
+      height: 520,
+      minWidth: 800,
+      minHeight: 520,
+    })
+  })
+
+  it('fits first-launch dimensions without forcing display coordinates', () => {
+    expect(resolveMainWindowLayout(
+      undefined,
+      { x: -800, y: 24, width: 800, height: 520 },
+      { width: 1280, height: 840 },
+      { width: 900, height: 640 },
+    )).toEqual({
+      width: 800,
+      height: 520,
+      minWidth: 800,
+      minHeight: 520,
+    })
+    expect(resolveMainWindowLayout(
+      undefined,
+      { x: 0, y: 24, width: 1440, height: 876 },
+      { width: 800, height: 600 },
+      { width: 900, height: 640 },
+    )).toEqual({
+      width: 900,
+      height: 640,
+      minWidth: 900,
+      minHeight: 640,
+    })
   })
 })


### PR DESCRIPTION
## Summary / 摘要

- Fit first-launch and restored main-window geometry to the selected display work area.
- Cap effective minimum dimensions to displays smaller than the configured minimum while preserving the configured minimum on normal displays.
- Preserve saved positioning when valid, let Electron place an unsaved first window, and fall back safely if state or screen lookup fails.
- Add pure geometry and Electron-runtime regression coverage for small displays, corrupt state, and screen API failures.

## Related Issues / 关联 Issue

N/A — found during local inspection.

## Type / 类型

- [x] Bug fix / Bug 修复
- [ ] Feature / 新功能
- [ ] Refactor / 重构
- [ ] Documentation / 文档
- [ ] Tests / 测试
- [ ] Chore / 维护

## Platforms / 影响平台

- [x] Not platform-specific / 非平台特定
- [ ] Windows installer / Windows 安装版
- [ ] Windows portable / Windows 便携版
- [ ] macOS
- [ ] Linux

## Verification / 验证

- [x] `corepack yarn check:layout`
- [x] `corepack yarn typecheck`
- [ ] `corepack yarn test`
- [ ] `corepack yarn check`
- [ ] Platform package smoke / 平台打包冒烟
- [x] Manual test / 手工测试

Additional verification:

- Focused desktop regression suites: 84/84 passed.
- Desktop full suite: 970 passed, 12 skipped, 13 failed due to Windows-host constraints/flakes unrelated to this diff (10 symlink privilege errors, missing `pnpm` in one packaged fixture, one lifecycle timeout, and one atomic-rename `EPERM`).
- Root `corepack yarn check` passed documentation/layout checks, Market build and 268/268 Market tests, Desktop build, and Desktop typecheck; it stopped at the same 13 Desktop environment failures.
- `git diff --check` passed.
- Independent review found no blocking or non-blocking findings.

Manual Windows monitor-disconnect smoke testing passed: the window was saved on a secondary display, restarted with only the primary display enabled, and remained fully visible after being fitted to the primary work area. High-DPI/RDP was not tested separately.

## Release Notes / 发布说明

The Desktop main window now stays within the available display work area on small, scaled, and remote-desktop displays. No migration or configuration change is required.