### PR TITLE
fix(updates): show Windows installer during update handoff

### DIFF
--- a/dsh-plugin-desktop-beta/src/electron-runtime.ts
+++ b/dsh-plugin-desktop-beta/src/electron-runtime.ts
@@ -765,7 +765,7 @@ export class ElectronDesktopRuntime implements DesktopRuntime {
     await resolveDesktopUpdateArtifact(userDataPath, artifact, result.response === 0)
   }
 
-  /** Start the downloaded NSIS installer before releasing the current process. */
+  /** Start the downloaded NSIS installer visibly before releasing the current process. */
   private async launchWindowsUpdateInstaller(installerPath: string): Promise<void> {
     await new Promise<void>((resolve, reject) => {
       let child: ReturnType<typeof spawn>
@@ -774,7 +774,9 @@ export class ElectronDesktopRuntime implements DesktopRuntime {
           detached: true,
           stdio: 'ignore',
           shell: false,
-          windowsHide: true,
+          // UV_PROCESS_WINDOWS_HIDE also applies SW_HIDE to GUI processes,
+          // which leaves an interactive NSIS installer running invisibly.
+          windowsHide: false,
         })
       } catch (cause) {
         reject(cause)

--- a/dsh-plugin-desktop-beta/tests/electron-runtime.spec.ts
+++ b/dsh-plugin-desktop-beta/tests/electron-runtime.spec.ts
@@ -1970,7 +1970,7 @@ describe('Electron desktop runtime', () => {
     await release()
   })
 
-  it('starts the downloaded Windows installer before requesting orderly exit', async () => {
+  it('starts the downloaded Windows installer visibly before requesting orderly exit', async () => {
     vi.spyOn(process, 'platform', 'get').mockReturnValue('win32')
     updater.download.mockResolvedValueOnce('C:\\Updates\\DSH-Desktop-2.1.0-windows.exe')
     const requestQuit = vi.fn()
@@ -1991,7 +1991,7 @@ describe('Electron desktop runtime', () => {
         detached: true,
         stdio: 'ignore',
         shell: false,
-        windowsHide: true,
+        windowsHide: false,
       },
     )
     expect(requestQuit).not.toHaveBeenCalled()

--- a/dsh-plugin-desktop/src/electron-runtime.ts
+++ b/dsh-plugin-desktop/src/electron-runtime.ts
@@ -765,7 +765,7 @@ export class ElectronDesktopRuntime implements DesktopRuntime {
     await resolveDesktopUpdateArtifact(userDataPath, artifact, result.response === 0)
   }
 
-  /** Start the downloaded NSIS installer before releasing the current process. */
+  /** Start the downloaded NSIS installer visibly before releasing the current process. */
   private async launchWindowsUpdateInstaller(installerPath: string): Promise<void> {
     await new Promise<void>((resolve, reject) => {
       let child: ReturnType<typeof spawn>
@@ -774,7 +774,9 @@ export class ElectronDesktopRuntime implements DesktopRuntime {
           detached: true,
           stdio: 'ignore',
           shell: false,
-          windowsHide: true,
+          // UV_PROCESS_WINDOWS_HIDE also applies SW_HIDE to GUI processes,
+          // which leaves an interactive NSIS installer running invisibly.
+          windowsHide: false,
         })
       } catch (cause) {
         reject(cause)

--- a/dsh-plugin-desktop/tests/electron-runtime.spec.ts
+++ b/dsh-plugin-desktop/tests/electron-runtime.spec.ts
@@ -1967,7 +1967,7 @@ describe('Electron desktop runtime', () => {
     await release()
   })
 
-  it('starts the downloaded Windows installer before requesting orderly exit', async () => {
+  it('starts the downloaded Windows installer visibly before requesting orderly exit', async () => {
     vi.spyOn(process, 'platform', 'get').mockReturnValue('win32')
     updater.download.mockResolvedValueOnce('C:\\Updates\\DSH-Desktop-2.1.0-windows.exe')
     const requestQuit = vi.fn()
@@ -1988,7 +1988,7 @@ describe('Electron desktop runtime', () => {
         detached: true,
         stdio: 'ignore',
         shell: false,
-        windowsHide: true,
+        windowsHide: false,
       },
     )
     expect(requestQuit).not.toHaveBeenCalled()


### PR DESCRIPTION
## Summary

- launch the interactive Windows NSIS updater with a visible GUI
- preserve the detached installer handoff and orderly Desktop shutdown sequence
- keep Stable and Beta shared runtime sources aligned while validating the fix through Beta first
- add regression assertions that prevent the updater process from being hidden again

## Root cause

The updater spawned the interactive NSIS installer with windowsHide enabled. Node/libuv applies SW_HIDE to GUI child processes in that mode, so the installer started successfully but its window stayed invisible while DSH Desktop exited.

Addresses #806.

## Verification

- corepack yarn workspace dsh-plugin-desktop-beta check
- corepack yarn workspace dsh-plugin-desktop typecheck
- corepack yarn workspace dsh-plugin-desktop test
- corepack yarn check:desktop-variants
- git diff --check

Beta check passed with 1,039 tests passing and 5 skipped. Stable tests passed with 1,019 tests passing and 5 skipped. A real interactive NSIS visibility smoke still requires a Windows host.