### PR TITLE
fix(profile): stop repeating uncertain channel warning

### DIFF
--- a/dsh-plugin-desktop-beta/src/profile-channel-admission.ts
+++ b/dsh-plugin-desktop-beta/src/profile-channel-admission.ts
@@ -127,7 +127,9 @@ export function inspectDesktopProfileChannelAdmission(
   const current = inspectDesktopReleaseProfileUsage(locations.current, profileDir, profileName)
   const other = inspectDesktopReleaseProfileUsage(locations.other, profileDir, profileName)
   if (other.status === 'invalid') {
-    return { status: 'warn', reason: 'uncertain' }
+    return current.status === 'valid'
+      ? { status: 'allow', reason: 'current-channel-latest' }
+      : { status: 'warn', reason: 'uncertain' }
   }
   if (current.status === 'invalid') {
     // A damaged record in this package alone is not evidence of a channel

--- a/dsh-plugin-desktop-beta/tests/profile-channel-admission.spec.ts
+++ b/dsh-plugin-desktop-beta/tests/profile-channel-admission.spec.ts
@@ -163,12 +163,15 @@ describe('Desktop Profile release-channel admission', () => {
       .toMatchObject({ status: 'warn', reason: 'other-channel-latest' })
   })
 
-  it('warns without claiming an owner when evidence is damaged', () => {
+  it('warns for damaged evidence until the current release becomes healthy', () => {
     const target = fixture()
     const manifestPath = capture(target, target.locations.other, '2026-09-02T01:00:00.000Z')
     writeFileSync(manifestPath, '{broken')
     expect(inspectDesktopProfileChannelAdmission(target.locations, target.profile, 'work'))
       .toEqual({ status: 'warn', reason: 'uncertain' })
+    capture(target, target.locations.current, '2026-09-02T01:00:01.000Z')
+    expect(inspectDesktopProfileChannelAdmission(target.locations, target.profile, 'work'))
+      .toEqual({ status: 'allow', reason: 'current-channel-latest' })
 
     const currentOnly = fixture()
     const currentManifest = capture(currentOnly, currentOnly.locations.current, '2026-09-02T01:00:00.000Z')

--- a/dsh-plugin-desktop/src/profile-channel-admission.ts
+++ b/dsh-plugin-desktop/src/profile-channel-admission.ts
@@ -127,7 +127,9 @@ export function inspectDesktopProfileChannelAdmission(
   const current = inspectDesktopReleaseProfileUsage(locations.current, profileDir, profileName)
   const other = inspectDesktopReleaseProfileUsage(locations.other, profileDir, profileName)
   if (other.status === 'invalid') {
-    return { status: 'warn', reason: 'uncertain' }
+    return current.status === 'valid'
+      ? { status: 'allow', reason: 'current-channel-latest' }
+      : { status: 'warn', reason: 'uncertain' }
   }
   if (current.status === 'invalid') {
     // A damaged record in this package alone is not evidence of a channel

--- a/dsh-plugin-desktop/tests/profile-channel-admission.spec.ts
+++ b/dsh-plugin-desktop/tests/profile-channel-admission.spec.ts
@@ -163,12 +163,15 @@ describe('Desktop Profile release-channel admission', () => {
       .toMatchObject({ status: 'warn', reason: 'other-channel-latest' })
   })
 
-  it('warns without claiming an owner when evidence is damaged', () => {
+  it('warns for damaged evidence until the current release becomes healthy', () => {
     const target = fixture()
     const manifestPath = capture(target, target.locations.other, '2026-09-02T01:00:00.000Z')
     writeFileSync(manifestPath, '{broken')
     expect(inspectDesktopProfileChannelAdmission(target.locations, target.profile, 'work'))
       .toEqual({ status: 'warn', reason: 'uncertain' })
+    capture(target, target.locations.current, '2026-09-02T01:00:01.000Z')
+    expect(inspectDesktopProfileChannelAdmission(target.locations, target.profile, 'work'))
+      .toEqual({ status: 'allow', reason: 'current-channel-latest' })
 
     const currentOnly = fixture()
     const currentManifest = capture(currentOnly, currentOnly.locations.current, '2026-09-02T01:00:00.000Z')


### PR DESCRIPTION
## Summary / 摘要

- Stop the cross-channel compatibility dialog from repeating after the current Desktop edition has completed a healthy launch.
- Keep the fail-closed warning on the first launch when the other edition's Profile evidence is damaged.
- Apply the same admission rule and regression coverage to Stable and Beta.

The root cause was that an invalid record in the other edition's private user data unconditionally returned `warn/uncertain`. A healthy checkpoint written by the current edition could therefore never reclaim the Profile, so every later startup showed unknown/unknown versions again.

修复另一发行通道的私有状态损坏时，Profile 兼容性提示在每次启动中重复出现的问题。首次启动仍会保留不确定状态警告；用户选择继续且当前版本完成健康启动后，当前版本写入的可信 checkpoint 会在后续启动中正常生效。Stable 与 Beta 保持一致。

## Related Issues / 关联 Issue

Fixes #805

## Type / 类型

- [x] Bug fix / 问题修复
- [ ] Feature / 新功能
- [ ] Documentation / 文档
- [ ] Release or packaging / 发布或打包
- [ ] Tests only / 仅测试
- [ ] Other / 其他

## Platforms / 影响平台

- [x] Windows installer / Windows 安装包
- [x] Windows portable ZIP / Windows 便携版 ZIP
- [ ] macOS Apple Silicon
- [ ] macOS Intel
- [ ] macOS Universal package / macOS 通用安装包
- [ ] Linux
- [ ] Not platform-specific / 与平台无关

## Verification / 验证

- [ ] `corepack yarn check:layout`
- [x] `corepack yarn typecheck`
- [ ] `corepack yarn test`
- [ ] `corepack yarn check`
- [ ] Platform package smoke / 平台打包或启动冒烟
- [x] Manual test / 人工测试

- Stable focused regression: 7/7 passed.
- Beta focused regression: 7/7 passed.
- Stable and Beta typechecks passed.
- Deterministic Windows-state reproduction: first launch remains `warn/uncertain`; after a current-edition healthy checkpoint, the next launch is `allow/current-channel-latest`.
- Full Stable suite: 1010 passed, 12 skipped; one existing local Windows failure in `recovery-plugin-uninstall.spec.ts` because its fixture cannot resolve `pnpm.cmd`.
- Full Beta suite: 1030 passed, 12 skipped; the same existing local fixture failure.
- `git diff --check` passed.
- `check:layout` reached variant verification and reported only the three pre-existing local CRLF/LF differences in `client/assets.d.ts`, `client/theme-presenter.ts`, and `tray-icons.ts`; no changed file drifted.

## Release Notes / 发布说明

After accepting a Profile compatibility warning and reaching a healthy startup, DSH Desktop no longer repeats an unknown-version warning on every subsequent launch when stale state from the other release channel is damaged.

用户接受 Profile 兼容性提示且应用健康启动后，即使另一发行通道残留损坏状态，后续启动也不会再反复显示“未知/未知”的版本提示。
