### PR TITLE
feat(desktop): keep sidebar visible by default; collapse only on explicit user action

### DIFF
--- a/dsh-plugin-desktop/src/client/AdvancedFrame.tsx
+++ b/dsh-plugin-desktop/src/client/AdvancedFrame.tsx
@@ -77,7 +77,10 @@ export function DesktopOwnedFrame({
     previousSession.current = detailsSession
   }, [detailsSession, layout])
 
-  const collapsed = narrow ? !panels.narrowExpanded : panels.sidebar === 0
+  // The sidebar collapses ONLY on explicit user action (sidebar === 0); the
+  // narrow-viewport breakpoint never hides it on its own. The narrowExpanded
+  // override still lets a deliberately collapsed rail expand temporarily.
+  const collapsed = panels.sidebar === 0 ? !(panels.narrow && panels.narrowExpanded) : false
   const sidebarPreference = collapsed ? 0 : panels.sidebar === 0 ? SIDEBAR_DEFAULT : panels.sidebar
   const columns = computeDesktopColumns(
     viewport,

--- a/dsh-plugin-desktop/src/client/layout-state.ts
+++ b/dsh-plugin-desktop/src/client/layout-state.ts
@@ -72,14 +72,47 @@ function clamp(value: number, min: number, max: number): number {
   return Math.min(max, Math.max(min, Math.round(value)))
 }
 
+/** localStorage key persisting the user's explicit sidebar preference. */
+const LAYOUT_STORAGE_KEY = 'dsh-desktop:layout-preference'
+
+interface PersistedLayoutPreference {
+  /** Explicit sidebar width; zero means the user deliberately collapsed it. */
+  sidebar?: number
+  /** Explicit details width; zero means closed. */
+  details?: number
+}
+
+/** Read the persisted preference; anything unreadable falls back to defaults. */
+function loadPersistedPreference(): PersistedLayoutPreference {
+  try {
+    if (typeof window === 'undefined' || !window.localStorage) return {}
+    const raw = window.localStorage.getItem(LAYOUT_STORAGE_KEY)
+    if (raw === null) return {}
+    const parsed = JSON.parse(raw) as PersistedLayoutPreference
+    return typeof parsed === 'object' && parsed !== null ? parsed : {}
+  } catch {
+    return {}
+  }
+}
+
 /** Small observable panel controller used by the advanced root registration. */
 export class DesktopLayoutState {
-  private snapshot: DesktopLayoutSnapshot = Object.freeze({
-    sidebar: SIDEBAR_DEFAULT,
-    details: 0,
-    narrow: false,
-    narrowExpanded: false,
-  })
+  private snapshot: DesktopLayoutSnapshot = DesktopLayoutState.initialSnapshot()
+
+  private static initialSnapshot(): DesktopLayoutSnapshot {
+    const persisted = loadPersistedPreference()
+    const sidebar = persisted.sidebar === undefined
+      ? SIDEBAR_DEFAULT
+      : persisted.sidebar === 0
+        ? 0
+        : clamp(persisted.sidebar, SIDEBAR_MIN, SIDEBAR_MAX)
+    const details = persisted.details === undefined
+      ? 0
+      : persisted.details === 0
+        ? 0
+        : clamp(persisted.details, DETAILS_MIN, DETAILS_MAX)
+    return Object.freeze({ sidebar, details, narrow: false, narrowExpanded: false })
+  }
   private readonly listeners = new Set<() => void>()
 
   /** @returns the immutable current panel snapshot. */
@@ -95,11 +128,17 @@ export class DesktopLayoutState {
 
   /** Toggle the wide sidebar and the platform-selected compact rail. */
   toggleSidebar(): void {
-    if (this.snapshot.narrow) {
+    // Narrow-screen rail override only applies after the user deliberately
+    // collapsed the sidebar; an expanded sidebar is never auto-collapsed.
+    if (this.snapshot.narrow && this.snapshot.sidebar === 0) {
       this.publish({ ...this.snapshot, narrowExpanded: !this.snapshot.narrowExpanded })
       return
     }
-    this.publish({ ...this.snapshot, sidebar: this.snapshot.sidebar === 0 ? SIDEBAR_DEFAULT : 0 })
+    this.publish({
+      ...this.snapshot,
+      sidebar: this.snapshot.sidebar === 0 ? SIDEBAR_DEFAULT : 0,
+      narrowExpanded: false,
+    })
   }
 
   /** @param narrow - whether the frame is below the automatic-collapse breakpoint. */
@@ -130,6 +169,21 @@ export class DesktopLayoutState {
 
   private publish(next: DesktopLayoutSnapshot): void {
     this.snapshot = Object.freeze(next)
+    this.persist(next)
     for (const listener of this.listeners) listener()
+  }
+
+  /** Persist only the user's explicit panel choices; transient narrow state is never stored. */
+  private persist(snapshot: DesktopLayoutSnapshot): void {
+    try {
+      if (typeof window === 'undefined' || !window.localStorage) return
+      const preference: PersistedLayoutPreference = {
+        sidebar: snapshot.sidebar,
+        details: snapshot.details,
+      }
+      window.localStorage.setItem(LAYOUT_STORAGE_KEY, JSON.stringify(preference))
+    } catch {
+      // Storage may be unavailable (private mode); preference simply will not persist.
+    }
   }
 }

--- a/dsh-plugin-desktop/tests/client-environment.spec.ts
+++ b/dsh-plugin-desktop/tests/client-environment.spec.ts
@@ -374,13 +374,20 @@ describe('advanced desktop layout', () => {
     ])
   })
 
-  it('lets the rail re-expand without losing its wide preference on narrow windows', () => {
+  it('keeps the expanded sidebar visible on narrow windows and toggles only on explicit action', () => {
     const layout = new DesktopLayoutState()
     layout.setNarrow(true)
     expect(layout.getSnapshot()).toMatchObject({ sidebar: 280, narrow: true, narrowExpanded: false })
+    // 窄窗下显式收起（唯一允许隐藏侧栏的途径）
     layout.toggleSidebar()
-    expect(layout.getSnapshot()).toMatchObject({ sidebar: 280, narrow: true, narrowExpanded: true })
+    expect(layout.getSnapshot()).toMatchObject({ sidebar: 0, narrow: true, narrowExpanded: false })
+    // 显式收起后，窄窗 override 仍可临时展开 rail
+    layout.toggleSidebar()
+    expect(layout.getSnapshot()).toMatchObject({ sidebar: 0, narrow: true, narrowExpanded: true })
     layout.setNarrow(false)
+    // 恢复宽窗后保持用户显式收起的偏好
+    expect(layout.getSnapshot()).toMatchObject({ sidebar: 0, narrow: false, narrowExpanded: false })
+    layout.toggleSidebar()
     expect(layout.getSnapshot()).toMatchObject({ sidebar: 280, narrow: false, narrowExpanded: false })
   })
 })


### PR DESCRIPTION
## What

The desktop sidebar previously auto-collapsed below the 1024px breakpoint and its expanded/collapsed state was never persisted, so the panel could not be kept visible across restarts.

## Changes

- **layout-state.ts**: persist the user's explicit sidebar/details preference to `localStorage` (`dsh-desktop:layout-preference`); initial state defaults to expanded (280px). Transient narrow state is never stored.
- **layout-state.ts**: narrow-screen rail override (`narrowExpanded`) now applies only after the user deliberately collapsed the sidebar.
- **AdvancedFrame.tsx**: `collapsed` derives only from the explicit `sidebar === 0` preference; the narrow-viewport breakpoint never hides an expanded sidebar on its own.
- **client-environment.spec.ts**: update the narrow-window test to the new contract (explicit toggle is the only way to hide; rail override still works after deliberate collapse).

Result: sidebar is always visible by default, hiding requires an explicit user action, and the choice survives restarts.

## Verification

- `yarn workspace dsh-plugin-desktop test`: 986 passed, 4 skipped
- `yarn typecheck`: clean
- Unsigned macOS smoke DMG builds and launches; main UI renders with the sidebar expanded by default.