### PR TITLE
fix(desktop): reclaim packaged pnpm path precedence

### DIFF
--- a/dsh-plugin-desktop-beta/src/desktop-runtime-environment.ts
+++ b/dsh-plugin-desktop-beta/src/desktop-runtime-environment.ts
@@ -327,11 +327,14 @@ function installPathDirectory(
   const original = pathEntries(environment, platform)
   const current = original.find(entry => entry.value !== undefined)
   const currentValue = current?.value ?? ''
-  if (withoutPathDirectory(currentValue, directory, platform) !== currentValue) return () => {}
-
   const key = current?.key ?? PATH
   const delimiter = platform === 'win32' ? ';' : ':'
-  const installedValue = currentValue.length === 0 ? directory : `${directory}${delimiter}${currentValue}`
+  const inheritedValue = withoutPathDirectory(currentValue, directory, platform)
+  const firstComponent = currentValue.split(delimiter)[0] ?? ''
+  if (normalizedPathComponent(firstComponent, platform) === normalizedPathComponent(directory, platform)) {
+    return () => {}
+  }
+  const installedValue = inheritedValue.length === 0 ? directory : `${directory}${delimiter}${inheritedValue}`
   for (const entry of original) delete environment[entry.key]
   environment[key] = installedValue
 

--- a/dsh-plugin-desktop-beta/tests/desktop-runtime-environment.spec.ts
+++ b/dsh-plugin-desktop-beta/tests/desktop-runtime-environment.spec.ts
@@ -261,7 +261,52 @@ describe('desktop Host pnpm runtime', () => {
     expect(environment).toEqual({ PATH: `${laterPath}${pathDelimiter}${originalPath}` })
   })
 
-  it('does not duplicate or later remove a PATH component another owner supplied', () => {
+  it.runIf(process.platform === 'win32')('reclaims PATH precedence from an inherited Desktop terminal shim', () => {
+    const root = temporaryDirectory()
+    const stateDir = join(root, 'runtime')
+    const pathDir = join(stateDir, 'bin')
+    const terminalShimDir = join(root, 'terminal', 'bin')
+    const captureEntry = join(root, 'capture.mjs')
+    const captureOutput = join(root, 'capture.txt')
+    mkdirSync(terminalShimDir, { recursive: true })
+    writeFileSync(join(terminalShimDir, 'pnpm.cmd'), '@echo inherited terminal shim failed\r\n@exit /b 90\r\n')
+    writeFileSync(captureEntry, [
+      "import { writeFileSync } from 'node:fs'",
+      "writeFileSync(process.argv.at(-1), 'host runtime')",
+      '',
+    ].join('\n'))
+    const environment: NodeJS.ProcessEnv = {
+      Path: `${terminalShimDir};${pathDir};${process.env.Path ?? ''}`,
+      PATHEXT: process.env.PATHEXT,
+      SystemRoot: process.env.SystemRoot,
+    }
+    const original = { ...environment }
+
+    const installation = installDesktopPnpmRuntime({
+      ...options(stateDir, 'win32', environment),
+      appExecutable: process.execPath,
+      pnpmBinPath: captureEntry,
+    })
+    const result = spawnSync(process.env.ComSpec ?? 'cmd.exe', [
+      '/d',
+      '/s',
+      '/c',
+      `pnpm "${captureOutput}"`,
+    ], {
+      encoding: 'utf8',
+      env: environment,
+      shell: false,
+      windowsVerbatimArguments: true,
+    })
+
+    expect(result.error).toBeUndefined()
+    expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(0)
+    expect(readFileSync(captureOutput, 'utf8')).toBe('host runtime')
+    installation.dispose()
+    expect(environment).toEqual(original)
+  })
+
+  it('does not duplicate or remove a runtime already first on PATH', () => {
     const stateDir = join(temporaryDirectory(), 'runtime')
     const pathDir = join(stateDir, 'bin')
     const platform = process.platform === 'win32' ? 'win32' : 'linux'

--- a/dsh-plugin-desktop/src/desktop-runtime-environment.ts
+++ b/dsh-plugin-desktop/src/desktop-runtime-environment.ts
@@ -327,11 +327,14 @@ function installPathDirectory(
   const original = pathEntries(environment, platform)
   const current = original.find(entry => entry.value !== undefined)
   const currentValue = current?.value ?? ''
-  if (withoutPathDirectory(currentValue, directory, platform) !== currentValue) return () => {}
-
   const key = current?.key ?? PATH
   const delimiter = platform === 'win32' ? ';' : ':'
-  const installedValue = currentValue.length === 0 ? directory : `${directory}${delimiter}${currentValue}`
+  const inheritedValue = withoutPathDirectory(currentValue, directory, platform)
+  const firstComponent = currentValue.split(delimiter)[0] ?? ''
+  if (normalizedPathComponent(firstComponent, platform) === normalizedPathComponent(directory, platform)) {
+    return () => {}
+  }
+  const installedValue = inheritedValue.length === 0 ? directory : `${directory}${delimiter}${inheritedValue}`
   for (const entry of original) delete environment[entry.key]
   environment[key] = installedValue
 

--- a/dsh-plugin-desktop/tests/desktop-runtime-environment.spec.ts
+++ b/dsh-plugin-desktop/tests/desktop-runtime-environment.spec.ts
@@ -261,7 +261,52 @@ describe('desktop Host pnpm runtime', () => {
     expect(environment).toEqual({ PATH: `${laterPath}${pathDelimiter}${originalPath}` })
   })
 
-  it('does not duplicate or later remove a PATH component another owner supplied', () => {
+  it.runIf(process.platform === 'win32')('reclaims PATH precedence from an inherited Desktop terminal shim', () => {
+    const root = temporaryDirectory()
+    const stateDir = join(root, 'runtime')
+    const pathDir = join(stateDir, 'bin')
+    const terminalShimDir = join(root, 'terminal', 'bin')
+    const captureEntry = join(root, 'capture.mjs')
+    const captureOutput = join(root, 'capture.txt')
+    mkdirSync(terminalShimDir, { recursive: true })
+    writeFileSync(join(terminalShimDir, 'pnpm.cmd'), '@echo inherited terminal shim failed\r\n@exit /b 90\r\n')
+    writeFileSync(captureEntry, [
+      "import { writeFileSync } from 'node:fs'",
+      "writeFileSync(process.argv.at(-1), 'host runtime')",
+      '',
+    ].join('\n'))
+    const environment: NodeJS.ProcessEnv = {
+      Path: `${terminalShimDir};${pathDir};${process.env.Path ?? ''}`,
+      PATHEXT: process.env.PATHEXT,
+      SystemRoot: process.env.SystemRoot,
+    }
+    const original = { ...environment }
+
+    const installation = installDesktopPnpmRuntime({
+      ...options(stateDir, 'win32', environment),
+      appExecutable: process.execPath,
+      pnpmBinPath: captureEntry,
+    })
+    const result = spawnSync(process.env.ComSpec ?? 'cmd.exe', [
+      '/d',
+      '/s',
+      '/c',
+      `pnpm "${captureOutput}"`,
+    ], {
+      encoding: 'utf8',
+      env: environment,
+      shell: false,
+      windowsVerbatimArguments: true,
+    })
+
+    expect(result.error).toBeUndefined()
+    expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(0)
+    expect(readFileSync(captureOutput, 'utf8')).toBe('host runtime')
+    installation.dispose()
+    expect(environment).toEqual(original)
+  })
+
+  it('does not duplicate or remove a runtime already first on PATH', () => {
     const stateDir = join(temporaryDirectory(), 'runtime')
     const pathDir = join(stateDir, 'bin')
     const platform = process.platform === 'win32' ? 'win32' : 'linux'


### PR DESCRIPTION
## Summary / 摘要

- Reclaim the packaged Host pnpm runtime as the first PATH entry when an inherited Desktop runtime directory already exists later on PATH.
- Remove duplicate inherited runtime entries while preserving the original environment when the generation releases.
- Add Stable and Beta Windows regression tests that put a failing terminal pnpm.cmd first, invoke bare pnpm through cmd.exe, and verify the packaged Host runtime wins.

This prevents a Desktop process inherited from a generated terminal from selecting cli/<profile>/bin/pnpm.cmd after the terminal-only DSH_DESKTOP_* variables have been cleared, which produced exit 9009.

## Related Issues / 关联 Issue

Fixes #784

## Type / 类型

- [x] Bug fix / 问题修复
- [ ] Feature / 新功能
- [ ] Documentation / 文档
- [ ] Release or packaging / 发布或打包
- [ ] Tests only / 仅测试
- [ ] Other / 其他

## Platforms / 影响平台

- [x] Windows installer / Windows 安装包
- [x] Windows portable ZIP / Windows 便携版 ZIP
- [ ] macOS Apple Silicon
- [ ] macOS Intel
- [ ] macOS Universal package / macOS 通用安装包
- [ ] Linux
- [ ] Not platform-specific / 与平台无关

## Verification / 验证

- [ ] corepack yarn check:layout (attempted; blocked by pre-existing CRLF/LF byte-only drift in three otherwise identical Stable/Beta files)
- [x] Stable and Beta typecheck
- [ ] corepack yarn test (attempted; both packages pass all except the existing recovery-plugin-uninstall fixture, which cannot resolve its pnpm.cmd on this Windows environment)
- [ ] corepack yarn check
- [ ] Platform package smoke / 平台打包或启动冒烟
- [x] Manual test / 人工测试

Commands and checks that passed:

- corepack yarn install --immutable
- Stable and Beta desktop-runtime-environment.spec.ts: 17/17 each
- Stable and Beta build and typecheck stages
- Stable and Beta verify:operations
- Stable and Beta verify:closure
- Stable and Beta verify:cli
- Stable and Beta verify:loader
- Stable and Beta verify:profile
- git diff --check

The regression test was observed failing before the fix with the intentionally earlier terminal shim returning exit code 90, then passing after the Host runtime reclaimed PATH precedence. A direct local invocation of the existing generated terminal pnpm.cmd without DSH_DESKTOP_* reproduced issue #784's exit 9009 and exact command-not-found diagnostic.

## Release Notes / 发布说明

Windows plugin operations no longer select a stale Desktop terminal pnpm shim when the packaged Host pnpm runtime is already present later in an inherited PATH.