### PR TITLE
fix(desktop): keep Node child processes headless

### DIFF
--- a/dsh-plugin-desktop-beta/src/desktop-runtime-environment.ts
+++ b/dsh-plugin-desktop-beta/src/desktop-runtime-environment.ts
@@ -51,7 +51,7 @@ export interface DesktopPnpmRuntimeInstallation {
   nodeBinDir: string
   /** Private Node command shim used by pnpm lifecycle scripts. */
   nodeShimPath: string
-  /** Preloaded module that removes Electron RunAsNode from child environments. */
+  /** Preloaded module that points POSIX descendants at the private Node shim and removes Electron RunAsNode. */
   clearEnvironmentPath: string
   /** Remove this installation's PATH entry without deleting persistent generated files. */
   dispose(): void
@@ -199,9 +199,10 @@ function replacePrivateFile(filename: string, contents: string, mode: number): v
   }
 }
 
-/** Module preloaded into RunAsNode children before their requested entry. */
-function clearEnvironmentModule(): string {
+/** Publish the POSIX shim as the Node identity, then clear Node mode before user code runs. */
+function clearEnvironmentModule(posixNodeShimPath: string | undefined): string {
   return [
+    ...(posixNodeShimPath === undefined ? [] : [`process.execPath = ${JSON.stringify(posixNodeShimPath)}`]),
     `for (const name of Object.keys(process.env)) {`,
     `  if (name.toUpperCase() === '${RUN_AS_NODE}') delete process.env[name]`,
     '}',
@@ -418,7 +419,7 @@ export function installDesktopPnpmRuntime(options: DesktopPnpmRuntimeOptions): D
   const pnpmShimPath = join(pathDir, pnpmShimName)
   const nodeShimPath = join(nodeBinDir, nodeShimName)
   const clearEnvironmentPath = join(privateDir, 'clear-env.mjs')
-  replacePrivateFile(clearEnvironmentPath, clearEnvironmentModule(), PRIVATE_FILE_MODE)
+  replacePrivateFile(clearEnvironmentPath, clearEnvironmentModule(windows ? undefined : nodeShimPath), PRIVATE_FILE_MODE)
   const clearEnvironmentUrl = pathToFileURL(clearEnvironmentPath).href
   replacePrivateFile(
     nodeShimPath,

--- a/dsh-plugin-desktop-beta/tests/desktop-runtime-environment.spec.ts
+++ b/dsh-plugin-desktop-beta/tests/desktop-runtime-environment.spec.ts
@@ -1,5 +1,6 @@
 import { spawnSync } from 'node:child_process'
 import {
+  chmodSync,
   lstatSync,
   mkdirSync,
   mkdtempSync,
@@ -44,6 +45,10 @@ function options(
     stateDir,
     environment,
   }
+}
+
+function quoteSh(value: string): string {
+  return `'${value.replaceAll("'", `'"'"'`)}'`
 }
 
 afterEach(() => {
@@ -92,9 +97,9 @@ describe('desktop Host pnpm runtime', () => {
     expect(node).toContain(`ELECTRON_RUN_AS_NODE=1 exec`)
     expect(node).toContain(`--import '${clearEnvironmentUrl}' "$@"`)
     expect(node).not.toContain('npm_config_')
-    expect(readFileSync(installation.clearEnvironmentPath, 'utf8')).toContain(
-      "name.toUpperCase() === 'ELECTRON_RUN_AS_NODE'",
-    )
+    const clearEnvironment = readFileSync(installation.clearEnvironmentPath, 'utf8')
+    expect(clearEnvironment).toContain(`process.execPath = ${JSON.stringify(installation.nodeShimPath)}`)
+    expect(clearEnvironment).toContain("name.toUpperCase() === 'ELECTRON_RUN_AS_NODE'")
 
     expect(environment).toEqual({
       ...original,
@@ -127,14 +132,14 @@ describe('desktop Host pnpm runtime', () => {
     expect(environment).toEqual(original)
   })
 
-  it('clears every RunAsNode casing before the requested Node entry executes', () => {
+  it('clears every RunAsNode casing and publishes the private Node identity', () => {
     const stateDir = join(temporaryDirectory(), 'runtime')
     const installation = installDesktopPnpmRuntime(options(stateDir, 'linux', { PATH: '/usr/bin' }))
     const result = spawnSync(process.execPath, [
       '--import',
       pathToFileURL(installation.clearEnvironmentPath).href,
       '-e',
-      'process.stdout.write(JSON.stringify(Object.keys(process.env).filter(name => name.toUpperCase() === "ELECTRON_RUN_AS_NODE")))',
+      'process.stdout.write(JSON.stringify({ execPath: process.execPath, runAsNode: Object.keys(process.env).filter(name => name.toUpperCase() === "ELECTRON_RUN_AS_NODE") }))',
     ], {
       encoding: 'utf8',
       env: {
@@ -146,9 +151,100 @@ describe('desktop Host pnpm runtime', () => {
 
     expect(result.error).toBeUndefined()
     expect(result.status).toBe(0)
-    expect(result.stdout).toBe('[]')
+    expect(JSON.parse(result.stdout)).toEqual({
+      execPath: installation.nodeShimPath,
+      runAsNode: [],
+    })
     installation.dispose()
   })
+
+  it.runIf(process.platform === 'darwin' || process.platform === 'linux')(
+    'keeps process.execPath children headless without changing explicit application launches',
+    () => {
+      const root = temporaryDirectory()
+      const appExecutable = join(root, 'Fake Electron')
+      const guiLaunches = join(root, 'gui-launches.txt')
+      const childEntry = join(root, 'child.mjs')
+      const probeEntry = join(root, 'probe.mjs')
+      const probeOutput = join(root, 'probe.json')
+      const environment: NodeJS.ProcessEnv = { PATH: process.env.PATH }
+
+      writeFileSync(appExecutable, [
+        '#!/bin/sh',
+        `if [ "\${ELECTRON_RUN_AS_NODE:-}" = "1" ]; then`,
+        `  exec ${quoteSh(process.execPath)} "$@"`,
+        'fi',
+        `printf '%s\\n' "$*" >> ${quoteSh(guiLaunches)}`,
+        'exit 86',
+        '',
+      ].join('\n'))
+      chmodSync(appExecutable, 0o700)
+      writeFileSync(childEntry, [
+        "process.stdout.write('child-stdout')",
+        "process.stderr.write('child-stderr')",
+        'process.exitCode = 23',
+        '',
+      ].join('\n'))
+      writeFileSync(probeEntry, [
+        "import { spawnSync } from 'node:child_process'",
+        "import { writeFileSync } from 'node:fs'",
+        'const [preloadUrl, appExecutable, childEntry, output] = process.argv.slice(2)',
+        'process.execPath = appExecutable',
+        'await import(preloadUrl)',
+        'const inherited = spawnSync(process.execPath, [childEntry], { encoding: \'utf8\' })',
+        'const explicit = spawnSync(appExecutable, [childEntry], { encoding: \'utf8\' })',
+        'writeFileSync(output, JSON.stringify({',
+        '  execPath: process.execPath,',
+        "  runAsNode: Object.keys(process.env).filter(name => name.toUpperCase() === 'ELECTRON_RUN_AS_NODE'),",
+        '  inherited: { status: inherited.status, stdout: inherited.stdout, stderr: inherited.stderr },',
+        '  explicit: { status: explicit.status, stdout: explicit.stdout, stderr: explicit.stderr },',
+        '}))',
+        '',
+      ].join('\n'))
+
+      const installation = installDesktopPnpmRuntime({
+        platform: process.platform,
+        appExecutable,
+        pnpmBinPath: childEntry,
+        electronVersion: '43.3.0',
+        stateDir: join(root, 'runtime'),
+        environment,
+      })
+      const result = spawnSync(process.execPath, [
+        probeEntry,
+        pathToFileURL(installation.clearEnvironmentPath).href,
+        appExecutable,
+        childEntry,
+        probeOutput,
+      ], {
+        encoding: 'utf8',
+        env: {
+          PATH: process.env.PATH,
+          ELECTRON_RUN_AS_NODE: '1',
+          electron_run_as_node: 'legacy',
+        },
+      })
+
+      expect(result.error).toBeUndefined()
+      expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(0)
+      expect(JSON.parse(readFileSync(probeOutput, 'utf8'))).toEqual({
+        execPath: installation.nodeShimPath,
+        runAsNode: [],
+        inherited: {
+          status: 23,
+          stdout: 'child-stdout',
+          stderr: 'child-stderr',
+        },
+        explicit: {
+          status: 86,
+          stdout: '',
+          stderr: '',
+        },
+      })
+      expect(readFileSync(guiLaunches, 'utf8').trim().split('\n')).toEqual([childEntry])
+      installation.dispose()
+    },
+  )
 
   it('scopes Electron ABI settings to the pnpm process tree', () => {
     const root = temporaryDirectory()
@@ -233,6 +329,7 @@ describe('desktop Host pnpm runtime', () => {
     expect(node).toContain('set "ELECTRON_RUN_AS_NODE=1"')
     expect(node).toContain(`--import "${escapedClearEnvironmentUrl}" %*`)
     expect(node).not.toContain('npm_config_')
+    expect(readFileSync(installation.clearEnvironmentPath, 'utf8')).not.toContain('process.execPath =')
 
     expect(environment).toEqual({
       Path: `${installation.pathDir};C:\\Windows\\System32;C:\\Windows`,

--- a/dsh-plugin-desktop/src/desktop-runtime-environment.ts
+++ b/dsh-plugin-desktop/src/desktop-runtime-environment.ts
@@ -51,7 +51,7 @@ export interface DesktopPnpmRuntimeInstallation {
   nodeBinDir: string
   /** Private Node command shim used by pnpm lifecycle scripts. */
   nodeShimPath: string
-  /** Preloaded module that removes Electron RunAsNode from child environments. */
+  /** Preloaded module that points POSIX descendants at the private Node shim and removes Electron RunAsNode. */
   clearEnvironmentPath: string
   /** Remove this installation's PATH entry without deleting persistent generated files. */
   dispose(): void
@@ -199,9 +199,10 @@ function replacePrivateFile(filename: string, contents: string, mode: number): v
   }
 }
 
-/** Module preloaded into RunAsNode children before their requested entry. */
-function clearEnvironmentModule(): string {
+/** Publish the POSIX shim as the Node identity, then clear Node mode before user code runs. */
+function clearEnvironmentModule(posixNodeShimPath: string | undefined): string {
   return [
+    ...(posixNodeShimPath === undefined ? [] : [`process.execPath = ${JSON.stringify(posixNodeShimPath)}`]),
     `for (const name of Object.keys(process.env)) {`,
     `  if (name.toUpperCase() === '${RUN_AS_NODE}') delete process.env[name]`,
     '}',
@@ -418,7 +419,7 @@ export function installDesktopPnpmRuntime(options: DesktopPnpmRuntimeOptions): D
   const pnpmShimPath = join(pathDir, pnpmShimName)
   const nodeShimPath = join(nodeBinDir, nodeShimName)
   const clearEnvironmentPath = join(privateDir, 'clear-env.mjs')
-  replacePrivateFile(clearEnvironmentPath, clearEnvironmentModule(), PRIVATE_FILE_MODE)
+  replacePrivateFile(clearEnvironmentPath, clearEnvironmentModule(windows ? undefined : nodeShimPath), PRIVATE_FILE_MODE)
   const clearEnvironmentUrl = pathToFileURL(clearEnvironmentPath).href
   replacePrivateFile(
     nodeShimPath,

--- a/dsh-plugin-desktop/tests/desktop-runtime-environment.spec.ts
+++ b/dsh-plugin-desktop/tests/desktop-runtime-environment.spec.ts
@@ -1,5 +1,6 @@
 import { spawnSync } from 'node:child_process'
 import {
+  chmodSync,
   lstatSync,
   mkdirSync,
   mkdtempSync,
@@ -44,6 +45,10 @@ function options(
     stateDir,
     environment,
   }
+}
+
+function quoteSh(value: string): string {
+  return `'${value.replaceAll("'", `'"'"'`)}'`
 }
 
 afterEach(() => {
@@ -92,9 +97,9 @@ describe('desktop Host pnpm runtime', () => {
     expect(node).toContain(`ELECTRON_RUN_AS_NODE=1 exec`)
     expect(node).toContain(`--import '${clearEnvironmentUrl}' "$@"`)
     expect(node).not.toContain('npm_config_')
-    expect(readFileSync(installation.clearEnvironmentPath, 'utf8')).toContain(
-      "name.toUpperCase() === 'ELECTRON_RUN_AS_NODE'",
-    )
+    const clearEnvironment = readFileSync(installation.clearEnvironmentPath, 'utf8')
+    expect(clearEnvironment).toContain(`process.execPath = ${JSON.stringify(installation.nodeShimPath)}`)
+    expect(clearEnvironment).toContain("name.toUpperCase() === 'ELECTRON_RUN_AS_NODE'")
 
     expect(environment).toEqual({
       ...original,
@@ -127,14 +132,14 @@ describe('desktop Host pnpm runtime', () => {
     expect(environment).toEqual(original)
   })
 
-  it('clears every RunAsNode casing before the requested Node entry executes', () => {
+  it('clears every RunAsNode casing and publishes the private Node identity', () => {
     const stateDir = join(temporaryDirectory(), 'runtime')
     const installation = installDesktopPnpmRuntime(options(stateDir, 'linux', { PATH: '/usr/bin' }))
     const result = spawnSync(process.execPath, [
       '--import',
       pathToFileURL(installation.clearEnvironmentPath).href,
       '-e',
-      'process.stdout.write(JSON.stringify(Object.keys(process.env).filter(name => name.toUpperCase() === "ELECTRON_RUN_AS_NODE")))',
+      'process.stdout.write(JSON.stringify({ execPath: process.execPath, runAsNode: Object.keys(process.env).filter(name => name.toUpperCase() === "ELECTRON_RUN_AS_NODE") }))',
     ], {
       encoding: 'utf8',
       env: {
@@ -146,9 +151,100 @@ describe('desktop Host pnpm runtime', () => {
 
     expect(result.error).toBeUndefined()
     expect(result.status).toBe(0)
-    expect(result.stdout).toBe('[]')
+    expect(JSON.parse(result.stdout)).toEqual({
+      execPath: installation.nodeShimPath,
+      runAsNode: [],
+    })
     installation.dispose()
   })
+
+  it.runIf(process.platform === 'darwin' || process.platform === 'linux')(
+    'keeps process.execPath children headless without changing explicit application launches',
+    () => {
+      const root = temporaryDirectory()
+      const appExecutable = join(root, 'Fake Electron')
+      const guiLaunches = join(root, 'gui-launches.txt')
+      const childEntry = join(root, 'child.mjs')
+      const probeEntry = join(root, 'probe.mjs')
+      const probeOutput = join(root, 'probe.json')
+      const environment: NodeJS.ProcessEnv = { PATH: process.env.PATH }
+
+      writeFileSync(appExecutable, [
+        '#!/bin/sh',
+        `if [ "\${ELECTRON_RUN_AS_NODE:-}" = "1" ]; then`,
+        `  exec ${quoteSh(process.execPath)} "$@"`,
+        'fi',
+        `printf '%s\\n' "$*" >> ${quoteSh(guiLaunches)}`,
+        'exit 86',
+        '',
+      ].join('\n'))
+      chmodSync(appExecutable, 0o700)
+      writeFileSync(childEntry, [
+        "process.stdout.write('child-stdout')",
+        "process.stderr.write('child-stderr')",
+        'process.exitCode = 23',
+        '',
+      ].join('\n'))
+      writeFileSync(probeEntry, [
+        "import { spawnSync } from 'node:child_process'",
+        "import { writeFileSync } from 'node:fs'",
+        'const [preloadUrl, appExecutable, childEntry, output] = process.argv.slice(2)',
+        'process.execPath = appExecutable',
+        'await import(preloadUrl)',
+        'const inherited = spawnSync(process.execPath, [childEntry], { encoding: \'utf8\' })',
+        'const explicit = spawnSync(appExecutable, [childEntry], { encoding: \'utf8\' })',
+        'writeFileSync(output, JSON.stringify({',
+        '  execPath: process.execPath,',
+        "  runAsNode: Object.keys(process.env).filter(name => name.toUpperCase() === 'ELECTRON_RUN_AS_NODE'),",
+        '  inherited: { status: inherited.status, stdout: inherited.stdout, stderr: inherited.stderr },',
+        '  explicit: { status: explicit.status, stdout: explicit.stdout, stderr: explicit.stderr },',
+        '}))',
+        '',
+      ].join('\n'))
+
+      const installation = installDesktopPnpmRuntime({
+        platform: process.platform,
+        appExecutable,
+        pnpmBinPath: childEntry,
+        electronVersion: '43.3.0',
+        stateDir: join(root, 'runtime'),
+        environment,
+      })
+      const result = spawnSync(process.execPath, [
+        probeEntry,
+        pathToFileURL(installation.clearEnvironmentPath).href,
+        appExecutable,
+        childEntry,
+        probeOutput,
+      ], {
+        encoding: 'utf8',
+        env: {
+          PATH: process.env.PATH,
+          ELECTRON_RUN_AS_NODE: '1',
+          electron_run_as_node: 'legacy',
+        },
+      })
+
+      expect(result.error).toBeUndefined()
+      expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(0)
+      expect(JSON.parse(readFileSync(probeOutput, 'utf8'))).toEqual({
+        execPath: installation.nodeShimPath,
+        runAsNode: [],
+        inherited: {
+          status: 23,
+          stdout: 'child-stdout',
+          stderr: 'child-stderr',
+        },
+        explicit: {
+          status: 86,
+          stdout: '',
+          stderr: '',
+        },
+      })
+      expect(readFileSync(guiLaunches, 'utf8').trim().split('\n')).toEqual([childEntry])
+      installation.dispose()
+    },
+  )
 
   it('scopes Electron ABI settings to the pnpm process tree', () => {
     const root = temporaryDirectory()
@@ -233,6 +329,7 @@ describe('desktop Host pnpm runtime', () => {
     expect(node).toContain('set "ELECTRON_RUN_AS_NODE=1"')
     expect(node).toContain(`--import "${escapedClearEnvironmentUrl}" %*`)
     expect(node).not.toContain('npm_config_')
+    expect(readFileSync(installation.clearEnvironmentPath, 'utf8')).not.toContain('process.execPath =')
 
     expect(environment).toEqual({
       Path: `${installation.pathDir};C:\\Windows\\System32;C:\\Windows`,


### PR DESCRIPTION
## Summary / 摘要

Electron RunAsNode 入口原先会清除 `ELECTRON_RUN_AS_NODE`，但 `process.execPath` 仍指向桌面 GUI 可执行文件；pnpm 后续用该路径再次启动 Node 子进程时，会误启动第二个桌面实例并触发已有窗口前置。

本修复在 macOS/Linux 的预加载模块中把 `process.execPath` 指向私有 Node shim，再清除 RunAsNode。这样 Node 语义子进程继续无窗口执行，而显式调用应用可执行文件仍保留 GUI 语义。Windows 不改写 `process.execPath`，避免把它指向不能被无 shell `execFile()` 直接执行的 `node.cmd`。

## Related Issues / 关联 Issue

Closes #830

## Type / 类型

- [x] Bug fix / 问题修复
- [ ] Feature / 新功能
- [ ] Documentation / 文档
- [ ] Release or packaging / 发布或打包
- [ ] Tests only / 仅测试
- [ ] Other / 其他

## Platforms / 影响平台

- [ ] Windows installer / Windows 安装包
- [ ] Windows portable ZIP / Windows 便携版 ZIP
- [x] macOS Apple Silicon
- [x] macOS Intel
- [x] macOS Universal package / macOS 通用安装包
- [x] Linux
- [ ] Not platform-specific / 与平台无关

## Verification / 验证

- [x] `corepack yarn check:layout`
- [x] `corepack yarn typecheck`
- [x] `corepack yarn test`
- [x] `corepack yarn check`
- [ ] Platform package smoke / 平台打包或启动冒烟
- [ ] Manual test / 人工测试

额外验证：Stable/Beta focused runtime tests 各 `16 passed / 2 skipped`；真实 Electron 43.3.0 探针确认父进程 `process.execPath` 指向私有 shim、RunAsNode 已清空，子脚本退出码 23 且 stdout/stderr 均正确；Fake Electron 回归确认继承子进程不走 GUI，显式应用路径仍走 GUI 分支。

未在当前用户的已安装 DSH Desktop 上重打包、重启或执行隐藏/最小化焦点验收；Windows 运行时也未实跑。本 PR 只声明代码与独立 Electron 探针对 macOS 问题路径的修复。

## Release Notes / 发布说明

修复 macOS 后台工具子进程可能误启动 DSH Desktop 窗口并抢占前台的问题。