### PR TITLE
feat(desktop): add Linux x64 AppImage packaging path (issue 827)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -161,6 +161,37 @@ jobs:
           DSH_PACKAGE_CHECK_ALREADY_RAN: '1'
         run: yarn workspace ${{ matrix.workspace }} dist:mac-smoke
 
+  # Linux x64 AppImage packaging on a real Linux runner: the headless `check`
+  # job already runs the unit gates, so this job adds the unsigned AppImage
+  # build and artifact verification that no Windows or macOS runner can do.
+  desktop-linux:
+    needs: changes
+    if: needs.changes.outputs.product == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+          submodules: recursive
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 22.23.2
+      - run: corepack enable
+      - name: Resolve Yarn cache folder
+        id: yarn-cache
+        run: echo "dir=$(yarn config get cacheFolder)" >> "$GITHUB_OUTPUT"
+      - uses: actions/cache@v6
+        with:
+          path: ${{ steps.yarn-cache.outputs.dir }}
+          key: yarn-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('yarn.lock', '.yarnrc.yml') }}
+      - run: yarn install --immutable
+      - run: yarn workspace dsh-plugin-desktop check:linux-package
+      - name: Build Linux AppImage artifact
+        env:
+          DSH_PACKAGE_CHECK_ALREADY_RAN: '1'
+        run: yarn workspace dsh-plugin-desktop dist:linux
+
   # Upstream toolchain smoke: the portable-shell scripts must resolve the
   # pinned submodule's own Yarn/pnpm release on Windows.
   upstream-command-windows:

--- a/dsh-plugin-desktop/package.json
+++ b/dsh-plugin-desktop/package.json
@@ -122,6 +122,7 @@
     "check": "yarn run build && yarn run typecheck && yarn run test && yarn run verify:closure && yarn run verify:cli && yarn run verify:loader && yarn run verify:profile && yarn run verify:licenses && yarn run verify:operations",
     "check:win-package": "yarn workspace dsh-community-market build && yarn run build && yarn run typecheck && vitest run tests/package.spec.ts tests/package-win.spec.ts tests/desktop-installer-quit.spec.ts tests/installer-nsh.spec.ts tests/update-checker.spec.ts tests/update-download.spec.ts tests/verify-win-installer.spec.ts tests/verify-win-portable.spec.ts tests/verify-packaged-runtime.spec.ts tests/windows-pwsh-sandbox.spec.ts tests/windows-volume-diagnostics.spec.ts tests/window-options.spec.ts && yarn run verify:closure",
     "check:mac-package": "yarn workspace dsh-community-market build && yarn run build && yarn run typecheck && vitest run tests/package.spec.ts tests/package-mac.spec.ts tests/verify-mac-smoke.spec.ts tests/verify-packaged-runtime.spec.ts tests/mac-universal.spec.ts && yarn run verify:closure",
+    "check:linux-package": "yarn workspace dsh-community-market build && yarn run build && yarn run typecheck && vitest run tests/package.spec.ts tests/package-linux.spec.ts tests/verify-linux.spec.ts tests/verify-packaged-runtime.spec.ts tests/electron-platform.spec.ts && yarn run verify:closure",
     "start": "node lib/bin.js",
     "dev": "yarn run build && node lib/bin.js",
     "package:dir": "yarn run build && node scripts/package-dir.mjs",
@@ -129,6 +130,7 @@
     "dist:mac-smoke": "node scripts/package-mac.ts",
     "dist:win": "node scripts/package-win.ts",
     "dist:win-portable": "node scripts/package-win-portable.ts",
+    "dist:linux": "node scripts/package-linux.ts",
     "prepack": "yarn run check"
   },
   "dependencies": {
@@ -393,8 +395,16 @@
     },
     "linux": {
       "target": [
-        "dir"
+        {
+          "target": "AppImage",
+          "arch": [
+            "x64"
+          ]
+        }
       ],
+      "artifactName": "DSH-Desktop-${version}-${arch}.${ext}",
+      "category": "Development",
+      "executableName": "dsh-desktop",
       "icon": "build/app-icon.png"
     }
   }

