### PR TITLE
feat(update): report plugins the offered release cannot supply

### DIFF
--- a/dsh-plugin-desktop-beta/src/electron-runtime.ts
+++ b/dsh-plugin-desktop-beta/src/electron-runtime.ts
@@ -103,6 +103,26 @@ export function desktopPreloadPath(moduleUrl: string = import.meta.url): string 
 
 const PRODUCT_VERSION = desktopProductVersion()
 
+/** How many affected bundles the update dialog names before summarizing the rest. */
+const UPGRADE_SUPPLY_LISTED = 5
+
+/** Scope every runtime package shares, dropped from dialog lines that repeat it. */
+const RUNTIME_SCOPE_PREFIX = '@deepseek-ai/'
+
+/**
+ * What an offered release would stop supplying to bundles already installed.
+ *
+ * Structural on purpose: the update dialog only needs the affected names and
+ * what each one expected, so it does not depend on how the reading was taken.
+ */
+export interface UpgradeSupplyReading {
+  /** Bundles the offered release cannot supply, in the order they were read. */
+  readonly unsupplied: readonly {
+    readonly packageName: string
+    readonly missing: readonly string[]
+  }[]
+}
+
 /** Main-process deadline for one Renderer generation to settle its client Loader. */
 export const RENDERER_BOOT_TIMEOUT_MS = 30_000
 
@@ -587,19 +607,73 @@ export class ElectronDesktopRuntime implements DesktopRuntime {
       : await this.generation.showSaveDialog(options)
   }
 
