### PR TITLE
fix(desktop): disable zero release-age policy

### DIFF
--- a/dsh-plugin-desktop-beta/tests/package.spec.ts
+++ b/dsh-plugin-desktop-beta/tests/package.spec.ts
@@ -1009,6 +1009,28 @@ describe('published package surface', () => {
     expect(installedPnpm.version).toBe('11.8.0')
   })
 
+  it('patches packaged pnpm to disable non-positive and invalid release-age policies', () => {
+    const patchPath = './patches/pnpm@11.8.0.patch'
+    const patchResolution = `patch:pnpm@npm%3A11.8.0#${patchPath}`
+    const lockfile = readFileSync(new URL('yarn.lock', workspaceRoot), 'utf8')
+    const patch = readFileSync(new URL(patchPath, workspaceRoot), 'utf8')
+    const workspaceRequire = createRequire(new URL('package.json', packageRoot))
+    const pnpmManifest = workspaceRequire.resolve('pnpm')
+    const installedRuntime = readFileSync(join(dirname(pnpmManifest), 'dist/pnpm.mjs'), 'utf8')
+
+    expect(workspaceManifest.resolutions).toMatchObject({
+      'pnpm@npm:11.8.0': patchResolution,
+    })
+    expect(lockfile).toContain('pnpm@patch:pnpm@npm%3A11.8.0#./patches/pnpm@11.8.0.patch')
+    for (const source of [patch, installedRuntime]) {
+      expect(source).toContain('const minimumReleaseAge = Number(opts3.minimumReleaseAge);')
+      expect(source).toContain('Number.isFinite(minimumReleaseAge) && minimumReleaseAge > 0')
+      expect(source).toContain('const configuredMinimumReleaseAge = Number(opts3.minimumReleaseAge);')
+      expect(source).toContain('!Number.isFinite(ts) || !Number.isFinite(cutoff)')
+    }
+    expect(installedRuntime).not.toContain('const ageCheckActive = Boolean(opts3.minimumReleaseAge);')
+  })
+
   it('packages the native-compiled Koffi Windows runtime', () => {
     const lockfile = readFileSync(new URL('yarn.lock', workspaceRoot), 'utf8')
 

--- a/dsh-plugin-desktop-beta/tests/pnpm.spec.ts
+++ b/dsh-plugin-desktop-beta/tests/pnpm.spec.ts
@@ -1,11 +1,18 @@
+import { execFile } from 'node:child_process'
+import { mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { createServer } from 'node:http'
+import { tmpdir } from 'node:os'
 import { PassThrough } from 'node:stream'
 import { delimiter, join } from 'node:path'
-import { pathToFileURL } from 'node:url'
+import { fileURLToPath, pathToFileURL } from 'node:url'
+import { promisify } from 'node:util'
 import { Context } from '@deepseek-ai/cordis'
 import type { SubprocessHandle, SubprocessOutcome, SubprocessRuntime, SubprocessSpawnSpec } from '@deepseek-ai/dsh-subprocess'
 import { describe, expect, it, vi } from 'vitest'
 import { apply, inject, name, type DesktopPnpm, type DesktopPnpmBootstrap } from '../src/pnpm.ts'
 import { PNPM_IGNORE_MINIMUM_RELEASE_AGE, withDesktopPnpmPolicy } from '../src/pnpm-policy.ts'
+
+const execFileAsync = promisify(execFile)
 
 interface Deferred<T> { promise: Promise<T>; resolve(value: T): void; reject(cause: unknown): void }
 interface ControlledSubprocess extends SubprocessHandle {
@@ -79,6 +86,57 @@ function finish(process: ControlledSubprocess, exitCode = 0): void {
 }
 
 describe('desktop pnpm execution service', () => {
+  it('disables release-age checks for zero and invalid policy values', async () => {
+    const server = createServer((_request, response) => {
+      const address = server.address()
+      if (address === null || typeof address === 'string') throw new Error('registry fixture is not listening')
+      response.setHeader('content-type', 'application/json')
+      response.end(JSON.stringify({
+        name: 'dsh-minimum-release-age-fixture',
+        'dist-tags': { latest: '1.0.0' },
+        versions: {
+          '1.0.0': {
+            name: 'dsh-minimum-release-age-fixture',
+            version: '1.0.0',
+            dist: {
+              tarball: `http://127.0.0.1:${address.port}/fixture.tgz`,
+              shasum: '0000000000000000000000000000000000000000',
+            },
+          },
+        },
+        time: { '1.0.0': '2100-01-01T00:00:00.000Z' },
+      }))
+    })
+    await new Promise<void>((resolve, reject) => {
+      server.once('error', reject)
+      server.listen(0, '127.0.0.1', resolve)
+    })
+    const address = server.address()
+    if (address === null || typeof address === 'string') throw new Error('registry fixture did not bind TCP')
+    const pnpmEntry = fileURLToPath(new URL('../node_modules/pnpm/dist/pnpm.mjs', import.meta.url))
+    const roots: string[] = []
+    try {
+      for (const value of ['0', 'invalid']) {
+        const root = await mkdtemp(join(tmpdir(), 'dsh-pnpm-minimum-release-age-'))
+        roots.push(root)
+        await writeFile(join(root, 'package.json'), JSON.stringify({ name: 'fixture', private: true }))
+        await expect(execFileAsync(globalThis.process.execPath, [
+          pnpmEntry,
+          `--registry=http://127.0.0.1:${address.port}`,
+          `--config.minimumReleaseAge=${value}`,
+          'add',
+          '--lockfile-only',
+          'dsh-minimum-release-age-fixture',
+        ], { cwd: root })).resolves.toBeDefined()
+      }
+    } finally {
+      await Promise.all(roots.map(async root => await rm(root, { recursive: true, force: true })))
+      await new Promise<void>((resolve, reject) => {
+        server.close(error => { if (error === undefined) resolve(); else reject(error) })
+      })
+    }
+  }, 20_000)
+
   it('applies the release-age policy exactly once to direct pnpm argv', () => {
     expect(withDesktopPnpmPolicy(['remove', 'example'])).toEqual([
       PNPM_IGNORE_MINIMUM_RELEASE_AGE,

--- a/dsh-plugin-desktop/tests/package.spec.ts
+++ b/dsh-plugin-desktop/tests/package.spec.ts
@@ -942,6 +942,28 @@ describe('published package surface', () => {
     expect(installedPnpm.version).toBe('11.8.0')
   })
 
+  it('patches packaged pnpm to disable non-positive and invalid release-age policies', () => {
+    const patchPath = './patches/pnpm@11.8.0.patch'
+    const patchResolution = `patch:pnpm@npm%3A11.8.0#${patchPath}`
+    const lockfile = readFileSync(new URL('yarn.lock', workspaceRoot), 'utf8')
+    const patch = readFileSync(new URL(patchPath, workspaceRoot), 'utf8')
+    const workspaceRequire = createRequire(new URL('package.json', packageRoot))
+    const pnpmManifest = workspaceRequire.resolve('pnpm')
+    const installedRuntime = readFileSync(join(dirname(pnpmManifest), 'dist/pnpm.mjs'), 'utf8')
+
+    expect(workspaceManifest.resolutions).toMatchObject({
+      'pnpm@npm:11.8.0': patchResolution,
+    })
+    expect(lockfile).toContain('pnpm@patch:pnpm@npm%3A11.8.0#./patches/pnpm@11.8.0.patch')
+    for (const source of [patch, installedRuntime]) {
+      expect(source).toContain('const minimumReleaseAge = Number(opts3.minimumReleaseAge);')
+      expect(source).toContain('Number.isFinite(minimumReleaseAge) && minimumReleaseAge > 0')
+      expect(source).toContain('const configuredMinimumReleaseAge = Number(opts3.minimumReleaseAge);')
+      expect(source).toContain('!Number.isFinite(ts) || !Number.isFinite(cutoff)')
+    }
+    expect(installedRuntime).not.toContain('const ageCheckActive = Boolean(opts3.minimumReleaseAge);')
+  })
+
   it('packages the native-compiled Koffi Windows runtime', () => {
     const lockfile = readFileSync(new URL('yarn.lock', workspaceRoot), 'utf8')
 

--- a/dsh-plugin-desktop/tests/pnpm.spec.ts
+++ b/dsh-plugin-desktop/tests/pnpm.spec.ts
@@ -1,11 +1,18 @@
+import { execFile } from 'node:child_process'
+import { mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { createServer } from 'node:http'
+import { tmpdir } from 'node:os'
 import { PassThrough } from 'node:stream'
 import { delimiter, join } from 'node:path'
-import { pathToFileURL } from 'node:url'
+import { fileURLToPath, pathToFileURL } from 'node:url'
+import { promisify } from 'node:util'
 import { Context } from '@deepseek-ai/cordis'
 import type { SubprocessHandle, SubprocessOutcome, SubprocessRuntime, SubprocessSpawnSpec } from '@deepseek-ai/dsh-subprocess'
 import { describe, expect, it, vi } from 'vitest'
 import { apply, inject, name, type DesktopPnpm, type DesktopPnpmBootstrap } from '../src/pnpm.ts'
 import { PNPM_IGNORE_MINIMUM_RELEASE_AGE, withDesktopPnpmPolicy } from '../src/pnpm-policy.ts'
+
+const execFileAsync = promisify(execFile)
 
 interface Deferred<T> { promise: Promise<T>; resolve(value: T): void; reject(cause: unknown): void }
 interface ControlledSubprocess extends SubprocessHandle {
@@ -79,6 +86,57 @@ function finish(process: ControlledSubprocess, exitCode = 0): void {
 }
 
 describe('desktop pnpm execution service', () => {
+  it('disables release-age checks for zero and invalid policy values', async () => {
+    const server = createServer((_request, response) => {
+      const address = server.address()
+      if (address === null || typeof address === 'string') throw new Error('registry fixture is not listening')
+      response.setHeader('content-type', 'application/json')
+      response.end(JSON.stringify({
+        name: 'dsh-minimum-release-age-fixture',
+        'dist-tags': { latest: '1.0.0' },
+        versions: {
+          '1.0.0': {
+            name: 'dsh-minimum-release-age-fixture',
+            version: '1.0.0',
+            dist: {
+              tarball: `http://127.0.0.1:${address.port}/fixture.tgz`,
+              shasum: '0000000000000000000000000000000000000000',
+            },
+          },
+        },
+        time: { '1.0.0': '2100-01-01T00:00:00.000Z' },
+      }))
+    })
+    await new Promise<void>((resolve, reject) => {
+      server.once('error', reject)
+      server.listen(0, '127.0.0.1', resolve)
+    })
+    const address = server.address()
+    if (address === null || typeof address === 'string') throw new Error('registry fixture did not bind TCP')
+    const pnpmEntry = fileURLToPath(new URL('../node_modules/pnpm/dist/pnpm.mjs', import.meta.url))
+    const roots: string[] = []
+    try {
+      for (const value of ['0', 'invalid']) {
+        const root = await mkdtemp(join(tmpdir(), 'dsh-pnpm-minimum-release-age-'))
+        roots.push(root)
+        await writeFile(join(root, 'package.json'), JSON.stringify({ name: 'fixture', private: true }))
+        await expect(execFileAsync(globalThis.process.execPath, [
+          pnpmEntry,
+          `--registry=http://127.0.0.1:${address.port}`,
+          `--config.minimumReleaseAge=${value}`,
+          'add',
+          '--lockfile-only',
+          'dsh-minimum-release-age-fixture',
+        ], { cwd: root })).resolves.toBeDefined()
+      }
+    } finally {
+      await Promise.all(roots.map(async root => await rm(root, { recursive: true, force: true })))
+      await new Promise<void>((resolve, reject) => {
+        server.close(error => { if (error === undefined) resolve(); else reject(error) })
+      })
+    }
+  }, 20_000)
+
   it('applies the release-age policy exactly once to direct pnpm argv', () => {
     expect(withDesktopPnpmPolicy(['remove', 'example'])).toEqual([
       PNPM_IGNORE_MINIMUM_RELEASE_AGE,

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "open@npm:11.0.1": "patch:open@npm%3A11.0.1#./patches/open@11.0.1.patch",
     "open@npm:^11.0.0": "patch:open@npm%3A11.0.1#./patches/open@11.0.1.patch",
     "dshmarket@npm:1.38.1": "patch:dshmarket@npm%3A1.38.1#./.yarn/patches/dshmarket-npm-1.38.1-775916754e.patch",
+    "pnpm@npm:11.8.0": "patch:pnpm@npm%3A11.8.0#./patches/pnpm@11.8.0.patch",
     "koffi@npm:^3.1.0": "3.1.5",
     "@deepseek-ai/dsh-brand@npm:0.1.2-rc.1": "file:vendor/dsh-runtime/0.1.2-rc.1/deepseek-ai-dsh-brand-0.1.2-rc.1.tgz",
     "@deepseek-ai/dsh-brand@npm:^0.1.2-rc.1": "file:vendor/dsh-runtime/0.1.2-rc.1/deepseek-ai-dsh-brand-0.1.2-rc.1.tgz",

--- a/patches/pnpm@11.8.0.patch
+++ b/patches/pnpm@11.8.0.patch
@@ -1,0 +1,55 @@
+diff --git a/dist/pnpm.mjs b/dist/pnpm.mjs
+--- a/dist/pnpm.mjs
++++ b/dist/pnpm.mjs
+@@ -64055,8 +64055,9 @@ function createPackageVersionPolicyOrThrow(patterns, key) {
+   }
+ }
+ function getPublishedByPolicy(opts3) {
++  const minimumReleaseAge = Number(opts3.minimumReleaseAge);
+   return {
+-    publishedBy: opts3.minimumReleaseAge ? new Date(Date.now() - opts3.minimumReleaseAge * 60 * 1e3) : void 0,
++    publishedBy: Number.isFinite(minimumReleaseAge) && minimumReleaseAge > 0 ? new Date(Date.now() - minimumReleaseAge * 60 * 1e3) : void 0,
+     publishedByExclude: opts3.minimumReleaseAgeExclude ? createPackageVersionPolicyOrThrow(opts3.minimumReleaseAgeExclude, "minimumReleaseAgeExclude") : void 0
+   };
+ }
+@@ -64263,9 +64264,11 @@ var init_fetchFullMetadataCached = __esm({
+ 
+ // ../resolving/npm-resolver/lib/createNpmResolutionVerifier.js
+ function createNpmResolutionVerifier(opts3) {
+-  const ageCheckActive = Boolean(opts3.minimumReleaseAge);
++  const configuredMinimumReleaseAge = Number(opts3.minimumReleaseAge);
++  const minimumReleaseAge = Number.isFinite(configuredMinimumReleaseAge) && configuredMinimumReleaseAge > 0 ? configuredMinimumReleaseAge : 0;
++  const ageCheckActive = minimumReleaseAge > 0;
+   const trustCheckActive = opts3.trustPolicy === "no-downgrade";
+-  const cutoff = ageCheckActive ? (opts3.now ?? Date.now()) - opts3.minimumReleaseAge * 60 * 1e3 : 0;
++  const cutoff = ageCheckActive ? (opts3.now ?? Date.now()) - minimumReleaseAge * 60 * 1e3 : 0;
+   const excludePolicy = opts3.minimumReleaseAgeExclude?.length ? createExcludePolicy(opts3.minimumReleaseAgeExclude, "minimumReleaseAgeExclude") : void 0;
+   const trustExcludePolicy = opts3.trustPolicyExclude?.length ? createExcludePolicy(opts3.trustPolicyExclude, "trustPolicyExclude") : void 0;
+   const namedRegistryPrefixes = Object.values({
+@@ -64289,8 +64292,7 @@ function createNpmResolutionVerifier(opts3) {
+     localMetaCache: /* @__PURE__ */ new Map(),
+     fullMetaCache: /* @__PURE__ */ new Map(),
+     fullMetaForTrustCache: /* @__PURE__ */ new Map()
+   };
+-  const minimumReleaseAge = opts3.minimumReleaseAge ?? 0;
+   const trustPolicy = opts3.trustPolicy;
+   const trustPolicyIgnoreAfter = opts3.trustPolicyIgnoreAfter;
+   const verify = async (resolution, { name, version: version2, nonSemverVersion }) => {
+@@ -65274,14 +65276,15 @@ function detectMinReleaseAgeViolation(args) {
+   if (Array.isArray(excludeResult) && excludeResult.includes(args.version))
+     return void 0;
+   const ts = new Date(args.publishedAt).getTime();
+-  if (Number.isNaN(ts) || ts <= args.publishedBy.getTime())
++  const cutoff = args.publishedBy.getTime();
++  if (!Number.isFinite(ts) || !Number.isFinite(cutoff) || ts <= cutoff)
+     return void 0;
+   return {
+     name: args.name,
+     version: args.version,
+     resolution: args.resolution,
+     code: MINIMUM_RELEASE_AGE_VIOLATION_CODE,
+-    reason: `was published at ${new Date(ts).toISOString()}, within the minimumReleaseAge cutoff (${args.publishedBy.toISOString()})`
++    reason: `was published at ${new Date(ts).toISOString()}, within the minimumReleaseAge cutoff (${new Date(cutoff).toISOString()})`
+   };
+ }
+ function getIntegrity(dist) {

--- a/patches/pnpm@11.8.0.patch
+++ b/patches/pnpm@11.8.0.patch
@@ -12,8 +12,7 @@ diff --git a/dist/pnpm.mjs b/dist/pnpm.mjs
      publishedByExclude: opts3.minimumReleaseAgeExclude ? createPackageVersionPolicyOrThrow(opts3.minimumReleaseAgeExclude, "minimumReleaseAgeExclude") : void 0
    };
  }
-@@ -64263,9 +64264,11 @@ var init_fetchFullMetadataCached = __esm({
- 
+@@ -64264,8 +64265,10 @@ var init_fetchFullMetadataCached = __esm({
  // ../resolving/npm-resolver/lib/createNpmResolutionVerifier.js
  function createNpmResolutionVerifier(opts3) {
 -  const ageCheckActive = Boolean(opts3.minimumReleaseAge);

--- a/yarn.lock
+++ b/yarn.lock
@@ -12773,6 +12773,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"pnpm@patch:pnpm@npm%3A11.8.0#./patches/pnpm@11.8.0.patch::locator=deepseek-harness-desktop%40workspace%3A.":
+  version: 11.8.0
+  resolution: "pnpm@patch:pnpm@npm%3A11.8.0#./patches/pnpm@11.8.0.patch::version=11.8.0&hash=bbe022&locator=deepseek-harness-desktop%40workspace%3A."
+  dependencies:
+    node-gyp: "npm:latest"
+  bin:
+    pn: bin/pnpm.mjs
+    pnpm: bin/pnpm.mjs
+    pnpx: bin/pnpx.mjs
+    pnx: bin/pnpx.mjs
+  checksum: 10c0/b1015c7aa081daf65d4ad34f3baddd80fca6a97ac0e23d5733f84dc648cde34092294651855b860d98bbf77713ddb75e78bf7869b46e29bcb5964d2df8ebcece
+  languageName: node
+  linkType: hard
+
 "postcss-selector-parser@npm:^7.1.0":
   version: 7.1.5
   resolution: "postcss-selector-parser@npm:7.1.5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -12775,7 +12775,7 @@ __metadata:
 
 "pnpm@patch:pnpm@npm%3A11.8.0#./patches/pnpm@11.8.0.patch::locator=deepseek-harness-desktop%40workspace%3A.":
   version: 11.8.0
-  resolution: "pnpm@patch:pnpm@npm%3A11.8.0#./patches/pnpm@11.8.0.patch::version=11.8.0&hash=bbe022&locator=deepseek-harness-desktop%40workspace%3A."
+  resolution: "pnpm@patch:pnpm@npm%3A11.8.0#./patches/pnpm@11.8.0.patch::version=11.8.0&hash=13eaf9&locator=deepseek-harness-desktop%40workspace%3A."
   dependencies:
     node-gyp: "npm:latest"
   bin:


### PR DESCRIPTION
## Summary / 摘要

- Patch the bundled pnpm 11.8.0 runtime so `minimumReleaseAge` is active only for finite positive numeric values.
- Guard release-age timestamp formatting against invalid dates instead of throwing `RangeError: Invalid time value`.
- Add Stable and Beta integration coverage that invokes the real bundled pnpm against a local registry for both `0` and invalid policy values, plus packaging assertions that verify the patch is installed.

## Related Issues / 关联 Issue

Fixes #807

## Type / 类型

- [x] Bug fix / 问题修复
- [ ] Feature / 新功能
- [ ] Documentation / 文档
- [ ] Release or packaging / 发布或打包
- [ ] Tests only / 仅测试
- [ ] Other / 其他

## Platforms / 影响平台

- [x] Windows installer / Windows 安装包
- [x] Windows portable ZIP / Windows 便携版 ZIP
- [ ] macOS Apple Silicon
- [ ] macOS Intel
- [ ] macOS Universal package / macOS 通用安装包
- [ ] Linux
- [ ] Not platform-specific / 与平台无关

## Verification / 验证

- [ ] `corepack yarn check:layout`
- [x] `corepack yarn typecheck`
- [ ] `corepack yarn test`
- [ ] `corepack yarn check`
- [ ] Platform package smoke / 平台打包或启动冒烟
- [x] Manual test / 人工测试

Commands and checks actually run:

- `corepack yarn install --immutable`
- `corepack yarn workspace dsh-plugin-desktop vitest run tests/pnpm.spec.ts tests/package.spec.ts` (48 passed)
- `corepack yarn workspace dsh-plugin-desktop-beta vitest run tests/pnpm.spec.ts tests/package.spec.ts` (52 passed)
- `corepack yarn workspace dsh-plugin-desktop typecheck`
- `corepack yarn workspace dsh-plugin-desktop-beta typecheck`
- `corepack yarn workspace dsh-plugin-desktop build`
- Stable and Beta `verify:notices` (617 packages checked)
- `git diff --check`
- The real bundled pnpm succeeds for both `--config.minimumReleaseAge=0` and `--config.minimumReleaseAge=invalid` against a local registry fixture whose latest version is dated in 2100.

`corepack yarn check` was also run. Its initial checks passed, but it stopped at the pre-existing undeclared Stable/Beta variant drift in `src/client/assets.d.ts`, `src/client/theme-presenter.ts`, and `src/tray-icons.ts`; none is changed by this PR.

## Release Notes / 发布说明

Plugin installation no longer treats the desktop-injected zero minimum release age as enabled, and invalid release-age configuration no longer crashes with `Invalid time value`.