--- a/dsh-plugin-desktop/scripts/package-linux.ts
+++ b/dsh-plugin-desktop/scripts/package-linux.ts
@@ -1,0 +1,148 @@
+/** Build an unsigned Linux x64 AppImage on a native Linux host. */
+
+import { spawnSync } from 'node:child_process'
+import { createRequire } from 'node:module'
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+/** Injectable native Linux packaging boundary used by focused tests. */
+export interface LinuxPackageOptions {
+  /** Environment inherited by the packaging command. */
+  readonly env: NodeJS.ProcessEnv
+  /** Platform executing the package build. */
+  readonly platform: NodeJS.Platform
+  /** Node architecture executing the package build. */
+  readonly arch: string
+  /** Node version executing the package build. */
+  readonly nodeVersion: string
+  /** Repository root containing the Yarn workspace. */
+  readonly workspaceRoot: string
+  /** Desktop package root containing electron-builder configuration. */
+  readonly desktopRoot: string
+  /** Absolute electron-builder CLI module. */
+  readonly builderCli: string
+  /** Absolute packaged-AppImage verification script. */
+  readonly verifier: string
+  /** Node executable used to run package-local scripts. */
+  readonly nodeExecutable: string
+  /** Execute one packaging command. */
+  readonly run: (
+    command: string,
+    args: readonly string[],
+    cwd: string,
+    env: NodeJS.ProcessEnv,
+  ) => void
+  /** Report non-secret packaging progress. */
+  readonly log: (message: string) => void
+}
+
+function run(
+  command: string,
+  args: readonly string[],
+  cwd: string,
+  env: NodeJS.ProcessEnv,
+): void {
+  const result = spawnSync(command, args, { cwd, env, stdio: 'inherit' })
+  if (result.error !== undefined) throw result.error
+  if (result.status !== 0) {
+    throw new Error(`${command} ${args.join(' ')} exited with ${String(result.status)}`)
+  }
+}
+
+/** Create the native packaging options for a Linux AppImage entry point. */
+export function createLinuxPackageOptions(verifier = './verify-linux.ts'): LinuxPackageOptions {
+  const desktopRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..')
+  const workspaceRoot = resolve(desktopRoot, '..')
+  const require = createRequire(import.meta.url)
+  return {
+    env: process.env,
+    platform: process.platform,
+    arch: process.arch,
+    nodeVersion: process.versions.node,
+    workspaceRoot,
+    desktopRoot,
+    builderCli: require.resolve('electron-builder/cli.js'),
+    verifier: fileURLToPath(new URL(verifier, import.meta.url)),
+    nodeExecutable: process.execPath,
+    run,
+    log: message => console.log(message),
+  }
+}
+
+/** Run the shared Linux host and Node release gates before packaging. */
+function assertLinuxPackageHost(options: LinuxPackageOptions): void {
+  if (options.platform !== 'linux') {
+    throw new Error('Linux AppImage must be built on a native Linux host')
+  }
+  if (options.arch !== 'x64') {
+    throw new Error(`Linux AppImage requires x64 Node; received ${options.arch}`)
+  }
+  const versionMatch = /^(\d+)\.(\d+)\./u.exec(options.nodeVersion)
+  const major = Number(versionMatch?.[1])
+  const minor = Number(versionMatch?.[2])
+  if (!((major === 22 && minor >= 19) || major === 24)) {
+    throw new Error(
+      `Linux AppImage requires Node 22.19+ or Node 24.x with bundled Corepack; received ${options.nodeVersion}`,
+    )
+  }
+}
+
+/**
+ * Run the gates and package one unsigned x64 Linux AppImage.
+ *
+ * Native modules are never rebuilt by Electron Builder: the Yarn install on a
+ * Linux x64 host already placed the matching Linux prebuilds (koffi, node-pty,
+ * sharp, ripgrep) in the dependency tree, so an AppImage built from those
+ * binaries cannot silently fall back to a host-ABI rebuild.
+ * @param options - Injectable process and command boundaries.
+ */
+export function packageLinuxAppImage(
+  options: LinuxPackageOptions = createLinuxPackageOptions(),
+): void {
+  assertLinuxPackageHost(options)
+
+  options.log('Building an unsigned Linux x64 AppImage; signing is a separate release step.')
+  if (options.env.DSH_PACKAGE_CHECK_ALREADY_RAN !== '1') {
+    options.run(
+      'corepack',
+      ['yarn', 'workspace', 'dsh-plugin-desktop', 'check:linux-package'],
+      options.workspaceRoot,
+      options.env,
+    )
+  } else {
+    options.log('Skipping the Linux package preflight; the package gate already passed.')
+  }
+  options.run(
+    options.nodeExecutable,
+    [
+      options.builderCli,
+      '--linux',
+      'AppImage',
+      '--x64',
+      '--publish',
+      'never',
+      '--config.npmRebuild=false',
+    ],
+    options.desktopRoot,
+    {
+      ...options.env,
+      CSC_IDENTITY_AUTO_DISCOVERY: 'false',
+    },
+  )
+  options.run(
+    options.nodeExecutable,
+    [options.verifier],
+    options.desktopRoot,
+    options.env,
+  )
+}
+
+const invokedPath = process.argv[1]
+if (invokedPath !== undefined && resolve(invokedPath) === fileURLToPath(import.meta.url)) {
+  try {
+    packageLinuxAppImage()
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error))
+    process.exitCode = 1
+  }
+}

