### PR TITLE
test(win): preserve shell lookup environment in recovery fixture

### DIFF
--- a/dsh-plugin-desktop/tests/recovery-plugin-uninstall.spec.ts
+++ b/dsh-plugin-desktop/tests/recovery-plugin-uninstall.spec.ts
@@ -155,6 +155,12 @@ describe('pre-Host recovery plugin uninstall command', () => {
       dshBootstrapPath,
       environment: {
         PATH: systemBin,
+        ...(process.platform === 'win32'
+          ? {
+              ComSpec: process.env.ComSpec ?? 'C:\\Windows\\System32\\cmd.exe',
+              PATHEXT: process.env.PATHEXT ?? '.COM;.EXE;.BAT;.CMD',
+            }
+          : {}),
         PNPM_SELECTION_MARKER: selectedMarker,
       },
     })).resolves.toMatchObject({ exitCode: 0 })


### PR DESCRIPTION
## Summary / 摘要

Preserve the standard Windows shell-resolution variables in the recovery-uninstall test's deliberately isolated child environment. This lets the real packaged DSH bootstrap resolve the fixture's `pnpm.cmd` shim and keeps the test focused on packaged-pnpm selection and bundle reconciliation.

The change is test-only; production recovery already inherits the process environment.

## Related Issues / 关联 Issue

Fixes #771

## Type / 类型

- [x] Bug fix / 问题修复
- [ ] Feature / 新功能
- [ ] Documentation / 文档
- [ ] Release or packaging / 发布或打包
- [x] Tests only / 仅测试
- [ ] Other / 其他

## Platforms / 影响平台

- [x] Windows installer / Windows 安装包
- [x] Windows portable ZIP / Windows 便携版 ZIP
- [ ] macOS Apple Silicon
- [ ] macOS Intel
- [ ] macOS Universal package / macOS 通用安装包
- [ ] Linux
- [ ] Not platform-specific / 与平台无关

## Verification / 验证

- [ ] `corepack yarn check:layout`
- [x] `corepack yarn typecheck` (run as `corepack yarn workspace dsh-plugin-desktop typecheck`)
- [ ] `corepack yarn test`
- [ ] `corepack yarn check`
- [ ] Platform package smoke / 平台打包或启动冒烟
- [x] Manual test / 人工测试

Commands actually run on Windows 11 x64:

- `corepack yarn workspace dsh-plugin-desktop vitest run tests/recovery-plugin-uninstall.spec.ts` — 1 file, 5 tests passed.
- `corepack yarn workspace dsh-plugin-desktop typecheck` — passed.
- `corepack yarn workspace dsh-plugin-desktop test` — the affected test now passes; suite result was 94 files passed, 8 files failed, 968 tests passed, 12 skipped, and 10 failed. All 10 remaining failures are host `EPERM` errors while creating symlinks because Windows Developer Mode is unavailable in this environment.
- `git diff --check` — passed.

## Release Notes / 发布说明

N/A — test-fixture correction only; no user-visible behavior changes.
