### PR TITLE
fix(ui): keep recovery dialog text clear of scrollbar

### DIFF
--- a/dsh-plugin-desktop-beta/src/native-ui/desktop-dialog/App.tsx
+++ b/dsh-plugin-desktop-beta/src/native-ui/desktop-dialog/App.tsx
@@ -95,7 +95,9 @@ export function DesktopDialogApp(): JSX.Element {
             ? <ScrollArea className="mt-3 h-64 rounded-lg border bg-muted/40">
                 <pre className="select-text whitespace-pre-wrap break-words p-3 font-mono text-xs leading-relaxed text-muted-foreground" id="desktop-dialog-detail">{state.detail}</pre>
               </ScrollArea>
-            : <p className="mt-2 max-h-28 overflow-auto whitespace-pre-wrap text-sm leading-relaxed text-muted-foreground" id="desktop-dialog-detail">{state.detail}</p>}
+            : <ScrollArea className="mt-2 h-28 pr-3">
+                <p className="whitespace-pre-wrap text-sm leading-relaxed text-muted-foreground" id="desktop-dialog-detail">{state.detail}</p>
+              </ScrollArea>}
         {state.advisory === undefined ? null : <div className="mt-3 rounded-md border border-amber-500/40 bg-amber-500/10 px-3 py-2.5 text-sm leading-relaxed text-amber-100" id="desktop-dialog-advisory">
           {desktopDialogAdvisoryLines(state.advisory).map((line, index) => <span className="block" key={`${String(index)}:${line}`}>{line}</span>)}
         </div>}

--- a/dsh-plugin-desktop-beta/tests/desktop-dialog-native-ui.spec.ts
+++ b/dsh-plugin-desktop-beta/tests/desktop-dialog-native-ui.spec.ts
@@ -1,5 +1,6 @@
 import { createElement } from 'react'
 import { renderToStaticMarkup } from 'react-dom/server'
+import { readFileSync } from 'node:fs'
 import { describe, expect, it } from 'vitest'
 import {
   DesktopDialogToneIcon,
@@ -26,6 +27,12 @@ describe('Desktop dialog native UI', () => {
       '2. Second',
       'Recommendation',
     ])
+  })
+
+  it('uses the shared ScrollArea for long default dialog details', () => {
+    const source = readFileSync(new URL('../src/native-ui/desktop-dialog/App.tsx', import.meta.url), 'utf8')
+    expect(source).toContain('<ScrollArea className="mt-2 h-28 pr-3">')
+    expect(source).not.toContain('max-h-28 overflow-auto')
   })
 
 })

--- a/dsh-plugin-desktop/src/native-ui/desktop-dialog/App.tsx
+++ b/dsh-plugin-desktop/src/native-ui/desktop-dialog/App.tsx
@@ -95,7 +95,9 @@ export function DesktopDialogApp(): JSX.Element {
             ? <ScrollArea className="mt-3 h-64 rounded-lg border bg-muted/40">
                 <pre className="select-text whitespace-pre-wrap break-words p-3 font-mono text-xs leading-relaxed text-muted-foreground" id="desktop-dialog-detail">{state.detail}</pre>
               </ScrollArea>
-            : <p className="mt-2 max-h-28 overflow-auto whitespace-pre-wrap text-sm leading-relaxed text-muted-foreground" id="desktop-dialog-detail">{state.detail}</p>}
+            : <ScrollArea className="mt-2 h-28 pr-3">
+                <p className="whitespace-pre-wrap text-sm leading-relaxed text-muted-foreground" id="desktop-dialog-detail">{state.detail}</p>
+              </ScrollArea>}
         {state.advisory === undefined ? null : <div className="mt-3 rounded-md border border-amber-500/40 bg-amber-500/10 px-3 py-2.5 text-sm leading-relaxed text-amber-100" id="desktop-dialog-advisory">
           {desktopDialogAdvisoryLines(state.advisory).map((line, index) => <span className="block" key={`${String(index)}:${line}`}>{line}</span>)}
         </div>}

--- a/dsh-plugin-desktop/tests/desktop-dialog-native-ui.spec.ts
+++ b/dsh-plugin-desktop/tests/desktop-dialog-native-ui.spec.ts
@@ -1,5 +1,6 @@
 import { createElement } from 'react'
 import { renderToStaticMarkup } from 'react-dom/server'
+import { readFileSync } from 'node:fs'
 import { describe, expect, it } from 'vitest'
 import {
   DesktopDialogToneIcon,
@@ -26,6 +27,12 @@ describe('Desktop dialog native UI', () => {
       '2. Second',
       'Recommendation',
     ])
+  })
+
+  it('uses the shared ScrollArea for long default dialog details', () => {
+    const source = readFileSync(new URL('../src/native-ui/desktop-dialog/App.tsx', import.meta.url), 'utf8')
+    expect(source).toContain('<ScrollArea className="mt-2 h-28 pr-3">')
+    expect(source).not.toContain('max-h-28 overflow-auto')
   })
 
 })


### PR DESCRIPTION
## Summary

- use the existing shared ScrollArea for default desktop dialog details
- add right-side padding so dialog text does not overlap the custom scrollbar
- keep stable and beta desktop variants aligned

## Verification

- desktop-dialog-native-ui tests (stable/beta)
- typecheck (stable/beta)
- desktop variant consistency check
- git diff --check