--- a/dsh-plugin-desktop/scripts/verify-linux.ts
+++ b/dsh-plugin-desktop/scripts/verify-linux.ts
@@ -1,0 +1,137 @@
+/** Verify the unsigned Linux x64 AppImage and unpacked application structure. */
+
+import { closeSync, openSync, readFileSync, readSync, statSync } from 'node:fs'
+import { join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const ELF_MAGIC = Buffer.from([0x7f, 0x45, 0x4c, 0x46])
+
+/** Verify that a buffer starts with a Linux ELF identification header. */
+export function assertElfIdentification(buffer: Buffer, label: string, source: string): void {
+  if (buffer.byteLength < 4 || !buffer.subarray(0, 4).equals(ELF_MAGIC)) {
+    throw new Error(`${label} does not have an ELF header: ${source}`)
+  }
+}
+
+/** Paths returned after Linux AppImage verification succeeds. */
+export interface LinuxAppImageArtifacts {
+  /** AppImage artifact path. */
+  readonly appImagePath: string
+  /** Unpacked application executable path. */
+  readonly applicationPath: string
+}
+
+/** Injectable Linux artifact verification boundary. */
+export interface LinuxArtifactVerificationOptions {
+  /** Desktop package root containing package.json and dist. */
+  readonly desktopRoot: string
+  /** Product version embedded in the expected artifact name. */
+  readonly version: string
+  /** Probe a physical artifact path. */
+  readonly exists: (path: string) => boolean
+  /** Report physical metadata for an artifact path. */
+  readonly stat: (path: string) => {
+    readonly size: number
+    readonly isFile: boolean
+    readonly mode: number
+  }
+  /** Read the ELF identification prefix of a physical artifact. */
+  readonly readPrefix: (path: string, byteLength: number) => Buffer
+}
+
+function readVersion(desktopRoot: string): string {
+  const manifest = JSON.parse(readFileSync(join(desktopRoot, 'package.json'), 'utf8')) as {
+    version?: unknown
+  }
+  if (typeof manifest.version !== 'string' || manifest.version.length === 0) {
+    throw new Error(`desktop package at ${desktopRoot} has no valid version`)
+  }
+  return manifest.version
+}
+
+function readPrefix(path: string, byteLength: number): Buffer {
+  const descriptor = openSync(path, 'r')
+  const prefix = Buffer.alloc(byteLength)
+  try {
+    const bytesRead = readSync(descriptor, prefix, 0, prefix.byteLength, 0)
+    return bytesRead === prefix.byteLength ? prefix : prefix.subarray(0, bytesRead)
+  } finally {
+    closeSync(descriptor)
+  }
+}
+
+function defaultOptions(): LinuxArtifactVerificationOptions {
+  const desktopRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..')
+  return {
+    desktopRoot,
+    version: readVersion(desktopRoot),
+    exists: path => {
+      try {
+        return statSync(path).isFile()
+      } catch {
+        return false
+      }
+    },
+    stat: path => {
+      const result = statSync(path)
+      return { size: result.size, isFile: result.isFile(), mode: result.mode }
+    },
+    readPrefix,
+  }
+}
+
+/**
+ * Verify the exact x64 AppImage and unpacked application executable.
+ * @param options - Artifact root, expected product version, and probe seams.
+ * @returns The verified artifact paths.
+ */
+export function verifyLinuxAppImage(
+  options: LinuxArtifactVerificationOptions = defaultOptions(),
+): LinuxAppImageArtifacts {
+  const distDir = join(options.desktopRoot, 'dist')
+  const appImagePath = join(
+    distDir,
+    `DSH-Desktop-${options.version}-x64.AppImage`,
+  )
+  const unpackedRoot = join(distDir, 'linux-unpacked')
+  const applicationPath = join(unpackedRoot, 'dsh-desktop')
+
+  for (const [path, label] of [
+    [appImagePath, 'Linux AppImage'],
+    [applicationPath, 'unpacked Linux application'],
+  ] as const) {
+    if (!options.exists(path)) {
+      throw new Error(`${label} is not a non-empty regular file: ${path}`)
+    }
+    const artifactStat = options.stat(path)
+    if (!artifactStat.isFile || artifactStat.size === 0) {
+      throw new Error(`${label} is not a non-empty regular file: ${path}`)
+    }
+    if ((artifactStat.mode & 0o111) === 0) {
+      throw new Error(`${label} is not executable: ${path}`)
+    }
+    assertElfIdentification(options.readPrefix(path, 4), label, path)
+  }
+
+  const appAsarPath = join(unpackedRoot, 'resources', 'app.asar')
+  if (!options.exists(appAsarPath)) {
+    throw new Error(`packaged application is missing ${appAsarPath}`)
+  }
+  const appAsarStat = options.stat(appAsarPath)
+  if (!appAsarStat.isFile || appAsarStat.size === 0) {
+    throw new Error(`packaged application archive is empty: ${appAsarPath}`)
+  }
+
+  return { appImagePath, applicationPath }
+}
+
+const invokedPath = process.argv[1]
+if (invokedPath !== undefined && resolve(invokedPath) === fileURLToPath(import.meta.url)) {
+  try {
+    const verified = verifyLinuxAppImage()
+    console.log(`Linux AppImage verification passed: ${verified.appImagePath}`)
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error))
+    process.exitCode = 1
+  }
+}

