### PR TITLE
feat(desktop): hot-apply the user patch layer without restart

### DIFF
--- a/dsh-plugin-desktop/package.json
+++ b/dsh-plugin-desktop/package.json
@@ -269,6 +269,7 @@
     "@deepseek-ai/dsh-workspace": "0.1.2-alpha.1",
     "@deepseek-ai/schemastery": "^3.18.1",
     "adm-zip": "^0.6.0",
+    "chokidar": "^4.0.3",
     "dsh-community-market": "0.1.0-dev.0",
     "dshmarket": "1.17.1",
     "koffi": "3.1.5",

--- a/dsh-plugin-desktop/src/main.ts
+++ b/dsh-plugin-desktop/src/main.ts
@@ -61,6 +61,7 @@ import {
 } from './lan-https-runtime.ts'
 import { LogFileSink } from './log-files.ts'
 import { maskSecrets } from './mask-secrets.ts'
+import { watchDesktopPatchLayer } from './patch-watcher.ts'
 import { resolveDesktopShellEnvironment } from './shell-environment.ts'
 import { installProfilePackageResolver } from './module-resolution.ts'
 import { packagedDependencyPath } from './packaged-runtime-path.ts'
@@ -1031,6 +1032,16 @@ async function start(): Promise<void> {
     startupStage = 'host-boot'
     lifecycleRecorder.transitionStartupStage(startupStage)
     const releasePackageResolver = installProfilePackageResolver(prepared.bareModuleBaseUrl)
+    const generationMarketSelection = marketSelection
+    const recomposePrepared = (): ReturnType<typeof prepareDesktopProfile> => prepareDesktopProfile(
+      process.env.DSH_TELEMETRY_DISABLED,
+      homeDir,
+      process.platform,
+      activeProfileName,
+      pluginManagementStatePath,
+      generationMarketSelection,
+      preparationHooks,
+    )
     const ctx = await boot(
       BIN_NAME,
       prepared.rootConfig,
@@ -1203,6 +1214,26 @@ async function start(): Promise<void> {
       throw cause
     })
     generation.bindHost(ctx)
+    if (prepared.profile.patchReload === 'live') {
+      try {
+        const disposePatchWatch = await watchDesktopPatchLayer(ctx, {
+          binName: BIN_NAME,
+          filenames: [
+            prepared.profile.patchPath,
+            join(homeDir, PROFILE_PATCH_FILENAME),
+          ],
+          compose: () => recomposePrepared().patches,
+        })
+        ctx.effect(
+          () => disposePatchWatch,
+          `${BIN_NAME}: desktop patch-layer watcher`,
+        )
+      } catch (cause) {
+        ctx.logger.error(
+          `${BIN_NAME}: failed to start desktop patch-layer watcher: ${cause instanceof Error ? cause.message : String(cause)}`,
+        )
+      }
+    }
     fileExporter?.setThreshold((ctx.settings.get(DESKTOP_SETTINGS_NAMESPACE) as DesktopSettings | undefined)?.logLevel ?? 'info')
     ctx.on('settings/updated', (namespace, next) => {
       if (namespace === DESKTOP_SETTINGS_NAMESPACE) {

--- a/dsh-plugin-desktop/src/patch-watcher.ts
+++ b/dsh-plugin-desktop/src/patch-watcher.ts
@@ -1,0 +1,126 @@
+import { watch } from 'chokidar'
+import type { PatchOptions } from '@deepseek-ai/cordis-plugin-include'
+
+/**
+ * Desktop-owned live patch-layer watcher.
+ *
+ * `dsh web` re-applies `<profile>/cordis.patch.yml` through `watchUserPatches`,
+ * which rides on the Cordis HMR service. The packaged desktop host keeps
+ * `loader.internal` cleared and ships the HMR row disabled, so it cannot use
+ * that path. This module watches the same files with chokidar and re-applies
+ * the full patch list through the loader's own transactional entry update —
+ * the root include entry re-applies its patches over the empty root, exactly
+ * like boot composition, with rollback when the new composition fails.
+ */
+
+/** The slice of the Cordis context the watcher depends on. */
+export interface DesktopPatchWatchHost {
+  loader: {
+    resolve(id: string): RootIncludeEntry | undefined
+  }
+  logger: {
+    info(message: string): void
+    error(message: string): void
+  }
+}
+
+/** The root include entry surface used for re-application. */
+export interface RootIncludeEntry {
+  options: { config?: unknown }
+  update(options: { config: RootIncludeConfig }): Promise<unknown>
+}
+
+/** The root include entry config shape installed by `mountRootInclude`. */
+export interface RootIncludeConfig {
+  path: string
+  patches?: PatchOptions[]
+}
+
+export interface DesktopPatchWatcherOptions {
+  /** Diagnostic prefix used in log lines. */
+  binName: string
+  /** Absolute paths of the patch files to watch (add/change/unlink). */
+  filenames: string[]
+  /** Recompute the complete ordered patch list for the current generation. */
+  compose: () => PatchOptions[]
+  /** Coalescing window for editor save-replace bursts, in milliseconds. */
+  debounceMs?: number
+}
+
+function describeCause(cause: unknown): string {
+  return cause instanceof Error ? cause.message : String(cause)
+}
+
+/**
+ * Watch the desktop patch layer and transactionally re-apply it on change.
+ *
+ * The returned disposer closes the watcher and waits for any in-flight
+ * re-apply; wire it through `ctx.effect()` so generation teardown disposes it.
+ * A malformed patch file or a composition failure is logged loudly while the
+ * previous generation stays mounted (the loader entry update rolls back).
+ */
+export async function watchDesktopPatchLayer(
+  host: DesktopPatchWatchHost,
+  options: DesktopPatchWatcherOptions,
+): Promise<() => Promise<void>> {
+  const { binName, filenames, compose, debounceMs = 150 } = options
+  const include = host.loader.resolve('include')
+  const includeConfig = include?.options.config as RootIncludeConfig | undefined
+  if (include === undefined || typeof includeConfig?.path !== 'string') {
+    throw new Error(`${binName}: root include entry is unavailable for patch-layer watching`)
+  }
+
+  let pending: ReturnType<typeof setTimeout> | undefined
+  let refreshing: Promise<void> = Promise.resolve()
+
+  const refresh = async (): Promise<void> => {
+    const patches = compose()
+    const current = include.options.config as RootIncludeConfig
+    await include.update({
+      config: {
+        ...current,
+        patches,
+      },
+    })
+    host.logger.info(`${binName}: re-applied desktop patch layer (${patches.length} entries)`)
+  }
+
+  const schedule = (): void => {
+    if (pending !== undefined) clearTimeout(pending)
+    pending = setTimeout(() => {
+      pending = undefined
+      refreshing = refreshing.then(
+        async () => {
+          try {
+            await refresh()
+          } catch (cause) {
+            host.logger.error(
+              `${binName}: failed to re-apply desktop patch layer, keeping previous generation: ${describeCause(cause)}`,
+            )
+          }
+        },
+        async () => {},
+      )
+    }, debounceMs)
+  }
+
+  const watcher = watch(filenames, { ignoreInitial: true })
+  watcher.on('add', schedule)
+  watcher.on('change', schedule)
+  watcher.on('unlink', schedule)
+  await new Promise<void>((resolve, reject) => {
+    watcher.once('ready', () => { resolve() })
+    watcher.once('error', (cause) => { reject(cause instanceof Error ? cause : new Error(String(cause))) })
+  })
+  // Chokidar can attribute same-tick writes to the initial scan; settle one
+  // tick so the first real edit is always observed as a change.
+  await new Promise(resolve => setImmediate(resolve))
+  host.logger.info(`${binName}: watching desktop patch layer (${filenames.join(', ')})`)
+
+  return async () => {
+    if (pending !== undefined) clearTimeout(pending)
+    pending = undefined
+    await watcher.close()
+    await refreshing
+  }
+}

--- a/dsh-plugin-desktop/tests/patch-watcher.spec.ts
+++ b/dsh-plugin-desktop/tests/patch-watcher.spec.ts
@@ -1,0 +1,199 @@
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { pathToFileURL } from 'node:url'
+import { afterEach, describe, expect, it } from 'vitest'
+import type { PatchOptions } from '@deepseek-ai/cordis-plugin-include'
+import {
+  watchDesktopPatchLayer,
+  type DesktopPatchWatchHost,
+  type RootIncludeConfig,
+} from '../src/patch-watcher.ts'
+
+interface FakeIncludeEntry {
+  options: { config: RootIncludeConfig }
+  updates: RootIncludeConfig[]
+  failNextUpdate: boolean
+  update(options: { config: RootIncludeConfig }): Promise<void>
+}
+
+function fakeIncludeEntry(): FakeIncludeEntry {
+  const entry: FakeIncludeEntry = {
+    options: { config: { path: pathToFileURL(join(tmpdir(), 'root-cordis.yml')).href } },
+    updates: [],
+    failNextUpdate: false,
+    async update(options) {
+      if (entry.failNextUpdate) {
+        entry.failNextUpdate = false
+        throw new Error('injected update failure')
+      }
+      entry.updates.push(options.config)
+    },
+  }
+  return entry
+}
+
+function fakeHost(include: FakeIncludeEntry) {
+  const logs: string[] = []
+  return {
+    logs,
+    host: {
+      loader: { resolve: (id: string) => (id === 'include' ? include : undefined) },
+      logger: {
+        info: (message: string) => { logs.push(message) },
+        error: (message: string) => { logs.push(message) },
+      },
+    } satisfies DesktopPatchWatchHost,
+  }
+}
+
+async function until(condition: () => boolean, timeoutMs = 5000): Promise<void> {
+  const start = Date.now()
+  while (!condition()) {
+    if (Date.now() - start > timeoutMs) throw new Error('condition not met within timeout')
+    await new Promise(resolve => setTimeout(resolve, 20))
+  }
+}
+
+const tempDirs: string[] = []
+
+function temporaryDir(): string {
+  const dir = mkdtempSync(join(tmpdir(), 'dsh-desktop-patch-watch-'))
+  tempDirs.push(dir)
+  return dir
+}
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+describe('watchDesktopPatchLayer', () => {
+  it('re-applies the composed patches after a file change', async () => {
+    const dir = temporaryDir()
+    const patchPath = join(dir, 'cordis.patch.yml')
+    writeFileSync(patchPath, '[]\n')
+    const include = fakeIncludeEntry()
+    const { host, logs } = fakeHost(include)
+    const composed: PatchOptions[] = [{ id: 'probe', name: 'probe-plugin' }]
+    const dispose = await watchDesktopPatchLayer(host, {
+      binName: 'dsh-plugin-desktop',
+      filenames: [patchPath],
+      compose: () => composed,
+      debounceMs: 20,
+    })
+    await new Promise(resolve => setTimeout(resolve, 100))
+    writeFileSync(patchPath, '- insert:\n    - id: probe\n      name: probe-plugin\n')
+    await until(() => include.updates.length === 1)
+    expect(include.updates[0]!.path).toBe(include.options.config.path)
+    expect(include.updates[0]!.patches).toEqual(composed)
+    expect(logs.some(line => line.includes('re-applied desktop patch layer'))).toBe(true)
+    await dispose()
+  })
+
+  it('coalesces a burst of saves into one re-apply', async () => {
+    const dir = temporaryDir()
+    const patchPath = join(dir, 'cordis.patch.yml')
+    writeFileSync(patchPath, '[]\n')
+    const include = fakeIncludeEntry()
+    const { host } = fakeHost(include)
+    let composeCalls = 0
+    const dispose = await watchDesktopPatchLayer(host, {
+      binName: 'dsh-plugin-desktop',
+      filenames: [patchPath],
+      compose: () => {
+        composeCalls += 1
+        return []
+      },
+      debounceMs: 50,
+    })
+    await new Promise(resolve => setTimeout(resolve, 100))
+    writeFileSync(patchPath, '# burst 1\n')
+    writeFileSync(patchPath, '# burst 2\n')
+    writeFileSync(patchPath, '# burst 3\n')
+    await new Promise(resolve => setTimeout(resolve, 400))
+    expect(include.updates.length).toBe(1)
+    expect(composeCalls).toBeLessThanOrEqual(2)
+    await dispose()
+  })
+
+  it('keeps the previous generation when compose throws', async () => {
+    const dir = temporaryDir()
+    const patchPath = join(dir, 'cordis.patch.yml')
+    writeFileSync(patchPath, '[]\n')
+    const include = fakeIncludeEntry()
+    const { host, logs } = fakeHost(include)
+    const dispose = await watchDesktopPatchLayer(host, {
+      binName: 'dsh-plugin-desktop',
+      filenames: [patchPath],
+      compose: () => {
+        throw new Error('malformed patch layer')
+      },
+      debounceMs: 20,
+    })
+    await new Promise(resolve => setTimeout(resolve, 100))
+    writeFileSync(patchPath, '# trigger\n')
+    await until(() => logs.some(line => line.includes('malformed patch layer')))
+    expect(include.updates.length).toBe(0)
+    expect(logs.some(line => line.includes('keeping previous generation'))).toBe(true)
+    await dispose()
+  })
+
+  it('keeps watching after an update failure and recovers', async () => {
+    const dir = temporaryDir()
+    const patchPath = join(dir, 'cordis.patch.yml')
+    writeFileSync(patchPath, '[]\n')
+    const include = fakeIncludeEntry()
+    const { host, logs } = fakeHost(include)
+    const dispose = await watchDesktopPatchLayer(host, {
+      binName: 'dsh-plugin-desktop',
+      filenames: [patchPath],
+      compose: () => [],
+      debounceMs: 20,
+    })
+    include.failNextUpdate = true
+    await new Promise(resolve => setTimeout(resolve, 100))
+    writeFileSync(patchPath, '# first\n')
+    await until(() => logs.some(line => line.includes('injected update failure')))
+    expect(include.updates.length).toBe(0)
+    await new Promise(resolve => setTimeout(resolve, 300))
+    writeFileSync(patchPath, '# second\n')
+    await until(() => include.updates.length === 1)
+    await dispose()
+  })
+
+  it('stops reacting after disposal', async () => {
+    const dir = temporaryDir()
+    const patchPath = join(dir, 'cordis.patch.yml')
+    writeFileSync(patchPath, '[]\n')
+    const include = fakeIncludeEntry()
+    const { host } = fakeHost(include)
+    const dispose = await watchDesktopPatchLayer(host, {
+      binName: 'dsh-plugin-desktop',
+      filenames: [patchPath],
+      compose: () => [],
+      debounceMs: 20,
+    })
+    await new Promise(resolve => setTimeout(resolve, 100))
+    writeFileSync(patchPath, '# before dispose\n')
+    await until(() => include.updates.length === 1)
+    await dispose()
+    writeFileSync(patchPath, '# after dispose\n')
+    await new Promise(resolve => setTimeout(resolve, 300))
+    expect(include.updates.length).toBe(1)
+  })
+
+  it('rejects when the root include entry is unavailable', async () => {
+    const dir = temporaryDir()
+    const patchPath = join(dir, 'cordis.patch.yml')
+    writeFileSync(patchPath, '[]\n')
+    const { host } = fakeHost(fakeIncludeEntry())
+    host.loader.resolve = () => undefined
+    await expect(watchDesktopPatchLayer(host, {
+      binName: 'dsh-plugin-desktop',
+      filenames: [patchPath],
+      compose: () => [],
+    })).rejects.toThrow('root include entry is unavailable')
+  })
+})

--- a/yarn.lock
+++ b/yarn.lock
@@ -9417,6 +9417,7 @@ __metadata:
     "@types/semver": "npm:^7.7.1"
     "@vitejs/plugin-react": "npm:^6"
     adm-zip: "npm:^0.6.0"
+    chokidar: "npm:^4.0.3"
     class-variance-authority: "npm:^0.7.1"
     clsx: "npm:^2.1.1"
     dsh-community-market: "npm:0.1.0-dev.0"


### PR DESCRIPTION
## Summary / 摘要

The desktop host boots the custom profile but never re-applies `cordis.patch.yml` after startup, so plugin-instance edits (MCP servers, disabling bundles, market tweaks) require a full app restart. `dsh web` hot-reloads through `watchUserPatches`, which rides on the Cordis HMR service — the desktop keeps the HMR row disabled (`dsh-base` ships it `disabled: true`) and clears `loader.internal`, so it cannot use that path.

This PR adds a desktop-owned watcher (`dsh-plugin-desktop/src/patch-watcher.ts`):

- Watches `<profile>/cordis.patch.yml` and `~/.dsh/cordis.patch.yml` with chokidar (`ignoreInitial`, 150 ms debounce).
- On any change it recomposes the patch list with the same `prepareDesktopProfile(...)` closure used at boot, then transactionally re-applies it through the root include `Entry.update` (config-only diff, rollback on failure) — so a malformed composition is logged loudly while the previous generation stays mounted.
- Re-applies are serialized; the watcher is wired via `ctx.effect` so generation teardown disposes it.
- Honours `patchReload: "startup"` (watcher is not started), matching `dsh web` semantics.
- Failure to start the watcher is logged, never fatal to boot.

桌面端启动时只组合一次自定义 profile，之后修改 `cordis.patch.yml`（如增删 MCP 服务器、禁用插件）必须重启应用才生效。`dsh web` 通过依赖 Cordis HMR 服务的 `watchUserPatches` 实现热重载，而桌面端 HMR 行被禁用且 `loader.internal` 被清除，无法复用该路径。本 PR 新增桌面自有的 watcher：监听 profile patch 与 `~/.dsh/cordis.patch.yml`，改动后复用启动时的组合逻辑并通过 root include 的 `Entry.update` 事务性重放（失败自动回滚、保留旧 generation）。

## Related Issues / 关联 Issue

#763

## Type / 类型

- [ ] Bug fix / 问题修复
- [x] Feature / 新功能
- [ ] Documentation / 文档
- [ ] Release or packaging / 发布或打包
- [ ] Tests only / 仅测试
- [ ] Other / 其他

## Platforms / 影响平台

- [ ] Windows installer / Windows 安装包
- [ ] Windows portable ZIP / Windows 便携版 ZIP
- [ ] macOS Apple Silicon
- [ ] macOS Intel
- [ ] macOS Universal package / macOS 通用安装包
- [ ] Linux
- [x] Not platform-specific / 与平台无关

## Verification / 验证

- `corepack yarn check` — exit 0 (build, typecheck, vitest, license check, operation-reliability matrix)
- `corepack yarn workspace dsh-plugin-desktop vitest run tests/patch-watcher.spec.ts` — 6/6 pass (`dsh-plugin-desktop/tests/patch-watcher.spec.ts`, covers change→re-apply, save-burst debouncing, compose failure rollback, update failure recovery, disposal, missing include entry)
- `corepack yarn workspace dsh-plugin-desktop verify:notices` — exit 0; no `THIRD_PARTY_NOTICES.md` change required (chokidar is MIT)
- Not yet run: end-to-end check inside a packaged desktop build (requires a full `yarn check` release build + app restart), which I'll follow up on.