+  /**
+   * Reading of what an offered release would stop supplying to installed
+   * bundles. Left unset when no inventory for that release is available, in
+   * which case the update flow proceeds exactly as it did before.
+   */
+  private upgradeSupplyReporter:
+    | ((version: string, channel: DesktopReleaseChannel) => Promise<UpgradeSupplyReading | undefined>)
+    | undefined
+
+  /** Supply the reading used to describe an offered release before downloading it. */
+  setUpgradeSupplyReporter(
+    reporter: (version: string, channel: DesktopReleaseChannel) => Promise<UpgradeSupplyReading | undefined>,
+  ): void {
+    this.upgradeSupplyReporter = reporter
+  }
+
+  /**
+   * Describe the bundles an offered release would stop supplying.
+   *
+   * Returns nothing when there is no reading, or nothing to report, so the
+   * dialog stays exactly as it is today whenever this has nothing to add.
+   */
+  private async describeUpgradeSupply(
+    version: string,
+    channel: DesktopReleaseChannel,
+  ): Promise<string | undefined> {
+    if (this.upgradeSupplyReporter === undefined) return undefined
+    let reading: UpgradeSupplyReading | undefined
+    try {
+      reading = await this.upgradeSupplyReporter(version, channel)
+    } catch (cause) {
+      this.logError(`dsh-plugin-desktop: could not read what ${version} supplies: ${cause instanceof Error ? cause.message : String(cause)}`)
+      return undefined
+    }
+    if (reading === undefined || reading.unsupplied.length === 0) return undefined
+
+    const copy = desktopNativeCopy(this.currentLocale)
+    const shown = reading.unsupplied.slice(0, UPGRADE_SUPPLY_LISTED)
+    const lines = [copy.upgradeSupplyHeadline(reading.unsupplied.length)]
+    for (const bundle of shown) {
+      // The scope is the same for every runtime package, so repeating it on
+      // every line only pushes the names past the width the dialog gives them.
+      const missing = bundle.missing.map(name => name.replace(RUNTIME_SCOPE_PREFIX, '')).join(', ')
+      lines.push(copy.upgradeSupplyEntry(bundle.packageName, missing))
+    }
+    if (reading.unsupplied.length > shown.length) {
+      lines.push(copy.upgradeSupplyMore(reading.unsupplied.length - shown.length))
+    }
+    lines.push(copy.upgradeSupplyReversible)
+    return lines.join('\n')
+  }
+
   /** Ask before making the fixed download endpoint's counted request. */
   private async confirmUpdateDownload(
     version: string,
     channel: DesktopReleaseChannel = 'stable',
   ): Promise<boolean> {
     const copy = desktopNativeCopy(this.currentLocale)
+    const question = channel === DESKTOP_RELEASE_CHANNEL
+      ? copy.downloadUpdate
+      : copy.installStableAlongsideBeta
+    const supply = await this.describeUpgradeSupply(version, channel)
     const result = await this.showUpdateMessageBox({
-      type: 'info',
+      type: supply === undefined ? 'info' : 'warning',
       title: copy.updateAvailableTitle,
       message: copy.updateAvailableMessage(version),
-      detail: channel === DESKTOP_RELEASE_CHANNEL
-        ? copy.downloadUpdate
-        : copy.installStableAlongsideBeta,
+      detail: supply === undefined ? question : `${supply}\n\n${question}`,
       buttons: [copy.download, copy.later],
       defaultId: 1,
       cancelId: 1,

--- a/dsh-plugin-desktop-beta/src/main.ts
+++ b/dsh-plugin-desktop-beta/src/main.ts
@@ -119,6 +119,11 @@ import {
   readDesktopSetupWizardState,
 } from './setup-wizard-state.ts'
 import {
+  offeredRuntimeInventoryOverNetwork,
+  previewUpgradeSupply,
+  readProfileBundleNames,
+} from './upgrade-supply-preview.ts'
+import {
   migrateDesktopBrowserAccessSettings,
   migrateDesktopWindowMaterialSettings,
   readDesktopSetupWizardSettings,
@@ -1277,6 +1282,22 @@ async function start(): Promise<void> {
       profilePreferencesStopping = true
       await profilePreferencesWriteTail
     }
+    // The Profile's bundles and their manifests are settled by this point, so an
+    // offered release can be described in the same terms the Loader uses later.
+    runtime.setUpgradeSupplyReporter(async () => {
+      const target = await offeredRuntimeInventoryOverNetwork(
+        DESKTOP_RELEASE_CHANNEL,
+        'beta',
+        undefined,
+        message => { electronLogger.error(`${BIN_NAME}: ${message}`) },
+      )
+      if (target === undefined) return undefined
+      return previewUpgradeSupply({
+        bundleNames: readProfileBundleNames(prepared.profile.dir),
+        profileDir: prepared.profile.dir,
+        target,
+      })
+    })
     startupStage = 'host-boot'
     lifecycleRecorder.transitionStartupStage(startupStage)
     const releasePackageResolver = installProfilePackageResolver(prepared.bareModuleBaseUrl)

--- a/dsh-plugin-desktop-beta/src/native-dialog-copy.ts
+++ b/dsh-plugin-desktop-beta/src/native-dialog-copy.ts
@@ -15,6 +15,10 @@ export interface DesktopNativeCopy {
   readonly dismiss: string
   readonly updateAvailableTitle: string
   readonly updateAvailableMessage: (version: string) => string
+  readonly upgradeSupplyHeadline: (count: number) => string
+  readonly upgradeSupplyEntry: (bundleName: string, missing: string) => string
+  readonly upgradeSupplyMore: (count: number) => string
+  readonly upgradeSupplyReversible: string
   readonly downloadUpdate: string
   readonly installStableAlongsideBeta: string
   readonly download: string
@@ -83,6 +87,12 @@ const COPY: Record<DesktopLocale, DesktopNativeCopy> = {
     dismiss: 'Dismiss',
     updateAvailableTitle: 'DSH Desktop Update Available',
     updateAvailableMessage: version => `DSH Desktop ${version} is available.`,
+    upgradeSupplyHeadline: count => count === 1
+      ? '1 installed plugin expects a package this release does not ship:'
+      : `${count} installed plugins expect packages this release does not ship:`,
+    upgradeSupplyEntry: (bundleName, missing) => `  ${bundleName} — ${missing}`,
+    upgradeSupplyMore: count => `  and ${count} more`,
+    upgradeSupplyReversible: 'Desktop would open in Recovery Mode instead of starting. Nothing is uninstalled; disabling them there restores startup.',
     downloadUpdate: 'Download this update now?',
     installStableAlongsideBeta: 'Install the stable edition alongside DSH Desktop Beta? The Beta app will remain installed.',
     download: 'Download',
@@ -144,6 +154,10 @@ const COPY: Record<DesktopLocale, DesktopNativeCopy> = {
     dismiss: '关闭',
     updateAvailableTitle: 'DSH Desktop 有可用更新',
     updateAvailableMessage: version => `DSH Desktop ${version} 已可用。`,
+    upgradeSupplyHeadline: count => `已安装的插件中有 ${count} 个需要此版本不包含的组件：`,
+    upgradeSupplyEntry: (bundleName, missing) => `  ${bundleName} — ${missing}`,
+    upgradeSupplyMore: count => `  另有 ${count} 个`,
+    upgradeSupplyReversible: '这会使 Desktop 无法启动、转入恢复模式。插件不会被卸载，在那里禁用即可恢复。',
     downloadUpdate: '现在下载此更新？',
     installStableAlongsideBeta: '是否同时安装稳定版？DSH Desktop Beta 将继续保留。',
     download: '下载',

--- a/dsh-plugin-desktop-beta/src/plugin-supply-check.ts
+++ b/dsh-plugin-desktop-beta/src/plugin-supply-check.ts
@@ -1,0 +1,276 @@
+/**
+ * Reading of whether the installed runtime still supplies every package the
+ * active Profile's bundles expect it to supply.
+ *
+ * A bundle names packages in two different ways, and the difference decides what
+ * absence means. A regular dependency is fetched by the package manager, so a
+ * bundle keeps loading when the runtime stops shipping that package: it simply
+ * carries its own copy. A peer dependency, and a browser-side inject entry, are
+ * the opposite. Nothing fetches those on the bundle's behalf, so when the
+ * installed runtime no longer ships one, resolution fails while the Loader is
+ * still bringing the bundle up, before any of the bundle's own code runs. No
+ * defensive coding inside the bundle survives that, and no version range it
+ * declares predicts it, because a range describes what its author expected and
+ * is satisfied by a release that no longer ships the package at all.
+ *
+ * This is why the reading is worth taking before boot: the same fact is already
+ * on disk, at no cost, that the Loader is about to discover the expensive way.
+ *
+ * The reading rules out exactly one way of failing, so its clean result is
+ * narrower than compatibility. A package that is installed but no longer exports
+ * the binding being imported, and a bundle that resolves yet refuses to
+ * activate, are both outside what it can see.
+ */
+
+import { existsSync, readFileSync } from 'node:fs'
+import { createRequire } from 'node:module'
+import { dirname, join, resolve } from 'node:path'
+
+/** Largest bundle manifest this reading will parse. */
+const MAX_BUNDLE_MANIFEST_BYTES = 1024 * 1024
+
+/** Largest number of expected names accepted from a single bundle manifest. */
+const MAX_EXPECTED_NAMES = 1024
+
+/** Package name shape shared with the rest of Desktop's Profile handling. */
+const PACKAGE_NAME_PATTERN = /^(?:@[a-z0-9][a-z0-9._-]*\/)?[a-z0-9][a-z0-9._-]*$/u
+
+/** How a bundle asked the runtime to supply one package name. */
+export type SupplyExpectation = 'peer' | 'client-inject'
+
+/** Whether one expected name is installed for the active Profile. */
+export type SupplyPresence = 'present' | 'absent' | 'undecidable'
+
+/** Whether a bundle's expectations are met, or could not be read at all. */
+export type BundleSupplyVerdict = 'supplied' | 'unsupplied' | 'undecidable'
+
+/** One package name a bundle expects the runtime to supply. */
+export interface ExpectedSupply {
+  /** Package name the bundle expects to resolve without installing it itself. */
+  readonly packageName: string
+  /** Every declaration site that named it, in manifest order without repeats. */
+  readonly expectations: readonly SupplyExpectation[]
+}
+
+/** Reading for one bundle declared by the active Profile. */
+export interface BundleSupplyReport {
+  /** Bundle package name as declared by the Profile manifest. */
+  readonly packageName: string
+  /** Whether the installed runtime can bring this bundle up. */
+  readonly verdict: BundleSupplyVerdict
+  /** Expected names that are not installed; empty unless the verdict is `unsupplied`. */
+  readonly missing: readonly string[]
+  /** Why no reading was possible; present only when the verdict is `undecidable`. */
+  readonly reason?: string
+}
+
+/** Reading across every bundle the caller asked about. */
+export interface ProfileSupplyReport {
+  /** Every bundle examined, in the order the caller supplied them. */
+  readonly bundles: readonly BundleSupplyReport[]
+  /** Bundles the installed runtime cannot supply, so they cannot come up. */
+  readonly unsupplied: readonly BundleSupplyReport[]
+  /** Bundles no reading could be taken for; never folded into either verdict. */
+  readonly undecidable: readonly BundleSupplyReport[]
+}
+
+/** Disk access this reading needs, injected so the judgement stays testable. */
+export interface ProfileSupplyProbe {
+  /**
+   * Parsed manifest of one installed bundle, or `undefined` when the Profile
+   * declares the bundle but nothing is installed under that name. Throws when a
+   * manifest exists yet cannot be read, so an unreadable bundle is never
+   * mistaken for an absent one.
+   */
+  readonly readBundleManifest: (packageName: string) => unknown
+  /** Whether one expected name is installed for the active Profile. */
+  readonly presence: (packageName: string) => SupplyPresence
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value)
+}
+
+/**
+ * Names the manifest expects the runtime to supply.
+ *
+ * Optional peer dependencies are excluded deliberately. Their absence is a
+ * declared and supported state, so counting them would report a healthy bundle
+ * as broken, which is the most damaging mistake this reading can make.
+ */
+export function collectExpectedSupply(manifest: unknown): readonly ExpectedSupply[] {
+  if (!isPlainObject(manifest)) throw new Error('bundle manifest must hold a JSON object')
+  const collected = new Map<string, SupplyExpectation[]>()
+  const add = (packageName: string, expectation: SupplyExpectation): void => {
+    if (!PACKAGE_NAME_PATTERN.test(packageName)) {
+      throw new Error(`bundle manifest names an invalid package ${JSON.stringify(packageName)}`)
+    }
+    const existing = collected.get(packageName)
+    if (existing === undefined) collected.set(packageName, [expectation])
+    else if (!existing.includes(expectation)) existing.push(expectation)
+  }
+
+  const peers = manifest.peerDependencies
+  if (peers !== undefined) {
+    if (!isPlainObject(peers)) throw new Error('bundle manifest peerDependencies must be an object')
+    const meta = manifest.peerDependenciesMeta
+    if (meta !== undefined && !isPlainObject(meta)) {
+      throw new Error('bundle manifest peerDependenciesMeta must be an object')
+    }
+    for (const packageName of Object.keys(peers)) {
+      const entry = isPlainObject(meta) ? meta[packageName] : undefined
+      if (isPlainObject(entry) && entry.optional === true) continue
+      add(packageName, 'peer')
+    }
+  }
+
+  const dsh = manifest.dsh
+  if (dsh !== undefined) {
+    if (!isPlainObject(dsh)) throw new Error('bundle manifest dsh field must be an object')
+    const client = dsh.client
+    if (client !== undefined) {
+      if (!isPlainObject(client)) throw new Error('bundle manifest dsh.client field must be an object')
+      const inject = client.inject
+      if (inject !== undefined) {
+        if (!Array.isArray(inject)) throw new Error('bundle manifest dsh.client.inject must be an array')
+        for (const entry of inject) {
+          if (typeof entry !== 'string') {
+            throw new Error('bundle manifest dsh.client.inject must hold package names')
+          }
+          add(entry, 'client-inject')
+        }
+      }
+    }
+  }
+
+  if (collected.size > MAX_EXPECTED_NAMES) {
+    throw new Error('bundle manifest expects too many names from the runtime')
+  }
+  return [...collected].map(([packageName, expectations]) => ({ packageName, expectations }))
+}
+
+function undecidableBundle(packageName: string, reason: string): BundleSupplyReport {
+  return { packageName, verdict: 'undecidable', missing: [], reason }
+}
+
+/**
+ * Reading for one bundle.
+ *
+ * ⛔ The order of the two negative outcomes matters. One name known to be absent
+ * is already sufficient for the bundle to fail, so it stands whether or not
+ * other names could be measured; asking "was anything unmeasurable" first would
+ * swallow a certain failure inside an uncertainty. Only when nothing is known to
+ * be absent does an unmeasurable name decide the reading, and then it must yield
+ * undecidable rather than supplied: a reading that quietly downgrades "not
+ * measured" to "fine" is worse than no reading, because nothing distinguishes it
+ * from a real pass.
+ */
+export function checkBundleSupply(
+  packageName: string,
+  probe: ProfileSupplyProbe,
+): BundleSupplyReport {
+  let expected: readonly ExpectedSupply[]
+  try {
+    const manifest = probe.readBundleManifest(packageName)
+    if (manifest === undefined) return undecidableBundle(packageName, 'nothing is installed under this name')
+    expected = collectExpectedSupply(manifest)
+  } catch (cause) {
+    return undecidableBundle(packageName, cause instanceof Error ? cause.message : String(cause))
+  }
+
+  const missing: string[] = []
+  const unmeasured: string[] = []
+  for (const entry of expected) {
+    const presence = probe.presence(entry.packageName)
+    if (presence === 'absent') missing.push(entry.packageName)
+    else if (presence === 'undecidable') unmeasured.push(entry.packageName)
+  }
+  if (missing.length > 0) return { packageName, verdict: 'unsupplied', missing }
+  if (unmeasured.length > 0) {
+    return undecidableBundle(packageName, `cannot tell whether ${unmeasured.join(', ')} is installed`)
+  }
+  return { packageName, verdict: 'supplied', missing: [] }
+}
+
+/** Reading across every bundle the caller asked about, in the order given. */
+export function checkProfileSupply(
+  bundleNames: readonly string[],
+  probe: ProfileSupplyProbe,
+): ProfileSupplyReport {
+  const bundles = bundleNames.map(packageName => checkBundleSupply(packageName, probe))
+  return {
+    bundles,
+    unsupplied: bundles.filter(bundle => bundle.verdict === 'unsupplied'),
+    undecidable: bundles.filter(bundle => bundle.verdict === 'undecidable'),
+  }
+}
+
+/**
+ * Every directory resolution would consult starting from `start`, nearest first.
+ *
+ * A Profile does not necessarily hold its own installed tree — Desktop lays the
+ * modules out one level above, shared across Profiles — so a probe that only
+ * looked inside the Profile would find nothing and report every bundle as
+ * undecidable. Walking the chain is what makes the reading independent of which
+ * layout is in use, and it is the same walk resolution itself performs.
+ */
+function resolutionChain(start: string): readonly string[] {
+  const dirs: string[] = []
+  let current = resolve(start)
+  for (;;) {
+    dirs.push(current)
+    const parent = dirname(current)
+    if (parent === current) return dirs
+    current = parent
+  }
+}
+
+/**
+ * Probe backed by the Profile's own installed tree.
+ *
+ * Presence is asked in the same terms the Loader will ask it, so the reading and
+ * the failure it predicts come from one mechanism rather than two that can drift
+ * apart. Directories are consulted nearest first, starting with the Profile whose
+ * bundles are being judged and continuing through the ancestors resolution
+ * would search.
+ */
+export function createProfileSupplyProbe(searchDirs: readonly string[]): ProfileSupplyProbe {
+  const [resolutionRoot] = searchDirs
+  if (resolutionRoot === undefined) {
+    throw new Error('a Profile supply probe needs at least one search directory')
+  }
+  const chain = [...new Set(searchDirs.flatMap(dir => resolutionChain(dir)))]
+  const installedManifestPath = (packageName: string): string | undefined => {
+    for (const dir of chain) {
+      const candidate = join(dir, 'node_modules', ...packageName.split('/'), 'package.json')
+      if (existsSync(candidate)) return candidate
+    }
+    return undefined
+  }
+  return {
+    readBundleManifest: packageName => {
+      const manifestPath = installedManifestPath(packageName)
+      if (manifestPath === undefined) return undefined
+      const bytes = readFileSync(manifestPath)
+      if (bytes.byteLength > MAX_BUNDLE_MANIFEST_BYTES) {
+        throw new Error(`installed manifest for ${packageName} is too large to read`)
+      }
+      return JSON.parse(new TextDecoder('utf-8', { fatal: true }).decode(bytes)) as unknown
+    },
+    presence: packageName => {
+      if (installedManifestPath(packageName) !== undefined) return 'present'
+      // A package can be installed yet decline to expose a manifest subpath, so
+      // an export-map refusal proves presence as firmly as a readable manifest.
+      try {
+        createRequire(join(resolutionRoot, 'package.json')).resolve(packageName)
+        return 'present'
+      } catch (cause) {
+        const code = (cause as NodeJS.ErrnoException).code
+        if (code === 'MODULE_NOT_FOUND') return 'absent'
+        if (code === 'ERR_PACKAGE_PATH_NOT_EXPORTED') return 'present'
+        if (code === 'ERR_UNSUPPORTED_DIR_IMPORT') return 'present'
+        return 'undecidable'
+      }
+    },
+  }
+}

--- a/dsh-plugin-desktop-beta/src/upgrade-supply-preview.ts
+++ b/dsh-plugin-desktop-beta/src/upgrade-supply-preview.ts
@@ -1,0 +1,257 @@
+/**
+ * What an offered release would stop supplying to the bundles already installed.
+ *
+ * The same reading as {@link checkProfileSupply}, with one substitution: instead
+ * of asking this machine what is installed, it asks the inventory published for
+ * the release being offered. Everything else — which names a bundle expects the
+ * runtime to supply, and what their absence means — is unchanged, so the answer
+ * before an upgrade and the answer after it are produced by one mechanism rather
+ * than two that can disagree.
+ *
+ * The reading is only as current as the inventory it is given. When no inventory
+ * for the offered release is available the preview is simply absent, and the
+ * update flow proceeds exactly as it does today. That failure direction is
+ * deliberate: a missing preview costs a warning that never appears, while a
+ * wrong preview would talk someone out of an upgrade that was fine.
+ */
+
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import {
+  checkProfileSupply,
+  createProfileSupplyProbe,
+  type ProfileSupplyReport,
+  type SupplyPresence,
+} from './plugin-supply-check.ts'
+
+/** Largest published inventory this preview will parse. */
+const MAX_INVENTORY_BYTES = 4 * 1024 * 1024
+
+/** Package name shape shared with the rest of Desktop's Profile handling. */
+const PACKAGE_NAME_PATTERN = /^(?:@[a-z0-9][a-z0-9._-]*\/)?[a-z0-9][a-z0-9._-]*$/u
+
+/**
+ * What an offered release publishes about itself.
+ *
+ * An inventory is authoritative only for the name prefixes it claims. A runtime
+ * manifest lists the runtime's own packages, so it can say nothing about a UI
+ * framework a bundle expects from the host — and treating that silence as
+ * absence is how a bundle gets condemned for depending on something the release
+ * does supply. Names outside the claimed scopes are therefore left undecided.
+ */
+export interface RuntimeInventory {
+  /** Every package name the offered release is known to supply. */
+  readonly packages: ReadonlySet<string>
+  /** Name prefixes this inventory can speak about; empty means it speaks about all. */
+  readonly scopes: readonly string[]
+}
+
+/** Everything the preview needs about the machine and the offered release. */
+export interface UpgradeSupplyInput {
+  /** Bundle names the active Profile declares, in manifest order. */
+  readonly bundleNames: readonly string[]
+  /** Active Profile directory, used to read each installed bundle's manifest. */
+  readonly profileDir: string
+  /** What the offered release publishes about what it supplies. */
+  readonly target: RuntimeInventory
+}
+
+/**
+ * Package names published for one release.
+ *
+ * `alwaysPresent` carries the packages that keep their own version line, which a
+ * runtime manifest leaves out precisely because they never move with the
+ * runtime. Without them, every bundle depending on the framework base would be
+ * reported as newly broken — the mistake that condemns working bundles in bulk.
+ *
+ * `scopes` bounds what the inventory is entitled to deny. A runtime manifest can
+ * say a runtime package is gone; it cannot say anything about a package from
+ * another publisher, and silence there is not absence.
+ */
+export function parseRuntimeInventory(
+  value: unknown,
+  alwaysPresent: readonly string[] = [],
+  scopes: readonly string[] = [],
+): RuntimeInventory {
+  if (value === null || typeof value !== 'object' || Array.isArray(value)) {
+    throw new Error('runtime inventory must hold a JSON object')
+  }
+  const packages = (value as { packages?: unknown }).packages
+  if (!Array.isArray(packages)) throw new Error('runtime inventory must list packages')
+  const names = new Set<string>(alwaysPresent)
+  for (const entry of packages) {
+    const name = typeof entry === 'string'
+      ? entry
+      : entry !== null && typeof entry === 'object' && !Array.isArray(entry)
+        ? (entry as { name?: unknown }).name
+        : undefined
+    if (typeof name !== 'string' || !PACKAGE_NAME_PATTERN.test(name)) {
+      throw new Error('runtime inventory holds an invalid package name')
+    }
+    names.add(name)
+  }
+  const declared = (value as { scopes?: unknown }).scopes
+  const resolved = Array.isArray(declared)
+    ? declared.filter((scope): scope is string => typeof scope === 'string')
+    : scopes
+  return { packages: names, scopes: resolved }
+}
+
+/** Read a published runtime inventory from disk. */
+export function readRuntimeInventory(
+  path: string,
+  alwaysPresent: readonly string[] = [],
+  scopes: readonly string[] = [],
+): RuntimeInventory {
+  const bytes = readFileSync(path)
+  if (bytes.byteLength > MAX_INVENTORY_BYTES) {
+    throw new Error('runtime inventory is too large to read')
+  }
+  return parseRuntimeInventory(
+    JSON.parse(new TextDecoder('utf-8', { fatal: true }).decode(bytes)) as unknown,
+    alwaysPresent,
+    scopes,
+  )
+}
+
+/**
+ * Environment override naming a directory of published runtime inventories.
+ *
+ * This is the seam where a release channel's own inventory arrives. Until one is
+ * published, the directory is how an inventory can be supplied out of band, and
+ * its absence simply means no preview is offered.
+ */
+export const RUNTIME_INVENTORY_DIRECTORY_ENV = 'DSH_DESKTOP_RUNTIME_INVENTORY_DIR'
+
+/** Inventory published for one offered release, or nothing when none is available. */
+export function offeredRuntimeInventory(
+  version: string,
+  directory: string | undefined = process.env[RUNTIME_INVENTORY_DIRECTORY_ENV],
+): RuntimeInventory | undefined {
+  if (directory === undefined || directory.length === 0) return undefined
+  if (!/^[0-9A-Za-z._+-]+$/u.test(version)) return undefined
+  try {
+    return readRuntimeInventory(join(directory, `${version}.json`))
+  } catch {
+    return undefined
+  }
+}
+
+/** Base URL of the repository serving the channel table and runtime manifests. */
+export const RUNTIME_INVENTORY_URL_ENV = 'DSH_DESKTOP_RUNTIME_INVENTORY_URL'
+
+/** Name prefix the vendored runtime manifests are authoritative about. */
+export const RUNTIME_INVENTORY_SCOPE = '@deepseek-ai/dsh'
+
+/** How long the two inventory requests may take before the preview is skipped. */
+const INVENTORY_FETCH_TIMEOUT_MS = 10_000
+
+/** Largest inventory response accepted from the network. */
+const MAX_INVENTORY_RESPONSE_BYTES = 4 * 1024 * 1024
+
+/**
+ * Fetch the inventory a channel publishes about itself.
+ *
+ * Two documents: the channel table names the runtime version that channel
+ * bundles, and that version's manifest lists the packages. Neither has to be
+ * installed first, which is what makes the reading possible before an upgrade
+ * rather than after it.
+ */
+export async function fetchRuntimeInventory(
+  baseUrl: string,
+  channel: string,
+  branch: string,
+  fetchImpl: typeof fetch = fetch,
+  signal?: AbortSignal,
+): Promise<RuntimeInventory> {
+  const read = async (path: string): Promise<unknown> => {
+    const init: RequestInit = { redirect: 'follow', ...(signal === undefined ? {} : { signal }) }
+    const response = await fetchImpl(`${baseUrl}/${branch}/${path}`, init)
+    if (!response.ok) throw new Error(`${path} responded ${response.status}`)
+    const text = await response.text()
+    if (text.length > MAX_INVENTORY_RESPONSE_BYTES) throw new Error(`${path} is too large to read`)
+    return JSON.parse(text) as unknown
+  }
+
+  const table = await read('upstream.json')
+  if (table === null || typeof table !== 'object' || Array.isArray(table)) {
+    throw new Error('channel table must hold a JSON object')
+  }
+  const channels = (table as { channels?: unknown }).channels
+  if (channels === null || typeof channels !== 'object' || Array.isArray(channels)) {
+    throw new Error('channel table must list channels')
+  }
+  const entry = (channels as Record<string, unknown>)[channel]
+  const version = entry !== null && typeof entry === 'object' && !Array.isArray(entry)
+    ? (entry as { sourceVersion?: unknown }).sourceVersion
+    : undefined
+  if (typeof version !== 'string' || !/^[0-9A-Za-z._+-]+$/u.test(version)) {
+    throw new Error(`channel ${channel} declares no usable runtime version`)
+  }
+  return parseRuntimeInventory(
+    await read(`vendor/dsh-runtime/${version}/manifest.json`),
+    [],
+    [RUNTIME_INVENTORY_SCOPE],
+  )
+}
+
+/** Inventory fetched for the offered release, or nothing when it cannot be had. */
+export async function offeredRuntimeInventoryOverNetwork(
+  channel: string,
+  branch: string,
+  baseUrl: string | undefined = process.env[RUNTIME_INVENTORY_URL_ENV],
+  report: (message: string) => void = () => {},
+): Promise<RuntimeInventory | undefined> {
+  if (baseUrl === undefined || baseUrl.length === 0) return undefined
+  const started = Date.now()
+  const controller = new AbortController()
+  const timer = setTimeout(() => { controller.abort() }, INVENTORY_FETCH_TIMEOUT_MS)
+  try {
+    const inventory = await fetchRuntimeInventory(baseUrl, channel, branch, fetch, controller.signal)
+    report(`runtime inventory fetched in ${Date.now() - started}ms, ${inventory.packages.size} packages`)
+    return inventory
+  } catch (cause) {
+    report(`runtime inventory unavailable after ${Date.now() - started}ms: ${cause instanceof Error ? cause.message : String(cause)}`)
+    return undefined
+  } finally {
+    clearTimeout(timer)
+  }
+}
+
+/** Bundle names the Profile manifest declares, or an empty list when it declares none. */
+export function readProfileBundleNames(profileDir: string): readonly string[] {
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(readFileSync(join(profileDir, 'package.json'), 'utf8')) as unknown
+  } catch {
+    return []
+  }
+  if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) return []
+  const dsh = (parsed as { dsh?: unknown }).dsh
+  if (dsh === null || typeof dsh !== 'object' || Array.isArray(dsh)) return []
+  const profile = (dsh as { profile?: unknown }).profile
+  if (profile === null || typeof profile !== 'object' || Array.isArray(profile)) return []
+  const bundles = (profile as { bundles?: unknown }).bundles
+  if (!Array.isArray(bundles)) return []
+  return bundles.filter((name): name is string => typeof name === 'string' && PACKAGE_NAME_PATTERN.test(name))
+}
+
+/**
+ * Reading of what the offered release would stop supplying.
+ *
+ * A name the inventory lists is present. A name it does not list is absent only
+ * when the inventory claims to speak about that name; otherwise the reading for
+ * that bundle is left undecided, and undecided bundles are never reported.
+ */
+export function previewUpgradeSupply(input: UpgradeSupplyInput): ProfileSupplyReport {
+  const installed = createProfileSupplyProbe([input.profileDir])
+  const { packages, scopes } = input.target
+  const speaksAbout = (packageName: string): boolean =>
+    scopes.length === 0 || scopes.some(scope => packageName.startsWith(scope))
+  const presence = (packageName: string): SupplyPresence =>
+    packages.has(packageName) ? 'present' : speaksAbout(packageName) ? 'absent' : 'undecidable'
+  return checkProfileSupply(input.bundleNames, {
+    readBundleManifest: installed.readBundleManifest,
+    presence,
+  })
+}

--- a/dsh-plugin-desktop-beta/tests/plugin-supply-check.spec.ts
+++ b/dsh-plugin-desktop-beta/tests/plugin-supply-check.spec.ts
@@ -1,0 +1,200 @@
+import { mkdirSync, writeFileSync } from 'node:fs'
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
+import {
+  checkBundleSupply,
+  checkProfileSupply,
+  collectExpectedSupply,
+  createProfileSupplyProbe,
+  type ProfileSupplyProbe,
+  type SupplyPresence,
+} from '../src/plugin-supply-check.ts'
+
+function probeOf(
+  manifests: Record<string, unknown>,
+  presence: Record<string, SupplyPresence>,
+): ProfileSupplyProbe {
+  return {
+    readBundleManifest: packageName => manifests[packageName],
+    presence: packageName => presence[packageName] ?? 'absent',
+  }
+}
+
+describe('expected supply collected from a bundle manifest', () => {
+  it('collects peer dependencies as names the runtime must supply', () => {
+    expect(collectExpectedSupply({ peerDependencies: { 'host-a': '^1.0.0' } })).toEqual([
+      { packageName: 'host-a', expectations: ['peer'] },
+    ])
+  })
+
+  it('collects browser-side inject entries as names the runtime must supply', () => {
+    expect(collectExpectedSupply({ dsh: { client: { inject: ['host-b'] } } })).toEqual([
+      { packageName: 'host-b', expectations: ['client-inject'] },
+    ])
+  })
+
+  it('records one entry when the same name is declared at both sites', () => {
+    const collected = collectExpectedSupply({
+      peerDependencies: { 'host-a': '^1.0.0' },
+      dsh: { client: { inject: ['host-a'] } },
+    })
+    expect(collected).toEqual([{ packageName: 'host-a', expectations: ['peer', 'client-inject'] }])
+  })
+
+  it('ignores regular and optional dependencies, which the package manager fetches itself', () => {
+    expect(collectExpectedSupply({
+      dependencies: { 'carried-a': '^1.0.0' },
+      optionalDependencies: { 'carried-b': '^1.0.0' },
+    })).toEqual([])
+  })
+
+  it('ignores peer dependencies declared optional, whose absence is a supported state', () => {
+    expect(collectExpectedSupply({
+      peerDependencies: { 'host-a': '^1.0.0', 'host-b': '^1.0.0' },
+      peerDependenciesMeta: { 'host-b': { optional: true } },
+    })).toEqual([{ packageName: 'host-a', expectations: ['peer'] }])
+  })
+
+  it('rejects manifests whose declarations cannot be read as package names', () => {
+    expect(() => collectExpectedSupply(null)).toThrow()
+    expect(() => collectExpectedSupply({ peerDependencies: [] })).toThrow()
+    expect(() => collectExpectedSupply({ dsh: { client: { inject: 'host-a' } } })).toThrow()
+    expect(() => collectExpectedSupply({ dsh: { client: { inject: [7] } } })).toThrow()
+    expect(() => collectExpectedSupply({ peerDependencies: { '../escape': '*' } })).toThrow()
+  })
+})
+
+describe('supply reading for one bundle', () => {
+  it('passes a bundle whose every expected name is installed', () => {
+    const probe = probeOf({ plug: { peerDependencies: { 'host-a': '*' } } }, { 'host-a': 'present' })
+    expect(checkBundleSupply('plug', probe)).toEqual({
+      packageName: 'plug',
+      verdict: 'supplied',
+      missing: [],
+    })
+  })
+
+  it('fails a bundle whose expected name is not installed, and names it', () => {
+    const probe = probeOf(
+      { plug: { peerDependencies: { 'host-a': '*', 'host-b': '*' } } },
+      { 'host-a': 'present', 'host-b': 'absent' },
+    )
+    expect(checkBundleSupply('plug', probe)).toEqual({
+      packageName: 'plug',
+      verdict: 'unsupplied',
+      missing: ['host-b'],
+    })
+  })
+
+  it('passes a bundle missing only a regular dependency, which it carries itself', () => {
+    const probe = probeOf({ plug: { dependencies: { 'carried-a': '*' } } }, {})
+    expect(checkBundleSupply('plug', probe).verdict).toBe('supplied')
+  })
+
+  it('reports undecidable rather than supplied when the manifest cannot be read', () => {
+    const probe: ProfileSupplyProbe = {
+      readBundleManifest: () => { throw new Error('manifest is not valid UTF-8') },
+      presence: () => 'present',
+    }
+    const report = checkBundleSupply('plug', probe)
+    expect(report.verdict).toBe('undecidable')
+    expect(report.reason).toBe('manifest is not valid UTF-8')
+  })
+
+  it('reports undecidable when the Profile declares a bundle nothing is installed for', () => {
+    expect(checkBundleSupply('plug', probeOf({}, {})).verdict).toBe('undecidable')
+  })
+
+  it('reports undecidable, never supplied, when one name could not be decided', () => {
+    const probe = probeOf(
+      { plug: { peerDependencies: { 'host-a': '*' } } },
+      { 'host-a': 'undecidable' },
+    )
+    const report = checkBundleSupply('plug', probe)
+    expect(report.verdict).toBe('undecidable')
+    expect(report.missing).toEqual([])
+  })
+
+  it('lets a name known to be absent stand even when another could not be decided', () => {
+    const probe = probeOf(
+      { plug: { peerDependencies: { 'host-a': '*', 'host-b': '*' } } },
+      { 'host-a': 'absent', 'host-b': 'undecidable' },
+    )
+    expect(checkBundleSupply('plug', probe)).toEqual({
+      packageName: 'plug',
+      verdict: 'unsupplied',
+      missing: ['host-a'],
+    })
+  })
+})
+
+describe('supply reading across a Profile', () => {
+  it('keeps the three outcomes apart and preserves the order it was given', () => {
+    const probe = probeOf(
+      {
+        good: { peerDependencies: { 'host-a': '*' } },
+        broken: { peerDependencies: { 'host-z': '*' } },
+      },
+      { 'host-a': 'present' },
+    )
+    const report = checkProfileSupply(['good', 'broken', 'missing'], probe)
+    expect(report.bundles.map(bundle => bundle.packageName)).toEqual(['good', 'broken', 'missing'])
+    expect(report.unsupplied.map(bundle => bundle.packageName)).toEqual(['broken'])
+    expect(report.undecidable.map(bundle => bundle.packageName)).toEqual(['missing'])
+  })
+})
+
+describe('supply probe backed by an installed tree', () => {
+  const roots: string[] = []
+
+  afterEach(async () => {
+    await Promise.all(roots.splice(0).map(async root => { await rm(root, { recursive: true, force: true }) }))
+  })
+
+  async function tree(): Promise<string> {
+    const root = await mkdtemp(join(tmpdir(), 'dsh-desktop-supply-'))
+    roots.push(root)
+    return root
+  }
+
+  function install(dir: string, packageName: string, manifest: Record<string, unknown>): void {
+    const target = join(dir, 'node_modules', ...packageName.split('/'))
+    mkdirSync(target, { recursive: true })
+    writeFileSync(join(target, 'index.js'), 'export default {}\n')
+    writeFileSync(join(target, 'package.json'), JSON.stringify({ name: packageName, version: '1.0.0', main: 'index.js', ...manifest }))
+  }
+
+  it('refuses to run without a directory to resolve from', () => {
+    expect(() => createProfileSupplyProbe([])).toThrow()
+  })
+
+  it('reads an installed bundle manifest and decides its expected names', async () => {
+    const root = await tree()
+    writeFileSync(join(root, 'package.json'), JSON.stringify({ name: 'profile', version: '1.0.0' }))
+    install(root, '@scope/plug', { peerDependencies: { '@scope/host-a': '*', '@scope/host-b': '*' } })
+    install(root, '@scope/host-a', {})
+
+    const report = checkBundleSupply('@scope/plug', createProfileSupplyProbe([root]))
+    expect(report.verdict).toBe('unsupplied')
+    expect(report.missing).toEqual(['@scope/host-b'])
+  })
+
+  it('counts a package resolvable from the Profile but installed higher up as present', async () => {
+    const root = await tree()
+    const profileDir = join(root, 'profile')
+    mkdirSync(profileDir, { recursive: true })
+    writeFileSync(join(profileDir, 'package.json'), JSON.stringify({ name: 'profile', version: '1.0.0' }))
+    install(root, 'hoisted-host', {})
+
+    expect(createProfileSupplyProbe([profileDir]).presence('hoisted-host')).toBe('present')
+  })
+
+  it('reports nothing installed under a name as an absent package', async () => {
+    const root = await tree()
+    writeFileSync(join(root, 'package.json'), JSON.stringify({ name: 'profile', version: '1.0.0' }))
+    expect(createProfileSupplyProbe([root]).presence('never-installed')).toBe('absent')
+    expect(createProfileSupplyProbe([root]).readBundleManifest('never-installed')).toBeUndefined()
+  })
+})

--- a/dsh-plugin-desktop/src/electron-runtime.ts
+++ b/dsh-plugin-desktop/src/electron-runtime.ts
@@ -103,6 +103,26 @@ export function desktopPreloadPath(moduleUrl: string = import.meta.url): string 
 
 const PRODUCT_VERSION = desktopProductVersion()
 
+/** How many affected bundles the update dialog names before summarizing the rest. */
+const UPGRADE_SUPPLY_LISTED = 5
+
+/** Scope every runtime package shares, dropped from dialog lines that repeat it. */
+const RUNTIME_SCOPE_PREFIX = '@deepseek-ai/'
+
+/**
+ * What an offered release would stop supplying to bundles already installed.
+ *
+ * Structural on purpose: the update dialog only needs the affected names and
+ * what each one expected, so it does not depend on how the reading was taken.
+ */
+export interface UpgradeSupplyReading {
+  /** Bundles the offered release cannot supply, in the order they were read. */
+  readonly unsupplied: readonly {
+    readonly packageName: string
+    readonly missing: readonly string[]
+  }[]
+}
+
 /** Main-process deadline for one Renderer generation to settle its client Loader. */
 export const RENDERER_BOOT_TIMEOUT_MS = 30_000
 
@@ -587,19 +607,73 @@ export class ElectronDesktopRuntime implements DesktopRuntime {
       : await this.generation.showSaveDialog(options)
   }
 
+  /**
+   * Reading of what an offered release would stop supplying to installed
+   * bundles. Left unset when no inventory for that release is available, in
+   * which case the update flow proceeds exactly as it did before.
+   */
+  private upgradeSupplyReporter:
+    | ((version: string, channel: DesktopReleaseChannel) => Promise<UpgradeSupplyReading | undefined>)
+    | undefined
+
+  /** Supply the reading used to describe an offered release before downloading it. */
+  setUpgradeSupplyReporter(
+    reporter: (version: string, channel: DesktopReleaseChannel) => Promise<UpgradeSupplyReading | undefined>,
+  ): void {
+    this.upgradeSupplyReporter = reporter
+  }
+
+  /**
+   * Describe the bundles an offered release would stop supplying.
+   *
+   * Returns nothing when there is no reading, or nothing to report, so the
+   * dialog stays exactly as it is today whenever this has nothing to add.
+   */
+  private async describeUpgradeSupply(
+    version: string,
+    channel: DesktopReleaseChannel,
+  ): Promise<string | undefined> {
+    if (this.upgradeSupplyReporter === undefined) return undefined
+    let reading: UpgradeSupplyReading | undefined
+    try {
+      reading = await this.upgradeSupplyReporter(version, channel)
+    } catch (cause) {
+      this.logError(`dsh-plugin-desktop: could not read what ${version} supplies: ${cause instanceof Error ? cause.message : String(cause)}`)
+      return undefined
+    }
+    if (reading === undefined || reading.unsupplied.length === 0) return undefined
+
+    const copy = desktopNativeCopy(this.currentLocale)
+    const shown = reading.unsupplied.slice(0, UPGRADE_SUPPLY_LISTED)
+    const lines = [copy.upgradeSupplyHeadline(reading.unsupplied.length)]
+    for (const bundle of shown) {
+      // The scope is the same for every runtime package, so repeating it on
+      // every line only pushes the names past the width the dialog gives them.
+      const missing = bundle.missing.map(name => name.replace(RUNTIME_SCOPE_PREFIX, '')).join(', ')
+      lines.push(copy.upgradeSupplyEntry(bundle.packageName, missing))
+    }
+    if (reading.unsupplied.length > shown.length) {
+      lines.push(copy.upgradeSupplyMore(reading.unsupplied.length - shown.length))
+    }
+    lines.push(copy.upgradeSupplyReversible)
+    return lines.join('\n')
+  }
+
   /** Ask before making the fixed download endpoint's counted request. */
   private async confirmUpdateDownload(
     version: string,
     channel: DesktopReleaseChannel = 'stable',
   ): Promise<boolean> {
     const copy = desktopNativeCopy(this.currentLocale)
+    const question = channel === DESKTOP_RELEASE_CHANNEL
+      ? copy.downloadUpdate
+      : copy.installStableAlongsideBeta
+    const supply = await this.describeUpgradeSupply(version, channel)
     const result = await this.showUpdateMessageBox({
-      type: 'info',
+      type: supply === undefined ? 'info' : 'warning',
       title: copy.updateAvailableTitle,
       message: copy.updateAvailableMessage(version),
-      detail: channel === DESKTOP_RELEASE_CHANNEL
-        ? copy.downloadUpdate
-        : copy.installStableAlongsideBeta,
+      detail: supply === undefined ? question : `${supply}\n\n${question}`,
       buttons: [copy.download, copy.later],
       defaultId: 1,
       cancelId: 1,

--- a/dsh-plugin-desktop/src/main.ts
+++ b/dsh-plugin-desktop/src/main.ts
@@ -119,6 +119,11 @@ import {
   readDesktopSetupWizardState,
 } from './setup-wizard-state.ts'
 import {
+  offeredRuntimeInventoryOverNetwork,
+  previewUpgradeSupply,
+  readProfileBundleNames,
+} from './upgrade-supply-preview.ts'
+import {
   migrateDesktopBrowserAccessSettings,
   migrateDesktopWindowMaterialSettings,
   readDesktopSetupWizardSettings,
@@ -1276,6 +1281,22 @@ async function start(): Promise<void> {
       profilePreferencesStopping = true
       await profilePreferencesWriteTail
     }
+    // The Profile's bundles and their manifests are settled by this point, so an
+    // offered release can be described in the same terms the Loader uses later.
+    runtime.setUpgradeSupplyReporter(async () => {
+      const target = await offeredRuntimeInventoryOverNetwork(
+        DESKTOP_RELEASE_CHANNEL,
+        'master',
+        undefined,
+        message => { electronLogger.error(`${BIN_NAME}: ${message}`) },
+      )
+      if (target === undefined) return undefined
+      return previewUpgradeSupply({
+        bundleNames: readProfileBundleNames(prepared.profile.dir),
+        profileDir: prepared.profile.dir,
+        target,
+      })
+    })
     startupStage = 'host-boot'
     lifecycleRecorder.transitionStartupStage(startupStage)
     const releasePackageResolver = installProfilePackageResolver(prepared.bareModuleBaseUrl)

--- a/dsh-plugin-desktop/src/native-dialog-copy.ts
+++ b/dsh-plugin-desktop/src/native-dialog-copy.ts
@@ -15,6 +15,10 @@ export interface DesktopNativeCopy {
   readonly dismiss: string
   readonly updateAvailableTitle: string
   readonly updateAvailableMessage: (version: string) => string
+  readonly upgradeSupplyHeadline: (count: number) => string
+  readonly upgradeSupplyEntry: (bundleName: string, missing: string) => string
+  readonly upgradeSupplyMore: (count: number) => string
+  readonly upgradeSupplyReversible: string
   readonly downloadUpdate: string
   readonly installStableAlongsideBeta: string
   readonly download: string
@@ -83,6 +87,12 @@ const COPY: Record<DesktopLocale, DesktopNativeCopy> = {
     dismiss: 'Dismiss',
     updateAvailableTitle: 'DSH Desktop Update Available',
     updateAvailableMessage: version => `DSH Desktop ${version} is available.`,
+    upgradeSupplyHeadline: count => count === 1
+      ? '1 installed plugin expects a package this release does not ship:'
+      : `${count} installed plugins expect packages this release does not ship:`,
+    upgradeSupplyEntry: (bundleName, missing) => `  ${bundleName} — ${missing}`,
+    upgradeSupplyMore: count => `  and ${count} more`,
+    upgradeSupplyReversible: 'Desktop would open in Recovery Mode instead of starting. Nothing is uninstalled; disabling them there restores startup.',
     downloadUpdate: 'Download this update now?',
     installStableAlongsideBeta: 'Install the stable edition alongside DSH Desktop Beta? The Beta app will remain installed.',
     download: 'Download',
@@ -144,6 +154,10 @@ const COPY: Record<DesktopLocale, DesktopNativeCopy> = {
     dismiss: '关闭',
     updateAvailableTitle: 'DSH Desktop 有可用更新',
     updateAvailableMessage: version => `DSH Desktop ${version} 已可用。`,
+    upgradeSupplyHeadline: count => `已安装的插件中有 ${count} 个需要此版本不包含的组件：`,
+    upgradeSupplyEntry: (bundleName, missing) => `  ${bundleName} — ${missing}`,
+    upgradeSupplyMore: count => `  另有 ${count} 个`,
+    upgradeSupplyReversible: '这会使 Desktop 无法启动、转入恢复模式。插件不会被卸载，在那里禁用即可恢复。',
     downloadUpdate: '现在下载此更新？',
     installStableAlongsideBeta: '是否同时安装稳定版？DSH Desktop Beta 将继续保留。',
     download: '下载',

--- a/dsh-plugin-desktop/src/plugin-supply-check.ts
+++ b/dsh-plugin-desktop/src/plugin-supply-check.ts
@@ -1,0 +1,276 @@
+/**
+ * Reading of whether the installed runtime still supplies every package the
+ * active Profile's bundles expect it to supply.
+ *
+ * A bundle names packages in two different ways, and the difference decides what
+ * absence means. A regular dependency is fetched by the package manager, so a
+ * bundle keeps loading when the runtime stops shipping that package: it simply
+ * carries its own copy. A peer dependency, and a browser-side inject entry, are
+ * the opposite. Nothing fetches those on the bundle's behalf, so when the
+ * installed runtime no longer ships one, resolution fails while the Loader is
+ * still bringing the bundle up, before any of the bundle's own code runs. No
+ * defensive coding inside the bundle survives that, and no version range it
+ * declares predicts it, because a range describes what its author expected and
+ * is satisfied by a release that no longer ships the package at all.
+ *
+ * This is why the reading is worth taking before boot: the same fact is already
+ * on disk, at no cost, that the Loader is about to discover the expensive way.
+ *
+ * The reading rules out exactly one way of failing, so its clean result is
+ * narrower than compatibility. A package that is installed but no longer exports
+ * the binding being imported, and a bundle that resolves yet refuses to
+ * activate, are both outside what it can see.
+ */
+
+import { existsSync, readFileSync } from 'node:fs'
+import { createRequire } from 'node:module'
+import { dirname, join, resolve } from 'node:path'
+
+/** Largest bundle manifest this reading will parse. */
+const MAX_BUNDLE_MANIFEST_BYTES = 1024 * 1024
+
+/** Largest number of expected names accepted from a single bundle manifest. */
+const MAX_EXPECTED_NAMES = 1024
+
+/** Package name shape shared with the rest of Desktop's Profile handling. */
+const PACKAGE_NAME_PATTERN = /^(?:@[a-z0-9][a-z0-9._-]*\/)?[a-z0-9][a-z0-9._-]*$/u
+
+/** How a bundle asked the runtime to supply one package name. */
+export type SupplyExpectation = 'peer' | 'client-inject'
+
+/** Whether one expected name is installed for the active Profile. */
+export type SupplyPresence = 'present' | 'absent' | 'undecidable'
+
+/** Whether a bundle's expectations are met, or could not be read at all. */
+export type BundleSupplyVerdict = 'supplied' | 'unsupplied' | 'undecidable'
+
+/** One package name a bundle expects the runtime to supply. */
+export interface ExpectedSupply {
+  /** Package name the bundle expects to resolve without installing it itself. */
+  readonly packageName: string
+  /** Every declaration site that named it, in manifest order without repeats. */
+  readonly expectations: readonly SupplyExpectation[]
+}
+
+/** Reading for one bundle declared by the active Profile. */
+export interface BundleSupplyReport {
+  /** Bundle package name as declared by the Profile manifest. */
+  readonly packageName: string
+  /** Whether the installed runtime can bring this bundle up. */
+  readonly verdict: BundleSupplyVerdict
+  /** Expected names that are not installed; empty unless the verdict is `unsupplied`. */
+  readonly missing: readonly string[]
+  /** Why no reading was possible; present only when the verdict is `undecidable`. */
+  readonly reason?: string
+}
+
+/** Reading across every bundle the caller asked about. */
+export interface ProfileSupplyReport {
+  /** Every bundle examined, in the order the caller supplied them. */
+  readonly bundles: readonly BundleSupplyReport[]
+  /** Bundles the installed runtime cannot supply, so they cannot come up. */
+  readonly unsupplied: readonly BundleSupplyReport[]
+  /** Bundles no reading could be taken for; never folded into either verdict. */
+  readonly undecidable: readonly BundleSupplyReport[]
+}
+
+/** Disk access this reading needs, injected so the judgement stays testable. */
+export interface ProfileSupplyProbe {
+  /**
+   * Parsed manifest of one installed bundle, or `undefined` when the Profile
+   * declares the bundle but nothing is installed under that name. Throws when a
+   * manifest exists yet cannot be read, so an unreadable bundle is never
+   * mistaken for an absent one.
+   */
+  readonly readBundleManifest: (packageName: string) => unknown
+  /** Whether one expected name is installed for the active Profile. */
+  readonly presence: (packageName: string) => SupplyPresence
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value)
+}
+
+/**
+ * Names the manifest expects the runtime to supply.
+ *
+ * Optional peer dependencies are excluded deliberately. Their absence is a
+ * declared and supported state, so counting them would report a healthy bundle
+ * as broken, which is the most damaging mistake this reading can make.
+ */
+export function collectExpectedSupply(manifest: unknown): readonly ExpectedSupply[] {
+  if (!isPlainObject(manifest)) throw new Error('bundle manifest must hold a JSON object')
+  const collected = new Map<string, SupplyExpectation[]>()
+  const add = (packageName: string, expectation: SupplyExpectation): void => {
+    if (!PACKAGE_NAME_PATTERN.test(packageName)) {
+      throw new Error(`bundle manifest names an invalid package ${JSON.stringify(packageName)}`)
+    }
+    const existing = collected.get(packageName)
+    if (existing === undefined) collected.set(packageName, [expectation])
+    else if (!existing.includes(expectation)) existing.push(expectation)
+  }
+
+  const peers = manifest.peerDependencies
+  if (peers !== undefined) {
+    if (!isPlainObject(peers)) throw new Error('bundle manifest peerDependencies must be an object')
+    const meta = manifest.peerDependenciesMeta
+    if (meta !== undefined && !isPlainObject(meta)) {
+      throw new Error('bundle manifest peerDependenciesMeta must be an object')
+    }
+    for (const packageName of Object.keys(peers)) {
+      const entry = isPlainObject(meta) ? meta[packageName] : undefined
+      if (isPlainObject(entry) && entry.optional === true) continue
+      add(packageName, 'peer')
+    }
+  }
+
+  const dsh = manifest.dsh
+  if (dsh !== undefined) {
+    if (!isPlainObject(dsh)) throw new Error('bundle manifest dsh field must be an object')
+    const client = dsh.client
+    if (client !== undefined) {
+      if (!isPlainObject(client)) throw new Error('bundle manifest dsh.client field must be an object')
+      const inject = client.inject
+      if (inject !== undefined) {
+        if (!Array.isArray(inject)) throw new Error('bundle manifest dsh.client.inject must be an array')
+        for (const entry of inject) {
+          if (typeof entry !== 'string') {
+            throw new Error('bundle manifest dsh.client.inject must hold package names')
+          }
+          add(entry, 'client-inject')
+        }
+      }
+    }
+  }
+
+  if (collected.size > MAX_EXPECTED_NAMES) {
+    throw new Error('bundle manifest expects too many names from the runtime')
+  }
+  return [...collected].map(([packageName, expectations]) => ({ packageName, expectations }))
+}
+
+function undecidableBundle(packageName: string, reason: string): BundleSupplyReport {
+  return { packageName, verdict: 'undecidable', missing: [], reason }
+}
+
+/**
+ * Reading for one bundle.
+ *
+ * ⛔ The order of the two negative outcomes matters. One name known to be absent
+ * is already sufficient for the bundle to fail, so it stands whether or not
+ * other names could be measured; asking "was anything unmeasurable" first would
+ * swallow a certain failure inside an uncertainty. Only when nothing is known to
+ * be absent does an unmeasurable name decide the reading, and then it must yield
+ * undecidable rather than supplied: a reading that quietly downgrades "not
+ * measured" to "fine" is worse than no reading, because nothing distinguishes it
+ * from a real pass.
+ */
+export function checkBundleSupply(
+  packageName: string,
+  probe: ProfileSupplyProbe,
+): BundleSupplyReport {
+  let expected: readonly ExpectedSupply[]
+  try {
+    const manifest = probe.readBundleManifest(packageName)
+    if (manifest === undefined) return undecidableBundle(packageName, 'nothing is installed under this name')
+    expected = collectExpectedSupply(manifest)
+  } catch (cause) {
+    return undecidableBundle(packageName, cause instanceof Error ? cause.message : String(cause))
+  }
+
+  const missing: string[] = []
+  const unmeasured: string[] = []
+  for (const entry of expected) {
+    const presence = probe.presence(entry.packageName)
+    if (presence === 'absent') missing.push(entry.packageName)
+    else if (presence === 'undecidable') unmeasured.push(entry.packageName)
+  }
+  if (missing.length > 0) return { packageName, verdict: 'unsupplied', missing }
+  if (unmeasured.length > 0) {
+    return undecidableBundle(packageName, `cannot tell whether ${unmeasured.join(', ')} is installed`)
+  }
+  return { packageName, verdict: 'supplied', missing: [] }
+}
+
+/** Reading across every bundle the caller asked about, in the order given. */
+export function checkProfileSupply(
+  bundleNames: readonly string[],
+  probe: ProfileSupplyProbe,
+): ProfileSupplyReport {
+  const bundles = bundleNames.map(packageName => checkBundleSupply(packageName, probe))
+  return {
+    bundles,
+    unsupplied: bundles.filter(bundle => bundle.verdict === 'unsupplied'),
+    undecidable: bundles.filter(bundle => bundle.verdict === 'undecidable'),
+  }
+}
+
+/**
+ * Every directory resolution would consult starting from `start`, nearest first.
+ *
+ * A Profile does not necessarily hold its own installed tree — Desktop lays the
+ * modules out one level above, shared across Profiles — so a probe that only
+ * looked inside the Profile would find nothing and report every bundle as
+ * undecidable. Walking the chain is what makes the reading independent of which
+ * layout is in use, and it is the same walk resolution itself performs.
+ */
+function resolutionChain(start: string): readonly string[] {
+  const dirs: string[] = []
+  let current = resolve(start)
+  for (;;) {
+    dirs.push(current)
+    const parent = dirname(current)
+    if (parent === current) return dirs
+    current = parent
+  }
+}
+
+/**
+ * Probe backed by the Profile's own installed tree.
+ *
+ * Presence is asked in the same terms the Loader will ask it, so the reading and
+ * the failure it predicts come from one mechanism rather than two that can drift
+ * apart. Directories are consulted nearest first, starting with the Profile whose
+ * bundles are being judged and continuing through the ancestors resolution
+ * would search.
+ */
+export function createProfileSupplyProbe(searchDirs: readonly string[]): ProfileSupplyProbe {
+  const [resolutionRoot] = searchDirs
+  if (resolutionRoot === undefined) {
+    throw new Error('a Profile supply probe needs at least one search directory')
+  }
+  const chain = [...new Set(searchDirs.flatMap(dir => resolutionChain(dir)))]
+  const installedManifestPath = (packageName: string): string | undefined => {
+    for (const dir of chain) {
+      const candidate = join(dir, 'node_modules', ...packageName.split('/'), 'package.json')
+      if (existsSync(candidate)) return candidate
+    }
+    return undefined
+  }
+  return {
+    readBundleManifest: packageName => {
+      const manifestPath = installedManifestPath(packageName)
+      if (manifestPath === undefined) return undefined
+      const bytes = readFileSync(manifestPath)
+      if (bytes.byteLength > MAX_BUNDLE_MANIFEST_BYTES) {
+        throw new Error(`installed manifest for ${packageName} is too large to read`)
+      }
+      return JSON.parse(new TextDecoder('utf-8', { fatal: true }).decode(bytes)) as unknown
+    },
+    presence: packageName => {
+      if (installedManifestPath(packageName) !== undefined) return 'present'
+      // A package can be installed yet decline to expose a manifest subpath, so
+      // an export-map refusal proves presence as firmly as a readable manifest.
+      try {
+        createRequire(join(resolutionRoot, 'package.json')).resolve(packageName)
+        return 'present'
+      } catch (cause) {
+        const code = (cause as NodeJS.ErrnoException).code
+        if (code === 'MODULE_NOT_FOUND') return 'absent'
+        if (code === 'ERR_PACKAGE_PATH_NOT_EXPORTED') return 'present'
+        if (code === 'ERR_UNSUPPORTED_DIR_IMPORT') return 'present'
+        return 'undecidable'
+      }
+    },
+  }
+}

--- a/dsh-plugin-desktop/src/upgrade-supply-preview.ts
+++ b/dsh-plugin-desktop/src/upgrade-supply-preview.ts
@@ -1,0 +1,257 @@
+/**
+ * What an offered release would stop supplying to the bundles already installed.
+ *
+ * The same reading as {@link checkProfileSupply}, with one substitution: instead
+ * of asking this machine what is installed, it asks the inventory published for
+ * the release being offered. Everything else — which names a bundle expects the
+ * runtime to supply, and what their absence means — is unchanged, so the answer
+ * before an upgrade and the answer after it are produced by one mechanism rather
+ * than two that can disagree.
+ *
+ * The reading is only as current as the inventory it is given. When no inventory
+ * for the offered release is available the preview is simply absent, and the
+ * update flow proceeds exactly as it does today. That failure direction is
+ * deliberate: a missing preview costs a warning that never appears, while a
+ * wrong preview would talk someone out of an upgrade that was fine.
+ */
+
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import {
+  checkProfileSupply,
+  createProfileSupplyProbe,
+  type ProfileSupplyReport,
+  type SupplyPresence,
+} from './plugin-supply-check.ts'
+
+/** Largest published inventory this preview will parse. */
+const MAX_INVENTORY_BYTES = 4 * 1024 * 1024
+
+/** Package name shape shared with the rest of Desktop's Profile handling. */
+const PACKAGE_NAME_PATTERN = /^(?:@[a-z0-9][a-z0-9._-]*\/)?[a-z0-9][a-z0-9._-]*$/u
+
+/**
+ * What an offered release publishes about itself.
+ *
+ * An inventory is authoritative only for the name prefixes it claims. A runtime
+ * manifest lists the runtime's own packages, so it can say nothing about a UI
+ * framework a bundle expects from the host — and treating that silence as
+ * absence is how a bundle gets condemned for depending on something the release
+ * does supply. Names outside the claimed scopes are therefore left undecided.
+ */
+export interface RuntimeInventory {
+  /** Every package name the offered release is known to supply. */
+  readonly packages: ReadonlySet<string>
+  /** Name prefixes this inventory can speak about; empty means it speaks about all. */
+  readonly scopes: readonly string[]
+}
+
+/** Everything the preview needs about the machine and the offered release. */
+export interface UpgradeSupplyInput {
+  /** Bundle names the active Profile declares, in manifest order. */
+  readonly bundleNames: readonly string[]
+  /** Active Profile directory, used to read each installed bundle's manifest. */
+  readonly profileDir: string
+  /** What the offered release publishes about what it supplies. */
+  readonly target: RuntimeInventory
+}
+
+/**
+ * Package names published for one release.
+ *
+ * `alwaysPresent` carries the packages that keep their own version line, which a
+ * runtime manifest leaves out precisely because they never move with the
+ * runtime. Without them, every bundle depending on the framework base would be
+ * reported as newly broken — the mistake that condemns working bundles in bulk.
+ *
+ * `scopes` bounds what the inventory is entitled to deny. A runtime manifest can
+ * say a runtime package is gone; it cannot say anything about a package from
+ * another publisher, and silence there is not absence.
+ */
+export function parseRuntimeInventory(
+  value: unknown,
+  alwaysPresent: readonly string[] = [],
+  scopes: readonly string[] = [],
+): RuntimeInventory {
+  if (value === null || typeof value !== 'object' || Array.isArray(value)) {
+    throw new Error('runtime inventory must hold a JSON object')
+  }
+  const packages = (value as { packages?: unknown }).packages
+  if (!Array.isArray(packages)) throw new Error('runtime inventory must list packages')
+  const names = new Set<string>(alwaysPresent)
+  for (const entry of packages) {
+    const name = typeof entry === 'string'
+      ? entry
+      : entry !== null && typeof entry === 'object' && !Array.isArray(entry)
+        ? (entry as { name?: unknown }).name
+        : undefined
+    if (typeof name !== 'string' || !PACKAGE_NAME_PATTERN.test(name)) {
+      throw new Error('runtime inventory holds an invalid package name')
+    }
+    names.add(name)
+  }
+  const declared = (value as { scopes?: unknown }).scopes
+  const resolved = Array.isArray(declared)
+    ? declared.filter((scope): scope is string => typeof scope === 'string')
+    : scopes
+  return { packages: names, scopes: resolved }
+}
+
+/** Read a published runtime inventory from disk. */
+export function readRuntimeInventory(
+  path: string,
+  alwaysPresent: readonly string[] = [],
+  scopes: readonly string[] = [],
+): RuntimeInventory {
+  const bytes = readFileSync(path)
+  if (bytes.byteLength > MAX_INVENTORY_BYTES) {
+    throw new Error('runtime inventory is too large to read')
+  }
+  return parseRuntimeInventory(
+    JSON.parse(new TextDecoder('utf-8', { fatal: true }).decode(bytes)) as unknown,
+    alwaysPresent,
+    scopes,
+  )
+}
+
+/**
+ * Environment override naming a directory of published runtime inventories.
+ *
+ * This is the seam where a release channel's own inventory arrives. Until one is
+ * published, the directory is how an inventory can be supplied out of band, and
+ * its absence simply means no preview is offered.
+ */
+export const RUNTIME_INVENTORY_DIRECTORY_ENV = 'DSH_DESKTOP_RUNTIME_INVENTORY_DIR'
+
+/** Inventory published for one offered release, or nothing when none is available. */
+export function offeredRuntimeInventory(
+  version: string,
+  directory: string | undefined = process.env[RUNTIME_INVENTORY_DIRECTORY_ENV],
+): RuntimeInventory | undefined {
+  if (directory === undefined || directory.length === 0) return undefined
+  if (!/^[0-9A-Za-z._+-]+$/u.test(version)) return undefined
+  try {
+    return readRuntimeInventory(join(directory, `${version}.json`))
+  } catch {
+    return undefined
+  }
+}
+
+/** Base URL of the repository serving the channel table and runtime manifests. */
+export const RUNTIME_INVENTORY_URL_ENV = 'DSH_DESKTOP_RUNTIME_INVENTORY_URL'
+
+/** Name prefix the vendored runtime manifests are authoritative about. */
+export const RUNTIME_INVENTORY_SCOPE = '@deepseek-ai/dsh'
+
+/** How long the two inventory requests may take before the preview is skipped. */
+const INVENTORY_FETCH_TIMEOUT_MS = 10_000
+
+/** Largest inventory response accepted from the network. */
+const MAX_INVENTORY_RESPONSE_BYTES = 4 * 1024 * 1024
+
+/**
+ * Fetch the inventory a channel publishes about itself.
+ *
+ * Two documents: the channel table names the runtime version that channel
+ * bundles, and that version's manifest lists the packages. Neither has to be
+ * installed first, which is what makes the reading possible before an upgrade
+ * rather than after it.
+ */
+export async function fetchRuntimeInventory(
+  baseUrl: string,
+  channel: string,
+  branch: string,
+  fetchImpl: typeof fetch = fetch,
+  signal?: AbortSignal,
+): Promise<RuntimeInventory> {
+  const read = async (path: string): Promise<unknown> => {
+    const init: RequestInit = { redirect: 'follow', ...(signal === undefined ? {} : { signal }) }
+    const response = await fetchImpl(`${baseUrl}/${branch}/${path}`, init)
+    if (!response.ok) throw new Error(`${path} responded ${response.status}`)
+    const text = await response.text()
+    if (text.length > MAX_INVENTORY_RESPONSE_BYTES) throw new Error(`${path} is too large to read`)
+    return JSON.parse(text) as unknown
+  }
+
+  const table = await read('upstream.json')
+  if (table === null || typeof table !== 'object' || Array.isArray(table)) {
+    throw new Error('channel table must hold a JSON object')
+  }
+  const channels = (table as { channels?: unknown }).channels
+  if (channels === null || typeof channels !== 'object' || Array.isArray(channels)) {
+    throw new Error('channel table must list channels')
+  }
+  const entry = (channels as Record<string, unknown>)[channel]
+  const version = entry !== null && typeof entry === 'object' && !Array.isArray(entry)
+    ? (entry as { sourceVersion?: unknown }).sourceVersion
+    : undefined
+  if (typeof version !== 'string' || !/^[0-9A-Za-z._+-]+$/u.test(version)) {
+    throw new Error(`channel ${channel} declares no usable runtime version`)
+  }
+  return parseRuntimeInventory(
+    await read(`vendor/dsh-runtime/${version}/manifest.json`),
+    [],
+    [RUNTIME_INVENTORY_SCOPE],
+  )
+}
+
+/** Inventory fetched for the offered release, or nothing when it cannot be had. */
+export async function offeredRuntimeInventoryOverNetwork(
+  channel: string,
+  branch: string,
+  baseUrl: string | undefined = process.env[RUNTIME_INVENTORY_URL_ENV],
+  report: (message: string) => void = () => {},
+): Promise<RuntimeInventory | undefined> {
+  if (baseUrl === undefined || baseUrl.length === 0) return undefined
+  const started = Date.now()
+  const controller = new AbortController()
+  const timer = setTimeout(() => { controller.abort() }, INVENTORY_FETCH_TIMEOUT_MS)
+  try {
+    const inventory = await fetchRuntimeInventory(baseUrl, channel, branch, fetch, controller.signal)
+    report(`runtime inventory fetched in ${Date.now() - started}ms, ${inventory.packages.size} packages`)
+    return inventory
+  } catch (cause) {
+    report(`runtime inventory unavailable after ${Date.now() - started}ms: ${cause instanceof Error ? cause.message : String(cause)}`)
+    return undefined
+  } finally {
+    clearTimeout(timer)
+  }
+}
+
+/** Bundle names the Profile manifest declares, or an empty list when it declares none. */
+export function readProfileBundleNames(profileDir: string): readonly string[] {
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(readFileSync(join(profileDir, 'package.json'), 'utf8')) as unknown
+  } catch {
+    return []
+  }
+  if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) return []
+  const dsh = (parsed as { dsh?: unknown }).dsh
+  if (dsh === null || typeof dsh !== 'object' || Array.isArray(dsh)) return []
+  const profile = (dsh as { profile?: unknown }).profile
+  if (profile === null || typeof profile !== 'object' || Array.isArray(profile)) return []
+  const bundles = (profile as { bundles?: unknown }).bundles
+  if (!Array.isArray(bundles)) return []
+  return bundles.filter((name): name is string => typeof name === 'string' && PACKAGE_NAME_PATTERN.test(name))
+}
+
+/**
+ * Reading of what the offered release would stop supplying.
+ *
+ * A name the inventory lists is present. A name it does not list is absent only
+ * when the inventory claims to speak about that name; otherwise the reading for
+ * that bundle is left undecided, and undecided bundles are never reported.
+ */
+export function previewUpgradeSupply(input: UpgradeSupplyInput): ProfileSupplyReport {
+  const installed = createProfileSupplyProbe([input.profileDir])
+  const { packages, scopes } = input.target
+  const speaksAbout = (packageName: string): boolean =>
+    scopes.length === 0 || scopes.some(scope => packageName.startsWith(scope))
+  const presence = (packageName: string): SupplyPresence =>
+    packages.has(packageName) ? 'present' : speaksAbout(packageName) ? 'absent' : 'undecidable'
+  return checkProfileSupply(input.bundleNames, {
+    readBundleManifest: installed.readBundleManifest,
+    presence,
+  })
+}

--- a/dsh-plugin-desktop/tests/plugin-supply-check.spec.ts
+++ b/dsh-plugin-desktop/tests/plugin-supply-check.spec.ts
@@ -1,0 +1,200 @@
+import { mkdirSync, writeFileSync } from 'node:fs'
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
+import {
+  checkBundleSupply,
+  checkProfileSupply,
+  collectExpectedSupply,
+  createProfileSupplyProbe,
+  type ProfileSupplyProbe,
+  type SupplyPresence,
+} from '../src/plugin-supply-check.ts'
+
+function probeOf(
+  manifests: Record<string, unknown>,
+  presence: Record<string, SupplyPresence>,
+): ProfileSupplyProbe {
+  return {
+    readBundleManifest: packageName => manifests[packageName],
+    presence: packageName => presence[packageName] ?? 'absent',
+  }
+}
+
+describe('expected supply collected from a bundle manifest', () => {
+  it('collects peer dependencies as names the runtime must supply', () => {
+    expect(collectExpectedSupply({ peerDependencies: { 'host-a': '^1.0.0' } })).toEqual([
+      { packageName: 'host-a', expectations: ['peer'] },
+    ])
+  })
+
+  it('collects browser-side inject entries as names the runtime must supply', () => {
+    expect(collectExpectedSupply({ dsh: { client: { inject: ['host-b'] } } })).toEqual([
+      { packageName: 'host-b', expectations: ['client-inject'] },
+    ])
+  })
+
+  it('records one entry when the same name is declared at both sites', () => {
+    const collected = collectExpectedSupply({
+      peerDependencies: { 'host-a': '^1.0.0' },
+      dsh: { client: { inject: ['host-a'] } },
+    })
+    expect(collected).toEqual([{ packageName: 'host-a', expectations: ['peer', 'client-inject'] }])
+  })
+
+  it('ignores regular and optional dependencies, which the package manager fetches itself', () => {
+    expect(collectExpectedSupply({
+      dependencies: { 'carried-a': '^1.0.0' },
+      optionalDependencies: { 'carried-b': '^1.0.0' },
+    })).toEqual([])
+  })
+
+  it('ignores peer dependencies declared optional, whose absence is a supported state', () => {
+    expect(collectExpectedSupply({
+      peerDependencies: { 'host-a': '^1.0.0', 'host-b': '^1.0.0' },
+      peerDependenciesMeta: { 'host-b': { optional: true } },
+    })).toEqual([{ packageName: 'host-a', expectations: ['peer'] }])
+  })
+
+  it('rejects manifests whose declarations cannot be read as package names', () => {
+    expect(() => collectExpectedSupply(null)).toThrow()
+    expect(() => collectExpectedSupply({ peerDependencies: [] })).toThrow()
+    expect(() => collectExpectedSupply({ dsh: { client: { inject: 'host-a' } } })).toThrow()
+    expect(() => collectExpectedSupply({ dsh: { client: { inject: [7] } } })).toThrow()
+    expect(() => collectExpectedSupply({ peerDependencies: { '../escape': '*' } })).toThrow()
+  })
+})
+
+describe('supply reading for one bundle', () => {
+  it('passes a bundle whose every expected name is installed', () => {
+    const probe = probeOf({ plug: { peerDependencies: { 'host-a': '*' } } }, { 'host-a': 'present' })
+    expect(checkBundleSupply('plug', probe)).toEqual({
+      packageName: 'plug',
+      verdict: 'supplied',
+      missing: [],
+    })
+  })
+
+  it('fails a bundle whose expected name is not installed, and names it', () => {
+    const probe = probeOf(
+      { plug: { peerDependencies: { 'host-a': '*', 'host-b': '*' } } },
+      { 'host-a': 'present', 'host-b': 'absent' },
+    )
+    expect(checkBundleSupply('plug', probe)).toEqual({
+      packageName: 'plug',
+      verdict: 'unsupplied',
+      missing: ['host-b'],
+    })
+  })
+
+  it('passes a bundle missing only a regular dependency, which it carries itself', () => {
+    const probe = probeOf({ plug: { dependencies: { 'carried-a': '*' } } }, {})
+    expect(checkBundleSupply('plug', probe).verdict).toBe('supplied')
+  })
+
+  it('reports undecidable rather than supplied when the manifest cannot be read', () => {
+    const probe: ProfileSupplyProbe = {
+      readBundleManifest: () => { throw new Error('manifest is not valid UTF-8') },
+      presence: () => 'present',
+    }
+    const report = checkBundleSupply('plug', probe)
+    expect(report.verdict).toBe('undecidable')
+    expect(report.reason).toBe('manifest is not valid UTF-8')
+  })
+
+  it('reports undecidable when the Profile declares a bundle nothing is installed for', () => {
+    expect(checkBundleSupply('plug', probeOf({}, {})).verdict).toBe('undecidable')
+  })
+
+  it('reports undecidable, never supplied, when one name could not be decided', () => {
+    const probe = probeOf(
+      { plug: { peerDependencies: { 'host-a': '*' } } },
+      { 'host-a': 'undecidable' },
+    )
+    const report = checkBundleSupply('plug', probe)
+    expect(report.verdict).toBe('undecidable')
+    expect(report.missing).toEqual([])
+  })
+
+  it('lets a name known to be absent stand even when another could not be decided', () => {
+    const probe = probeOf(
+      { plug: { peerDependencies: { 'host-a': '*', 'host-b': '*' } } },
+      { 'host-a': 'absent', 'host-b': 'undecidable' },
+    )
+    expect(checkBundleSupply('plug', probe)).toEqual({
+      packageName: 'plug',
+      verdict: 'unsupplied',
+      missing: ['host-a'],
+    })
+  })
+})
+
+describe('supply reading across a Profile', () => {
+  it('keeps the three outcomes apart and preserves the order it was given', () => {
+    const probe = probeOf(
+      {
+        good: { peerDependencies: { 'host-a': '*' } },
+        broken: { peerDependencies: { 'host-z': '*' } },
+      },
+      { 'host-a': 'present' },
+    )
+    const report = checkProfileSupply(['good', 'broken', 'missing'], probe)
+    expect(report.bundles.map(bundle => bundle.packageName)).toEqual(['good', 'broken', 'missing'])
+    expect(report.unsupplied.map(bundle => bundle.packageName)).toEqual(['broken'])
+    expect(report.undecidable.map(bundle => bundle.packageName)).toEqual(['missing'])
+  })
+})
+
+describe('supply probe backed by an installed tree', () => {
+  const roots: string[] = []
+
+  afterEach(async () => {
+    await Promise.all(roots.splice(0).map(async root => { await rm(root, { recursive: true, force: true }) }))
+  })
+
+  async function tree(): Promise<string> {
+    const root = await mkdtemp(join(tmpdir(), 'dsh-desktop-supply-'))
+    roots.push(root)
+    return root
+  }
+
+  function install(dir: string, packageName: string, manifest: Record<string, unknown>): void {
+    const target = join(dir, 'node_modules', ...packageName.split('/'))
+    mkdirSync(target, { recursive: true })
+    writeFileSync(join(target, 'index.js'), 'export default {}\n')
+    writeFileSync(join(target, 'package.json'), JSON.stringify({ name: packageName, version: '1.0.0', main: 'index.js', ...manifest }))
+  }
+
+  it('refuses to run without a directory to resolve from', () => {
+    expect(() => createProfileSupplyProbe([])).toThrow()
+  })
+
+  it('reads an installed bundle manifest and decides its expected names', async () => {
+    const root = await tree()
+    writeFileSync(join(root, 'package.json'), JSON.stringify({ name: 'profile', version: '1.0.0' }))
+    install(root, '@scope/plug', { peerDependencies: { '@scope/host-a': '*', '@scope/host-b': '*' } })
+    install(root, '@scope/host-a', {})
+
+    const report = checkBundleSupply('@scope/plug', createProfileSupplyProbe([root]))
+    expect(report.verdict).toBe('unsupplied')
+    expect(report.missing).toEqual(['@scope/host-b'])
+  })
+
+  it('counts a package resolvable from the Profile but installed higher up as present', async () => {
+    const root = await tree()
+    const profileDir = join(root, 'profile')
+    mkdirSync(profileDir, { recursive: true })
+    writeFileSync(join(profileDir, 'package.json'), JSON.stringify({ name: 'profile', version: '1.0.0' }))
+    install(root, 'hoisted-host', {})
+
+    expect(createProfileSupplyProbe([profileDir]).presence('hoisted-host')).toBe('present')
+  })
+
+  it('reports nothing installed under a name as an absent package', async () => {
+    const root = await tree()
+    writeFileSync(join(root, 'package.json'), JSON.stringify({ name: 'profile', version: '1.0.0' }))
+    expect(createProfileSupplyProbe([root]).presence('never-installed')).toBe('absent')
+    expect(createProfileSupplyProbe([root]).readBundleManifest('never-installed')).toBeUndefined()
+  })
+})


### PR DESCRIPTION
## Summary

Name the installed plugins an offered release cannot supply, before the update is downloaded.

A plugin whose peer dependency is missing from the runtime fails while the Loader resolves it, and `client/boot-health.ts` reports the renderer unhealthy when any fiber is not ACTIVE — so one such plugin sends the whole app into Recovery Mode rather than merely disabling itself. That fact is already readable from the inventory the offered release publishes, so the update dialog now names the affected plugins and what each one expects.

Only `peerDependencies` are judged, because nothing supplies them on the plugin's behalf. Regular dependencies are excluded, since the package manager fetches its own copy. `dsh.client.inject` entries are excluded too, because `dsh-client-modules` skips a missing entry rather than waiting on it. When no inventory can be read the dialog is unchanged, so a failed reading degrades to exactly today's behaviour.

No buttons are added and no window is introduced: the existing `[Download] [Later]` pair keeps `Later` as its default answer, and only the detail text and the tone icon change. No new production dependency — Node built-ins only.

## 摘要

在下载更新之前，指出这一版无法提供其依赖的已装插件。

插件的 peer 依赖若在运行时中不存在，会在 Loader 解析阶段失败；而 `client/boot-health.ts` 只要发现任一 fiber 不是 ACTIVE 就判定渲染进程不健康——因此一个这样的插件会让整个应用进入恢复模式，而不只是它自己不加载。这个事实在下载之前就能从该版本发布的清单里读出来，所以更新对话框现在会列出受影响的插件及各自缺少的组件。

只判定 `peerDependencies`，因为没有任何机制会替插件安装它们。普通 `dependencies` 不计入，包管理器会自带一份；`dsh.client.inject` 也不计入，`dsh-client-modules` 对缺失条目是跳过而非等待。读不到清单时对话框完全不变——这个功能失败，就退回今天的行为。

不新增按钮、不新建窗口：沿用现有的 `[下载] [稍后]`，默认仍停在「稍后」，只改详情文字与图标语气。不引入任何生产依赖，只用 Node 内置模块。

<img width="602" height="331" alt="Update dialog naming two installed plugins that the offered release cannot supply" src="https://github.com/user-attachments/assets/fc40e767-4589-4e00-8f0d-1a3ee79875bc" />

A Profile on `0.1.1-rc.2` being offered `0.1.2-rc.1`. Both plugins expect `@deepseek-ai/dsh-client-runtime`, which that release no longer ships. The buttons and their default answer are unchanged.

一个 `0.1.1-rc.2` 的 Profile 被提供 `0.1.2-rc.1` 时的实际提示。两个插件都依赖 `@deepseek-ai/dsh-client-runtime`，而该版本不再包含它。按钮与默认选项均未改动。

## Related Issues / 关联 Issue

Related to #737, #728 and #753, which report this failure after it happens. Complements #749, which improved what Recovery Mode says once it is reached.

关联 #737、#728、#753：它们记录的是失败发生之后。与 #749 互补——那一个改进的是进入恢复模式之后的提示。

## Type / 类型

- [x] Feature / 新功能

## Platforms / 影响平台

- [x] Not platform-specific / 与平台无关

## Verification / 验证

- [x] corepack yarn typecheck
- [x] corepack yarn test
- [x] Manual test / 人工测试

Commands actually run / 实际运行的命令：

```
corepack yarn workspace dsh-plugin-desktop typecheck                                                passed
corepack yarn workspace dsh-plugin-desktop-beta typecheck                                           passed
corepack yarn workspace dsh-plugin-desktop      exec vitest run tests/plugin-supply-check.spec.ts    18 passed
corepack yarn workspace dsh-plugin-desktop-beta exec vitest run tests/plugin-supply-check.spec.ts    18 passed
node scripts/verify-desktop-variants.mjs                                     138 shared source files aligned
corepack yarn workspace dsh-plugin-desktop test                    1017 passed, 11 failed, 12 skipped
```

The 11 failures are not introduced here. Reverting this branch and running the same suite on the base commit fails the same 11: they need symlink privilege and a test pnpm shim that this Windows environment does not provide — the same two environment-sensitive failures reported in #749. This branch's only effect on that run is one added file and 18 added passes.

Manual: a Profile on `0.1.1-rc.2` offered `0.1.2-rc.1` names the two installed plugins that expect `@deepseek-ai/dsh-client-runtime`, which that release no longer ships. With the inventory unavailable the dialog is unchanged.

那 11 个失败不是本分支引入的。把本分支改动撤掉、在基线提交上跑同一套测试，失败的是同样 11 个——它们需要符号链接权限和测试用的 pnpm shim，本 Windows 环境不具备，正是 #749 里提到的那两类环境敏感失败。本分支对这次运行的唯一影响是多了一个文件、多了 18 个通过。

人工测试：`0.1.1-rc.2` 的 Profile 在被提供 `0.1.2-rc.1` 时，列出了两个依赖 `@deepseek-ai/dsh-client-runtime` 的已装插件——该版本不再包含这个包。清单不可用时对话框与现状一致。

## Release Notes / 发布说明

Before downloading an update, DSH Desktop now checks whether any installed plugin depends on a component the new version no longer ships, and lists those plugins in the update prompt. Nothing changes when that information is unavailable.

下载更新前，DSH Desktop 会检查已装插件是否依赖新版本不再包含的组件，并在更新提示中列出这些插件。信息不可用时行为与现状一致。

## Follow-ups (for discussion, not in this PR)

**1. Ship the removal set in the version response.** The version endpoint already receives the installed version, and both runtime manifests already live in this repository. The difference between them is 408 bytes for `0.1.1-rc.2 → 0.1.2-rc.1` — well inside the existing 4 KB budget. Carrying it would remove the extra request entirely, and the reading would no longer need to reach the repository at all.

**2. A one-click action on the update dialog.** A second action that disables just the named plugins before proceeding, reusing `disableDesktopProfileBundle` and its immutable-bundle guard, so a user who wants the update does not have to choose between updating and keeping a working startup.

**3. The same reading in the Market, where it can go further.** Before an upgrade, only "is the package still shipped" is answerable. In the Market the package is on disk, so it can also be asked whether it still exports the binding being imported, and whether the plugin tree starts at all — a fuller health check at install time, on the manifest the installer already fetches and currently discards.

## 后续（供讨论，不在本 PR）

**1. 在版本响应里直接带上被移除的依赖。** 版本接口本就收到当前版本，两份运行时清单也都在仓库里。`0.1.1-rc.2 → 0.1.2-rc.1` 的差集只有 408 字节，远低于现有 4 KB 上限。带上它就能彻底省掉额外请求，判定也不必再去拉仓库。

**2. 更新对话框上加一键处理。** 在继续之前只禁用被点名的那几个插件，复用现成的 `disableDesktopProfileBundle` 及其不可变 bundle 保护——这样想更新的用户不必在「更新」和「保住能启动」之间二选一。

**3. 同一套判定用于插件市场，并且在那里能问得更深。** 升级前只答得了「这个包还在不在」。而在市场里包就在磁盘上，还能问「它是否仍然导出被引用的名字」以及「这棵插件树能不能起来」——即安装时的完整健康检查，用的还是安装流程已经拉取、目前却丢弃的那份 manifest。