--- a/dsh-plugin-desktop/tests/package-linux.spec.ts
+++ b/dsh-plugin-desktop/tests/package-linux.spec.ts
@@ -1,0 +1,135 @@
+import { describe, expect, it } from 'vitest'
+import {
+  packageLinuxAppImage,
+  type LinuxPackageOptions,
+} from '../scripts/package-linux.ts'
+
+interface CommandCall {
+  readonly command: string
+  readonly args: readonly string[]
+  readonly cwd: string
+  readonly env: NodeJS.ProcessEnv
+}
+
+function options(calls: CommandCall[], logs: string[] = []): LinuxPackageOptions {
+  return {
+    env: {
+      PATH: '/usr/bin:/bin',
+      SAFE_VALUE: 'kept',
+    },
+    platform: 'linux',
+    arch: 'x64',
+    nodeVersion: '22.23.2',
+    workspaceRoot: '/repo',
+    desktopRoot: '/repo/dsh-plugin-desktop',
+    builderCli: '/repo/node_modules/electron-builder/cli.js',
+    verifier: '/repo/dsh-plugin-desktop/scripts/verify-linux.ts',
+    nodeExecutable: '/usr/local/bin/node',
+    run: (command, args, cwd, env) => {
+      calls.push({ command, args: [...args], cwd, env: { ...env } })
+    },
+    log: message => logs.push(message),
+  }
+}
+
+describe('Linux x64 AppImage packaging', () => {
+  it('runs the package gate, builds an unsigned AppImage, then verifies it', () => {
+    const calls: CommandCall[] = []
+    const logs: string[] = []
+
+    packageLinuxAppImage(options(calls, logs))
+
+    expect(calls).toHaveLength(3)
+    expect(calls[0]).toEqual({
+      command: 'corepack',
+      args: ['yarn', 'workspace', 'dsh-plugin-desktop', 'check:linux-package'],
+      cwd: '/repo',
+      env: { PATH: '/usr/bin:/bin', SAFE_VALUE: 'kept' },
+    })
+    expect(calls[1]).toEqual({
+      command: '/usr/local/bin/node',
+      args: [
+        '/repo/node_modules/electron-builder/cli.js',
+        '--linux',
+        'AppImage',
+        '--x64',
+        '--publish',
+        'never',
+        '--config.npmRebuild=false',
+      ],
+      cwd: '/repo/dsh-plugin-desktop',
+      env: {
+        PATH: '/usr/bin:/bin',
+        SAFE_VALUE: 'kept',
+        CSC_IDENTITY_AUTO_DISCOVERY: 'false',
+      },
+    })
+    expect(calls[2]).toEqual({
+      command: '/usr/local/bin/node',
+      args: ['/repo/dsh-plugin-desktop/scripts/verify-linux.ts'],
+      cwd: '/repo/dsh-plugin-desktop',
+      env: { PATH: '/usr/bin:/bin', SAFE_VALUE: 'kept' },
+    })
+    expect(logs).toEqual([
+      'Building an unsigned Linux x64 AppImage; signing is a separate release step.',
+    ])
+  })
+
+  it('reuses a completed CI package gate when explicitly requested', () => {
+    const calls: CommandCall[] = []
+    const logs: string[] = []
+    const value = {
+      ...options(calls, logs),
+      env: {
+        ...options(calls).env,
+        DSH_PACKAGE_CHECK_ALREADY_RAN: '1',
+      },
+    }
+
+    packageLinuxAppImage(value)
+
+    expect(calls).toHaveLength(2)
+    expect(calls[0]?.args).toEqual([
+      '/repo/node_modules/electron-builder/cli.js',
+      '--linux',
+      'AppImage',
+      '--x64',
+      '--publish',
+      'never',
+      '--config.npmRebuild=false',
+    ])
+    expect(logs).toEqual([
+      'Building an unsigned Linux x64 AppImage; signing is a separate release step.',
+      'Skipping the Linux package preflight; the package gate already passed.',
+    ])
+  })
+
+  it.each([
+    ['win32', 'x64', '22.23.2', 'native Linux host'],
+    ['linux', 'arm64', '22.23.2', 'requires x64 Node'],
+    ['linux', 'x64', '25.0.0', 'Node 22.19+ or Node 24.x'],
+  ] as const)(
+    'rejects unsupported host %s/%s with Node %s before running commands',
+    (platform, arch, nodeVersion, message) => {
+      const calls: CommandCall[] = []
+      const value = { ...options(calls), platform, arch, nodeVersion }
+
+      expect(() => packageLinuxAppImage(value)).toThrow(message)
+      expect(calls).toEqual([])
+    },
+  )
+
+  it('stops before packaging when the headless check fails', () => {
+    const calls: CommandCall[] = []
+    const value: LinuxPackageOptions = {
+      ...options(calls),
+      run: (command, args, cwd, env) => {
+        calls.push({ command, args: [...args], cwd, env: { ...env } })
+        throw new Error('headless check failed')
+      },
+    }
+
+    expect(() => packageLinuxAppImage(value)).toThrow('headless check failed')
+    expect(calls).toHaveLength(1)
+  })
+})

