### PR TITLE
fix(desktop): preserve minimized startup windows

### DIFF
--- a/dsh-plugin-desktop-beta/src/electron-shell-generation.ts
+++ b/dsh-plugin-desktop-beta/src/electron-shell-generation.ts
@@ -251,8 +251,8 @@ export class ElectronShellGeneration {
     const show = (): void => { this.show() }
     let startupSurfaceRevealed = false
     const revealStartupSurface = (): void => {
-      if (window.isDestroyed()) return
-      if (startupSurfaceRevealed && !applicationNeedsReveal(window, platform.platform)) return
+      // A later startup callback must not undo a user's minimize or hide action.
+      if (window.isDestroyed() || startupSurfaceRevealed) return
       startupSurfaceRevealed = true
       this.show()
     }

--- a/dsh-plugin-desktop-beta/tests/electron-runtime.spec.ts
+++ b/dsh-plugin-desktop-beta/tests/electron-runtime.spec.ts
@@ -1221,6 +1221,63 @@ describe('Electron desktop runtime', () => {
     await release()
   })
 
+  it('does not restore a startup surface minimized before ready-to-show', async () => {
+    vi.spyOn(process, 'platform', 'get').mockReturnValue('win32')
+    const { ElectronDesktopRuntime } = await import('../src/electron-runtime.ts')
+    const runtime = new ElectronDesktopRuntime(async () => {})
+    const release = runtime.schedule(spec)
+
+    await runtime.mountScheduled()
+
+    const window = electron.browserWindows[0]
+    const ready = window?.once.mock.calls.find(([event]) => event === 'ready-to-show')?.[1]
+    expect(ready).toEqual(expect.any(Function))
+    expect(window?.show).toHaveBeenCalledOnce()
+    expect(window?.focus).toHaveBeenCalledOnce()
+
+    window?.isVisible.mockReturnValue(true)
+    window?.isMinimized.mockReturnValue(true)
+    ready()
+
+    expect(window?.restore).not.toHaveBeenCalled()
+    expect(window?.show).toHaveBeenCalledOnce()
+    expect(window?.focus).toHaveBeenCalledOnce()
+
+    await release()
+  })
+
+  it('does not restore after ready-to-show wins the startup reveal race', async () => {
+    let resolveAuthentication!: (response: Response) => void
+    electron.sessionFetch.mockImplementationOnce(async () => await new Promise<Response>(resolve => {
+      resolveAuthentication = resolve
+    }))
+    vi.spyOn(process, 'platform', 'get').mockReturnValue('win32')
+    const { ElectronDesktopRuntime } = await import('../src/electron-runtime.ts')
+    const runtime = new ElectronDesktopRuntime(async () => {})
+    const release = runtime.schedule(spec)
+
+    const mount = runtime.mountScheduled()
+    expect(electron.sessionFetch).toHaveBeenCalledOnce()
+
+    const window = electron.browserWindows[0]
+    const ready = window?.once.mock.calls.find(([event]) => event === 'ready-to-show')?.[1]
+    expect(ready).toEqual(expect.any(Function))
+    ready()
+    expect(window?.show).toHaveBeenCalledOnce()
+    expect(window?.focus).toHaveBeenCalledOnce()
+
+    window?.isVisible.mockReturnValue(true)
+    window?.isMinimized.mockReturnValue(true)
+    resolveAuthentication(new Response(null, { status: 200 }))
+    await mount
+
+    expect(window?.restore).not.toHaveBeenCalled()
+    expect(window?.show).toHaveBeenCalledOnce()
+    expect(window?.focus).toHaveBeenCalledOnce()
+
+    await release()
+  })
+
   it('shows privacy-safe macOS attention only while unfocused and clears it on notification click', async () => {
     vi.spyOn(process, 'platform', 'get').mockReturnValue('darwin')
     const { ElectronDesktopRuntime } = await import('../src/electron-runtime.ts')

--- a/dsh-plugin-desktop/src/electron-shell-generation.ts
+++ b/dsh-plugin-desktop/src/electron-shell-generation.ts
@@ -251,8 +251,8 @@ export class ElectronShellGeneration {
     const show = (): void => { this.show() }
     let startupSurfaceRevealed = false
     const revealStartupSurface = (): void => {
-      if (window.isDestroyed()) return
-      if (startupSurfaceRevealed && !applicationNeedsReveal(window, platform.platform)) return
+      // A later startup callback must not undo a user's minimize or hide action.
+      if (window.isDestroyed() || startupSurfaceRevealed) return
       startupSurfaceRevealed = true
       this.show()
     }

--- a/dsh-plugin-desktop/tests/electron-runtime.spec.ts
+++ b/dsh-plugin-desktop/tests/electron-runtime.spec.ts
@@ -1218,6 +1218,63 @@ describe('Electron desktop runtime', () => {
     await release()
   })
 
+  it('does not restore a startup surface minimized before ready-to-show', async () => {
+    vi.spyOn(process, 'platform', 'get').mockReturnValue('win32')
+    const { ElectronDesktopRuntime } = await import('../src/electron-runtime.ts')
+    const runtime = new ElectronDesktopRuntime(async () => {})
+    const release = runtime.schedule(spec)
+
+    await runtime.mountScheduled()
+
+    const window = electron.browserWindows[0]
+    const ready = window?.once.mock.calls.find(([event]) => event === 'ready-to-show')?.[1]
+    expect(ready).toEqual(expect.any(Function))
+    expect(window?.show).toHaveBeenCalledOnce()
+    expect(window?.focus).toHaveBeenCalledOnce()
+
+    window?.isVisible.mockReturnValue(true)
+    window?.isMinimized.mockReturnValue(true)
+    ready()
+
+    expect(window?.restore).not.toHaveBeenCalled()
+    expect(window?.show).toHaveBeenCalledOnce()
+    expect(window?.focus).toHaveBeenCalledOnce()
+
+    await release()
+  })
+
+  it('does not restore after ready-to-show wins the startup reveal race', async () => {
+    let resolveAuthentication!: (response: Response) => void
+    electron.sessionFetch.mockImplementationOnce(async () => await new Promise<Response>(resolve => {
+      resolveAuthentication = resolve
+    }))
+    vi.spyOn(process, 'platform', 'get').mockReturnValue('win32')
+    const { ElectronDesktopRuntime } = await import('../src/electron-runtime.ts')
+    const runtime = new ElectronDesktopRuntime(async () => {})
+    const release = runtime.schedule(spec)
+
+    const mount = runtime.mountScheduled()
+    expect(electron.sessionFetch).toHaveBeenCalledOnce()
+
+    const window = electron.browserWindows[0]
+    const ready = window?.once.mock.calls.find(([event]) => event === 'ready-to-show')?.[1]
+    expect(ready).toEqual(expect.any(Function))
+    ready()
+    expect(window?.show).toHaveBeenCalledOnce()
+    expect(window?.focus).toHaveBeenCalledOnce()
+
+    window?.isVisible.mockReturnValue(true)
+    window?.isMinimized.mockReturnValue(true)
+    resolveAuthentication(new Response(null, { status: 200 }))
+    await mount
+
+    expect(window?.restore).not.toHaveBeenCalled()
+    expect(window?.show).toHaveBeenCalledOnce()
+    expect(window?.focus).toHaveBeenCalledOnce()
+
+    await release()
+  })
+
   it('shows privacy-safe macOS attention only while unfocused and clears it on notification click', async () => {
     vi.spyOn(process, 'platform', 'get').mockReturnValue('darwin')
     const { ElectronDesktopRuntime } = await import('../src/electron-runtime.ts')


### PR DESCRIPTION
## Summary

- make startup surface reveal strictly one-shot so later startup callbacks cannot undo a user minimize or hide action
- keep stable and Beta shared Electron sources aligned while targeting the existing unreleased 2.0.5-beta.2 rollout
- cover both startup callback orderings with regression tests

## Verification

- corepack yarn check
- corepack yarn workspace dsh-plugin-desktop-beta check
- stable and Beta Electron runtime specs: 67/67 each
- desktop variant alignment and TypeScript checks

## Release scope

Publish this fix through DSH Desktop Beta 2.0.5-beta.2 first. Do not change the stable 2.0.5 update selector.