### PR TITLE
test(win): keep ComSpec/PATHEXT in the isolated recovery-uninstall env

### DIFF
--- a/dsh-plugin-desktop-beta/tests/recovery-plugin-uninstall.spec.ts
+++ b/dsh-plugin-desktop-beta/tests/recovery-plugin-uninstall.spec.ts
@@ -156,6 +156,11 @@ describe('pre-Host recovery plugin uninstall command', () => {
       environment: {
         PATH: systemBin,
         PNPM_SELECTION_MARKER: selectedMarker,
+        // Windows needs ComSpec/PATHEXT to resolve and run the .cmd shim.
+        // The isolated fixture otherwise strips them (see #771).
+        ...(process.platform === 'win32'
+          ? { ComSpec: process.env.ComSpec, PATHEXT: process.env.PATHEXT }
+          : {}),
       },
     })).resolves.toMatchObject({ exitCode: 0 })
 

--- a/dsh-plugin-desktop/tests/recovery-plugin-uninstall.spec.ts
+++ b/dsh-plugin-desktop/tests/recovery-plugin-uninstall.spec.ts
@@ -156,6 +156,11 @@ describe('pre-Host recovery plugin uninstall command', () => {
       environment: {
         PATH: systemBin,
         PNPM_SELECTION_MARKER: selectedMarker,
+        // Windows needs ComSpec/PATHEXT to resolve and run the .cmd shim.
+        // The isolated fixture otherwise strips them (see #771).
+        ...(process.platform === 'win32'
+          ? { ComSpec: process.env.ComSpec, PATHEXT: process.env.PATHEXT }
+          : {}),
       },
     })).resolves.toMatchObject({ exitCode: 0 })
 


### PR DESCRIPTION
## Summary

Fixes #771 — the recovery-plugin-uninstall test fixture on Windows omitted the shell-resolution variables needed to launch a `.cmd` shim.

The test builds an intentionally isolated child environment (`PATH` + `PNPM_SELECTION_MARKER`) to verify packaged pnpm is selected ahead of system pnpm. On Windows, launching `pnpm.cmd` requires `ComSpec` and `PATHEXT` for the shell to resolve and run the shim. Without them, the DSH bootstrap exits 127 (`dsh: pnpm not found on PATH`). Production is unaffected because `recoveryPluginEnvironment()` inherits the real process environment, which retains both variables.

This adds `ComSpec` and `PATHEXT` back on **win32 only**, so the isolation intent (pin pnpm via PATH) is preserved.

## Change

`+10` lines across two test files (desktop + beta are identical):

```ts
environment: {
  PATH: systemBin,
  PNPM_SELECTION_MARKER: selectedMarker,
  // Windows needs ComSpec/PATHEXT to resolve and run the .cmd shim.
  // The isolated fixture otherwise strips them (see #771).
  ...(process.platform === 'win32'
    ? { ComSpec: process.env.ComSpec, PATHEXT: process.env.PATHEXT }
    : {}),
},
```

## Verification

- The added branch is a **no-op on non-Windows** (spreads an empty object), so POSIX test behaviour is unchanged.
- **I could not run the Windows test from macOS** — the fix is verified by the repo's Windows CI, which exercises the `pnpm.cmd` path.
- Local POSIX run of the suite is unaffected by the change.