--- a/dsh-plugin-desktop/tests/package.spec.ts
+++ b/dsh-plugin-desktop/tests/package.spec.ts
@@ -47,7 +47,13 @@ const manifest = JSON.parse(readFileSync(new URL('package.json', packageRoot), '
     win?: { icon?: unknown; target?: unknown; artifactName?: unknown }
     nsis?: Record<string, unknown>
     portable?: Record<string, unknown>
-    linux?: { icon?: unknown }
+    linux?: {
+      icon?: unknown
+      target?: unknown
+      artifactName?: unknown
+      category?: unknown
+      executableName?: unknown
+    }
   }
   dependencies?: Record<string, unknown>
   optionalDependencies?: Record<string, unknown>
@@ -788,7 +794,13 @@ describe('published package surface', () => {
       useZip: false,
       artifactName: 'DSH-Desktop-${version}-${arch}-Setup.${ext}',
     })
-    expect(manifest.build?.linux?.icon).toBe('build/app-icon.png')
+    expect(manifest.build?.linux).toEqual({
+      target: [{ target: 'AppImage', arch: ['x64'] }],
+      artifactName: 'DSH-Desktop-${version}-${arch}.${ext}',
+      category: 'Development',
+      executableName: 'dsh-desktop',
+      icon: 'build/app-icon.png',
+    })
   })
 
   it('separates unsigned smoke packaging from the signed macOS release', () => {
@@ -801,6 +813,7 @@ describe('published package surface', () => {
     expect(manifest.scripts?.['dist:mac-smoke']).toBe('node scripts/package-mac.ts')
     expect(manifest.scripts?.['dist:win']).toBe('node scripts/package-win.ts')
     expect(manifest.scripts?.['dist:win-portable']).toBe('node scripts/package-win-portable.ts')
+    expect(manifest.scripts?.['dist:linux']).toBe('node scripts/package-linux.ts')
     expect(manifest.scripts?.['check:win-package']).toContain('yarn workspace dsh-community-market build')
     expect(manifest.scripts?.['check:win-package']).toContain('yarn run build')
     expect(manifest.scripts?.['check:win-package']).toContain('yarn run typecheck')
@@ -820,6 +833,13 @@ describe('published package surface', () => {
     expect(manifest.scripts?.['check:mac-package']).toContain('tests/verify-mac-smoke.spec.ts')
     expect(manifest.scripts?.['check:mac-package']).toContain('tests/mac-universal.spec.ts')
     expect(manifest.scripts?.['check:mac-package']).toContain('yarn run verify:closure')
+    expect(manifest.scripts?.['check:linux-package']).toContain('yarn workspace dsh-community-market build')
+    expect(manifest.scripts?.['check:linux-package']).toContain('yarn run build')
+    expect(manifest.scripts?.['check:linux-package']).toContain('yarn run typecheck')
+    expect(manifest.scripts?.['check:linux-package']).toContain('tests/package-linux.spec.ts')
+    expect(manifest.scripts?.['check:linux-package']).toContain('tests/verify-linux.spec.ts')
+    expect(manifest.scripts?.['check:linux-package']).toContain('tests/electron-platform.spec.ts')
+    expect(manifest.scripts?.['check:linux-package']).toContain('yarn run verify:closure')
     expect(manifest.scripts?.['verify:cli']).toBe('node scripts/verify-cli-runtime.mjs')
     expect(manifest.scripts?.check).toContain('yarn run verify:cli')
     expect(workspaceManifest.scripts?.['dist:mac'])
@@ -830,6 +850,8 @@ describe('published package surface', () => {
       .toBe('yarn workspace dsh-community-market build && yarn workspace dsh-plugin-desktop dist:win')
     expect(workspaceManifest.scripts?.['dist:win-portable'])
       .toBe('yarn workspace dsh-community-market build && yarn workspace dsh-plugin-desktop dist:win-portable')
+    expect(workspaceManifest.scripts?.['dist:linux'])
+      .toBe('yarn workspace dsh-community-market build && yarn workspace dsh-plugin-desktop dist:linux')
     expect(manifest.build?.afterPack).toBe('./scripts/verify-packaged-runtime.ts')
     expect(manifest.build?.mac).toEqual(expect.objectContaining({
       extendInfo: {
@@ -855,6 +877,10 @@ describe('published package surface', () => {
     )
     const macosJob = ciWorkflow.slice(
       ciWorkflow.indexOf('  desktop-macos:'),
+      ciWorkflow.indexOf('  desktop-linux:'),
+    )
+    const linuxJob = ciWorkflow.slice(
+      ciWorkflow.indexOf('  desktop-linux:'),
       ciWorkflow.indexOf('  upstream-command-windows:'),
     )
 
@@ -870,6 +896,11 @@ describe('published package surface', () => {
     expect(macosJob).toContain('run: yarn workspace ${{ matrix.workspace }} dist:mac-smoke')
     expect(macosJob).toContain('DSH_PACKAGE_CHECK_ALREADY_RAN: \'1\'')
     expect(macosJob).not.toContain('- run: yarn dist:mac-smoke')
+    expect(linuxJob).not.toContain('- run: yarn check')
+    expect(linuxJob).toContain('- run: yarn workspace dsh-plugin-desktop check:linux-package')
+    expect(linuxJob).toContain('run: yarn workspace dsh-plugin-desktop dist:linux')
+    expect(linuxJob).toContain('DSH_PACKAGE_CHECK_ALREADY_RAN: \'1\'')
+    expect(linuxJob).not.toContain('- run: yarn dist:linux')
   })
 
   it('skips product packaging only for documentation-only changes', () => {

--- a/dsh-plugin-desktop/tests/verify-linux.spec.ts
+++ b/dsh-plugin-desktop/tests/verify-linux.spec.ts
@@ -1,0 +1,136 @@
+import {
+  chmodSync,
+  closeSync,
+  mkdirSync,
+  mkdtempSync,
+  openSync,
+  readSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
+import {
+  verifyLinuxAppImage,
+  type LinuxArtifactVerificationOptions,
+} from '../scripts/verify-linux.ts'
+
+const temporaryRoots: string[] = []
+
+function elfFile(): Buffer {
+  const executable = Buffer.alloc(64)
+  executable.writeUInt8(0x7f, 0)
+  executable.write('ELF', 1, 'ascii')
+  return executable
+}
+
+interface LinuxFixture {
+  readonly root: string
+  readonly appImage: string
+  readonly application: string
+  readonly appAsar: string
+  readonly modeOverrides: Map<string, number>
+}
+
+function fixture(version = '2.0.0'): LinuxFixture {
+  const root = mkdtempSync(join(tmpdir(), 'dsh-linux-appimage-'))
+  temporaryRoots.push(root)
+  const dist = join(root, 'dist')
+  const unpacked = join(dist, 'linux-unpacked')
+  const resources = join(unpacked, 'resources')
+  mkdirSync(resources, { recursive: true })
+  const modeOverrides = new Map<string, number>()
+  const appImage = join(dist, `DSH-Desktop-${version}-x64.AppImage`)
+  const application = join(unpacked, 'dsh-desktop')
+  const appAsar = join(resources, 'app.asar')
+  writeFileSync(appImage, elfFile())
+  chmodSync(appImage, 0o755)
+  modeOverrides.set(appImage, 0o755)
+  writeFileSync(application, elfFile())
+  chmodSync(application, 0o755)
+  modeOverrides.set(application, 0o755)
+  writeFileSync(appAsar, 'packed')
+  return { root, appImage, application, appAsar, modeOverrides }
+}
+
+function readPrefix(path: string, byteLength: number): Buffer {
+  const descriptor = openSync(path, 'r')
+  const prefix = Buffer.alloc(byteLength)
+  try {
+    const bytesRead = readSync(descriptor, prefix, 0, prefix.byteLength, 0)
+    return bytesRead === prefix.byteLength ? prefix : prefix.subarray(0, bytesRead)
+  } finally {
+    closeSync(descriptor)
+  }
+}
+
+function options(
+  root: string,
+  modeOverrides: ReadonlyMap<string, number> = new Map(),
+): LinuxArtifactVerificationOptions {
+  return {
+    desktopRoot: root,
+    version: '2.0.0',
+    exists: path => {
+      try {
+        return statSync(path).isFile()
+      } catch {
+        return false
+      }
+    },
+    stat: path => {
+      const result = statSync(path)
+      return { size: result.size, isFile: result.isFile(), mode: modeOverrides.get(path) ?? result.mode }
+    },
+    readPrefix,
+  }
+}
+
+afterEach(() => {
+  for (const root of temporaryRoots.splice(0)) rmSync(root, { recursive: true, force: true })
+})
+
+describe('Linux AppImage artifact verification', () => {
+  it('accepts the exact versioned AppImage and unpacked application', () => {
+    const value = fixture()
+
+    expect(verifyLinuxAppImage(options(value.root, value.modeOverrides))).toEqual({
+      appImagePath: value.appImage,
+      applicationPath: value.application,
+    })
+  })
+
+  it('rejects a stale AppImage from a different version', () => {
+    const value = fixture('1.9.0')
+
+    expect(() => verifyLinuxAppImage(options(value.root, value.modeOverrides)))
+      .toThrow('DSH-Desktop-2.0.0-x64.AppImage')
+  })
+
+  it('rejects an AppImage without an ELF header', () => {
+    const value = fixture()
+    writeFileSync(value.appImage, elfFile().fill(0, 0, 4))
+
+    expect(() => verifyLinuxAppImage(options(value.root, value.modeOverrides)))
+      .toThrow('does not have an ELF header')
+  })
+
+  it('rejects an unpacked application that is not executable', () => {
+    const value = fixture()
+    chmodSync(value.application, 0o644)
+    value.modeOverrides.set(value.application, 0o644)
+
+    expect(() => verifyLinuxAppImage(options(value.root, value.modeOverrides)))
+      .toThrow('is not executable')
+  })
+
+  it('rejects an empty packaged application archive', () => {
+    const value = fixture()
+    writeFileSync(value.appAsar, '')
+
+    expect(() => verifyLinuxAppImage(options(value.root, value.modeOverrides)))
+      .toThrow('packaged application archive is empty')
+  })
+})

--- a/package.json
+++ b/package.json
@@ -1050,6 +1050,7 @@
     "dist:mac-smoke": "yarn workspace dsh-community-market build && yarn workspace dsh-plugin-desktop dist:mac-smoke",
     "dist:win": "yarn workspace dsh-community-market build && yarn workspace dsh-plugin-desktop dist:win",
     "dist:win-portable": "yarn workspace dsh-community-market build && yarn workspace dsh-plugin-desktop dist:win-portable",
+    "dist:linux": "yarn workspace dsh-community-market build && yarn workspace dsh-plugin-desktop dist:linux",
     "upstream:version": "cd deepseek-harness && corepack pnpm --version",
     "upstream:install": "cd deepseek-harness && CI=true corepack pnpm install --frozen-lockfile",
     "upstream:build": "cd deepseek-harness && corepack pnpm run build",


### PR DESCRIPTION
## Summary / 摘要

Adds an unsigned Linux x64 AppImage distributable path for issue 827, mirroring the existing Windows/macOS package gates:

- `dsh-plugin-desktop/package.json`: electron-builder `build.linux` now targets AppImage x64 with `DSH-Desktop-<version>-<arch>.AppImage` artifact naming, `executableName dsh-desktop`, `category Development`; adds `check:linux-package` and `dist:linux` scripts.
- Root `package.json`: `dist:linux` workspace wrapper.
- `scripts/package-linux.ts`: Linux-host + x64 gate, preflight gate bypassable for CI, unsigned electron-builder `--linux AppImage --x64 --publish never` run, then the verifier.
- `scripts/verify-linux.ts`: asserts the exact versioned AppImage exists, the unpacked ELF executable has exec bits, and `resources/app.asar` is non-empty.
- Unit coverage for both scripts plus manifest/CI-shape assertions.
- `.github/workflows/ci.yml`: new `desktop-linux` ubuntu-latest job (product-only, runs `check:linux-package` then the AppImage build+verify) so the real unsigned x64 AppImage build runs on a Linux runner.

## Related Issues / 关联 Issue

Fixes #827

## Type / 类型

- [ ] Bug fix / 问题修复
- [x] Feature / 新功能
- [ ] Documentation / 文档
- [x] Release or packaging / 发布或打包
- [ ] Tests only / 仅测试
- [ ] Other / 其他

## Platforms / 影响平台

- [ ] Windows installer / Windows 安装包
- [ ] Windows portable ZIP / Windows 便携版 ZIP
- [ ] macOS Apple Silicon
- [ ] macOS Intel
- [ ] macOS Universal package / macOS 通用安装包
- [x] Linux
- [ ] Not platform-specific / 与平台无关

## Verification / 验证

- Branch rebased onto current `master` (89a22d2858); change set is the single packaging commit.
- JSON parse of root and `dsh-plugin-desktop` package.json; YAML parse of `ci.yml`; `desktop-linux` job wired to existing `check:linux-package`/`dist:linux` scripts; CI path classifier marks the change set product=true.
- Script logic checks (host gates, artifact-set acceptance, ELF/exec-bit/asar assertions, gate ordering) executed against the real `package-linux.ts`/`verify-linux.ts` modules in the implementation segment.
- The real unsigned x64 AppImage build and artifact verification run on the `desktop-linux` ubuntu job of this PR (Linux-only; cannot run on the Windows authoring host). Full `corepack yarn typecheck/test` were not run locally on the authoring host.

## Release Notes / 发布说明

Adds a Linux x64 AppImage distributable asset to the desktop release pipeline (unsigned build produced and verified on the `desktop-linux` CI job).
