### PR TITLE
fix(desktop): prevent background Node re-entry from focusing the window

### DIFF
--- a/dsh-plugin-desktop-beta/src/desktop-installer-quit.ts
+++ b/dsh-plugin-desktop-beta/src/desktop-installer-quit.ts
@@ -8,3 +8,26 @@ export function isDesktopInstallerQuitRequest(
 ): boolean {
   return platform === 'win32' && argv.includes(DESKTOP_INSTALLER_QUIT_FLAG)
 }
+
+const NODE_ENTRY = /\.(?:c|m)?js$/iu
+
+/**
+ * Identify an Electron executable that was accidentally re-entered as a GUI
+ * while a background Node command was trying to launch a descendant.
+ *
+ * Desktop does not accept JavaScript documents or Node loader flags as GUI
+ * launch arguments. Suppressing these requests therefore preserves explicit
+ * application launches while preventing an internal command from focusing the
+ * existing window if its RunAsNode environment is ever lost.
+ */
+export function isDesktopBackgroundNodeRequest(argv: readonly string[]): boolean {
+  return argv.slice(1).some(argument => {
+    const normalized = argument.replace(/^file:\/\//iu, '').split(/[?#]/u, 1)[0] ?? ''
+    return NODE_ENTRY.test(normalized)
+      || argument === '--require'
+      || argument.startsWith('--require=')
+      || argument === '--import'
+      || argument.startsWith('--import=')
+      || argument === '--expose-internals'
+  })
+}

--- a/dsh-plugin-desktop-beta/src/desktop-runtime-environment.ts
+++ b/dsh-plugin-desktop-beta/src/desktop-runtime-environment.ts
@@ -53,7 +53,7 @@ export interface DesktopPnpmRuntimeInstallation {
   nodeBinDir: string
   /** Private Node command shim used by pnpm lifecycle scripts. */
   nodeShimPath: string
-  /** Preloaded module that removes Electron RunAsNode from child environments. */
+  /** Preloaded module that preserves the platform's safe Node descendant identity. */
   clearEnvironmentPath: string
   /** Remove this installation's PATH entry without deleting persistent generated files. */
   dispose(): void
@@ -335,9 +335,16 @@ function installRuntimeGeneration(stateDir: string, plan: RuntimeGenerationPlan)
   return { root, obsoletePathDirectories }
 }
 
-/** Module preloaded into RunAsNode children before their requested entry. */
-function clearEnvironmentModule(): string {
+/** Keep descendants in Node mode on Windows, where the private shim is a non-executable batch file. */
+function clearEnvironmentModule(platform: NodeJS.Platform): string {
+  if (platform === 'win32') {
+    return [
+      '// process.execPath is the Electron executable; its Node descendants must retain RunAsNode.',
+      '',
+    ].join('\n')
+  }
   return [
+    `process.execPath = require('node:path').join(__dirname, 'node-bin', 'node')`,
     `for (const name of Object.keys(process.env)) {`,
     `  if (name.toUpperCase() === '${RUN_AS_NODE}') delete process.env[name]`,
     '}',
@@ -563,7 +570,7 @@ export function installDesktopPnpmRuntime(options: DesktopPnpmRuntimeOptions): D
     [
       {
         relativePath: 'private/clear-env.cjs',
-        contents: clearEnvironmentModule(),
+        contents: clearEnvironmentModule(options.platform),
         mode: PRIVATE_FILE_MODE,
       },
       {

--- a/dsh-plugin-desktop-beta/src/main.ts
+++ b/dsh-plugin-desktop-beta/src/main.ts
@@ -21,7 +21,10 @@ import {
 } from '@deepseek-ai/dsh-launch-environment'
 import type {} from '@deepseek-ai/dsh-web-app'
 import type {} from '@deepseek-ai/dsh-client-connection'
-import { isDesktopInstallerQuitRequest } from './desktop-installer-quit.ts'
+import {
+  isDesktopBackgroundNodeRequest,
+  isDesktopInstallerQuitRequest,
+} from './desktop-installer-quit.ts'
 import { createDesktopBrowserAccess } from './desktop-browser-access.ts'
 import {
   installDesktopDshRuntime,
@@ -630,6 +633,9 @@ async function start(): Promise<void> {
   app.on('second-instance', (_event, argv) => {
     if (isDesktopInstallerQuitRequest(argv, process.platform)) {
       requestQuit(0)
+      return
+    }
+    if (isDesktopBackgroundNodeRequest(argv)) {
       return
     }
     if (!showPreHostSurface()) runtime.show()

--- a/dsh-plugin-desktop-beta/tests/desktop-installer-quit.spec.ts
+++ b/dsh-plugin-desktop-beta/tests/desktop-installer-quit.spec.ts
@@ -3,6 +3,7 @@ import { join } from 'node:path'
 import { describe, expect, it } from 'vitest'
 import {
   DESKTOP_INSTALLER_QUIT_FLAG,
+  isDesktopBackgroundNodeRequest,
   isDesktopInstallerQuitRequest,
 } from '../src/desktop-installer-quit.ts'
 
@@ -20,6 +21,15 @@ describe('Desktop installer quit request', () => {
     )).toBe(false)
   })
 
+  it('distinguishes background Node re-entry from an explicit application launch', () => {
+    expect(isDesktopBackgroundNodeRequest(['DSH Desktop.exe'])).toBe(false)
+    expect(isDesktopBackgroundNodeRequest(['DSH Desktop.exe', '--profile', 'desktop'])).toBe(false)
+    expect(isDesktopBackgroundNodeRequest(['DSH Desktop.exe', 'C:\\app\\pnpm\\bin\\pnpm.mjs', 'install'])).toBe(true)
+    expect(isDesktopBackgroundNodeRequest(['DSH Desktop.exe', '--require', 'C:\\runtime\\clear-env.cjs'])).toBe(true)
+    expect(isDesktopBackgroundNodeRequest(['DSH Desktop.exe', '--import=file:///runtime/clear-env.mjs'])).toBe(true)
+    expect(isDesktopBackgroundNodeRequest(['DSH Desktop.exe', '--expose-internals', 'desktop-cli.js'])).toBe(true)
+  })
+
   it('handles first- and second-instance requests without showing a window', () => {
     const main = readFileSync(join(process.cwd(), 'src', 'main.ts'), 'utf8')
     const lock = main.indexOf('if (!app.requestSingleInstanceLock())')
@@ -32,6 +42,7 @@ describe('Desktop installer quit request', () => {
       'if (isDesktopInstallerQuitRequest(argv, process.platform))',
       secondInstance,
     )
+    const backgroundNode = main.indexOf('if (isDesktopBackgroundNodeRequest(argv))', secondInstance)
     const show = main.indexOf('if (!showPreHostSurface()) runtime.show()', secondInstance)
 
     expect(lock).toBeGreaterThanOrEqual(0)
@@ -39,8 +50,9 @@ describe('Desktop installer quit request', () => {
     expect(earlyQuit).toBeLessThan(startup)
     expect(secondInstance).toBeGreaterThan(startup)
     expect(secondQuit).toBeGreaterThan(secondInstance)
-    expect(secondQuit).toBeLessThan(show)
-    expect(show).toBeGreaterThan(secondQuit)
-    expect(main.slice(secondQuit, show)).toContain('requestQuit(0)')
+    expect(backgroundNode).toBeGreaterThan(secondQuit)
+    expect(show).toBeGreaterThan(backgroundNode)
+    expect(main.slice(secondQuit, backgroundNode)).toContain('requestQuit(0)')
+    expect(main.slice(backgroundNode, show)).toContain('return')
   })
 })

--- a/dsh-plugin-desktop-beta/tests/desktop-runtime-environment.spec.ts
+++ b/dsh-plugin-desktop-beta/tests/desktop-runtime-environment.spec.ts
@@ -11,9 +11,9 @@ import {
   symlinkSync,
   writeFileSync,
 } from 'node:fs'
-import { syncBuiltinESMExports } from 'node:module'
+import { createRequire, syncBuiltinESMExports } from 'node:module'
 import { tmpdir } from 'node:os'
-import { basename, delimiter as pathDelimiter, dirname, join } from 'node:path'
+import { basename, delimiter as pathDelimiter, dirname, join, resolve } from 'node:path'
 import { pathToFileURL } from 'node:url'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import {
@@ -101,9 +101,9 @@ describe('desktop Host pnpm runtime', () => {
     expect(node).toContain(`ELECTRON_RUN_AS_NODE=1 exec`)
     expect(node).toContain('--require "$runtime_clear_environment" "$@"')
     expect(node).not.toContain('npm_config_')
-    expect(readFileSync(installation.clearEnvironmentPath, 'utf8')).toContain(
-      "name.toUpperCase() === 'ELECTRON_RUN_AS_NODE'",
-    )
+    const clearEnvironment = readFileSync(installation.clearEnvironmentPath, 'utf8')
+    expect(clearEnvironment).toContain("process.execPath = require('node:path').join(__dirname, 'node-bin', 'node')")
+    expect(clearEnvironment).toContain("name.toUpperCase() === 'ELECTRON_RUN_AS_NODE'")
 
     expect(environment).toEqual({
       ...original,
@@ -136,14 +136,14 @@ describe('desktop Host pnpm runtime', () => {
     expect(environment).toEqual(original)
   })
 
-  it('clears every RunAsNode casing before the requested Node entry executes', () => {
+  it('publishes the POSIX shim as process.execPath and clears every RunAsNode casing', () => {
     const stateDir = join(temporaryDirectory(), 'runtime')
     const installation = installDesktopPnpmRuntime(options(stateDir, 'linux', { PATH: '/usr/bin' }))
     const result = spawnSync(process.execPath, [
       '--import',
       pathToFileURL(installation.clearEnvironmentPath).href,
       '-e',
-      'process.stdout.write(JSON.stringify(Object.keys(process.env).filter(name => name.toUpperCase() === "ELECTRON_RUN_AS_NODE")))',
+      'process.stdout.write(JSON.stringify({ execPath: process.execPath, runAsNode: Object.keys(process.env).filter(name => name.toUpperCase() === "ELECTRON_RUN_AS_NODE") }))',
     ], {
       encoding: 'utf8',
       env: {
@@ -155,7 +155,10 @@ describe('desktop Host pnpm runtime', () => {
 
     expect(result.error).toBeUndefined()
     expect(result.status).toBe(0)
-    expect(result.stdout).toBe('[]')
+    expect(JSON.parse(result.stdout)).toEqual({
+      execPath: installation.nodeShimPath,
+      runAsNode: [],
+    })
     installation.dispose()
   })
 
@@ -200,19 +203,81 @@ describe('desktop Host pnpm runtime', () => {
 
     expect(result.error).toBeUndefined()
     expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(0)
-    expect(JSON.parse(readFileSync(captureOutput, 'utf8'))).toEqual({
+    const capture = JSON.parse(readFileSync(captureOutput, 'utf8')) as Record<string, unknown>
+    expect(capture).toMatchObject({
       ignoresMinimumReleaseAge: true,
-      runAsNode: [],
+      runAsNode: process.platform === 'win32' ? ['ELECTRON_RUN_AS_NODE'] : [],
       runtime: 'electron',
       target: '43.4.0',
       disturl: 'https://electronjs.org/headers',
-      node: installation.nodeShimPath,
-      path: `${installation.nodeBinDir}${pathDelimiter}${environment.PATH ?? ''}`,
     })
+    expect(resolve(String(capture.node))).toBe(resolve(installation.nodeShimPath))
+    const [capturedNodeBinDir, ...capturedPath] = String(capture.path).split(pathDelimiter)
+    expect(resolve(capturedNodeBinDir ?? '')).toBe(resolve(installation.nodeBinDir))
+    expect(capturedPath.join(pathDelimiter)).toBe(environment.PATH ?? '')
     expect(environment).not.toHaveProperty('ELECTRON_RUN_AS_NODE')
     expect(environment).not.toHaveProperty('npm_config_runtime')
     installation.dispose()
   })
+
+  it.runIf(process.platform === 'win32')(
+    'keeps process.execPath descendants in Electron Node mode on Windows',
+    () => {
+      const root = temporaryDirectory()
+      const childEntry = join(root, 'child.mjs')
+      const parentEntry = join(root, 'parent.mjs')
+      const output = join(root, 'result.json')
+      const electronExecutable = createRequire(import.meta.url)('electron') as string
+      writeFileSync(childEntry, [
+        "process.stdout.write('child-stdout')",
+        "process.stderr.write('child-stderr')",
+        'process.exitCode = 23',
+        '',
+      ].join('\n'))
+      writeFileSync(parentEntry, [
+        "import { spawnSync } from 'node:child_process'",
+        "import { writeFileSync } from 'node:fs'",
+        'const [childEntry, output] = process.argv.slice(2)',
+        "const child = spawnSync(process.execPath, [childEntry], { encoding: 'utf8', windowsHide: true })",
+        'writeFileSync(output, JSON.stringify({',
+        '  execPath: process.execPath,',
+        "  runAsNode: Object.keys(process.env).filter(name => name.toUpperCase() === 'ELECTRON_RUN_AS_NODE'),",
+        '  child: { status: child.status, stdout: child.stdout, stderr: child.stderr },',
+        '}))',
+        '',
+      ].join('\n'))
+      const installation = installDesktopPnpmRuntime({
+        ...options(join(root, 'runtime'), 'win32', { Path: process.env.Path }),
+        appExecutable: electronExecutable,
+        pnpmBinPath: parentEntry,
+      })
+
+      const result = spawnSync(electronExecutable, [
+        '--require',
+        installation.clearEnvironmentPath,
+        parentEntry,
+        childEntry,
+        output,
+      ], {
+        encoding: 'utf8',
+        env: { ...process.env, ELECTRON_RUN_AS_NODE: '1' },
+        timeout: 30_000,
+        windowsHide: true,
+      })
+
+      expect(result.error).toBeUndefined()
+      expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(0)
+      const capture = JSON.parse(readFileSync(output, 'utf8')) as Record<string, unknown>
+      expect(resolve(String(capture.execPath))).toBe(resolve(electronExecutable))
+      expect(capture.runAsNode).toEqual(['ELECTRON_RUN_AS_NODE'])
+      expect(capture.child).toEqual({
+        status: 23,
+        stdout: 'child-stdout',
+        stderr: 'child-stderr',
+      })
+      installation.dispose()
+    },
+  )
 
   it('creates Windows batch shims without publishing the private Node directory', () => {
     const stateDir = join(temporaryDirectory(), 'runtime-state')
@@ -243,6 +308,9 @@ describe('desktop Host pnpm runtime', () => {
     expect(node).toContain('set "ELECTRON_RUN_AS_NODE=1"')
     expect(node).toContain('--require "%DSH_RUNTIME_PRIVATE%\\clear-env.cjs" %*')
     expect(node).not.toContain('npm_config_')
+    expect(readFileSync(installation.clearEnvironmentPath, 'utf8')).not.toContain(
+      "name.toUpperCase() === 'ELECTRON_RUN_AS_NODE'",
+    )
 
     expect(environment).toEqual({
       Path: `${installation.pathDir};C:\\Windows\\System32;C:\\Windows`,

--- a/dsh-plugin-desktop/src/desktop-installer-quit.ts
+++ b/dsh-plugin-desktop/src/desktop-installer-quit.ts
@@ -8,3 +8,26 @@ export function isDesktopInstallerQuitRequest(
 ): boolean {
   return platform === 'win32' && argv.includes(DESKTOP_INSTALLER_QUIT_FLAG)
 }
+
+const NODE_ENTRY = /\.(?:c|m)?js$/iu
+
+/**
+ * Identify an Electron executable that was accidentally re-entered as a GUI
+ * while a background Node command was trying to launch a descendant.
+ *
+ * Desktop does not accept JavaScript documents or Node loader flags as GUI
+ * launch arguments. Suppressing these requests therefore preserves explicit
+ * application launches while preventing an internal command from focusing the
+ * existing window if its RunAsNode environment is ever lost.
+ */
+export function isDesktopBackgroundNodeRequest(argv: readonly string[]): boolean {
+  return argv.slice(1).some(argument => {
+    const normalized = argument.replace(/^file:\/\//iu, '').split(/[?#]/u, 1)[0] ?? ''
+    return NODE_ENTRY.test(normalized)
+      || argument === '--require'
+      || argument.startsWith('--require=')
+      || argument === '--import'
+      || argument.startsWith('--import=')
+      || argument === '--expose-internals'
+  })
+}

--- a/dsh-plugin-desktop/src/desktop-runtime-environment.ts
+++ b/dsh-plugin-desktop/src/desktop-runtime-environment.ts
@@ -53,7 +53,7 @@ export interface DesktopPnpmRuntimeInstallation {
   nodeBinDir: string
   /** Private Node command shim used by pnpm lifecycle scripts. */
   nodeShimPath: string
-  /** Preloaded module that removes Electron RunAsNode from child environments. */
+  /** Preloaded module that preserves the platform's safe Node descendant identity. */
   clearEnvironmentPath: string
   /** Remove this installation's PATH entry without deleting persistent generated files. */
   dispose(): void
@@ -335,9 +335,16 @@ function installRuntimeGeneration(stateDir: string, plan: RuntimeGenerationPlan)
   return { root, obsoletePathDirectories }
 }
 
-/** Module preloaded into RunAsNode children before their requested entry. */
-function clearEnvironmentModule(): string {
+/** Keep descendants in Node mode on Windows, where the private shim is a non-executable batch file. */
+function clearEnvironmentModule(platform: NodeJS.Platform): string {
+  if (platform === 'win32') {
+    return [
+      '// process.execPath is the Electron executable; its Node descendants must retain RunAsNode.',
+      '',
+    ].join('\n')
+  }
   return [
+    `process.execPath = require('node:path').join(__dirname, 'node-bin', 'node')`,
     `for (const name of Object.keys(process.env)) {`,
     `  if (name.toUpperCase() === '${RUN_AS_NODE}') delete process.env[name]`,
     '}',
@@ -563,7 +570,7 @@ export function installDesktopPnpmRuntime(options: DesktopPnpmRuntimeOptions): D
     [
       {
         relativePath: 'private/clear-env.cjs',
-        contents: clearEnvironmentModule(),
+        contents: clearEnvironmentModule(options.platform),
         mode: PRIVATE_FILE_MODE,
       },
       {

--- a/dsh-plugin-desktop/src/main.ts
+++ b/dsh-plugin-desktop/src/main.ts
@@ -17,7 +17,10 @@ import { resolveDshHome } from '@deepseek-ai/dsh-home-paths'
 import { DSH_LAUNCH_ENVIRONMENT_KEY } from '@deepseek-ai/dsh-launch-environment'
 import type {} from '@deepseek-ai/dsh-web-app'
 import type {} from '@deepseek-ai/dsh-client-connection'
-import { isDesktopInstallerQuitRequest } from './desktop-installer-quit.ts'
+import {
+  isDesktopBackgroundNodeRequest,
+  isDesktopInstallerQuitRequest,
+} from './desktop-installer-quit.ts'
 import { createDesktopBrowserAccess } from './desktop-browser-access.ts'
 import {
   installDesktopDshRuntime,
@@ -602,6 +605,9 @@ async function start(): Promise<void> {
   app.on('second-instance', (_event, argv) => {
     if (isDesktopInstallerQuitRequest(argv, process.platform)) {
       requestQuit(0)
+      return
+    }
+    if (isDesktopBackgroundNodeRequest(argv)) {
       return
     }
     if (!showPreHostSurface()) runtime.show()

--- a/dsh-plugin-desktop/tests/desktop-installer-quit.spec.ts
+++ b/dsh-plugin-desktop/tests/desktop-installer-quit.spec.ts
@@ -3,6 +3,7 @@ import { join } from 'node:path'
 import { describe, expect, it } from 'vitest'
 import {
   DESKTOP_INSTALLER_QUIT_FLAG,
+  isDesktopBackgroundNodeRequest,
   isDesktopInstallerQuitRequest,
 } from '../src/desktop-installer-quit.ts'
 
@@ -20,6 +21,15 @@ describe('Desktop installer quit request', () => {
     )).toBe(false)
   })
 
+  it('distinguishes background Node re-entry from an explicit application launch', () => {
+    expect(isDesktopBackgroundNodeRequest(['DSH Desktop.exe'])).toBe(false)
+    expect(isDesktopBackgroundNodeRequest(['DSH Desktop.exe', '--profile', 'desktop'])).toBe(false)
+    expect(isDesktopBackgroundNodeRequest(['DSH Desktop.exe', 'C:\\app\\pnpm\\bin\\pnpm.mjs', 'install'])).toBe(true)
+    expect(isDesktopBackgroundNodeRequest(['DSH Desktop.exe', '--require', 'C:\\runtime\\clear-env.cjs'])).toBe(true)
+    expect(isDesktopBackgroundNodeRequest(['DSH Desktop.exe', '--import=file:///runtime/clear-env.mjs'])).toBe(true)
+    expect(isDesktopBackgroundNodeRequest(['DSH Desktop.exe', '--expose-internals', 'desktop-cli.js'])).toBe(true)
+  })
+
   it('handles first- and second-instance requests without showing a window', () => {
     const main = readFileSync(join(process.cwd(), 'src', 'main.ts'), 'utf8')
     const lock = main.indexOf('if (!app.requestSingleInstanceLock())')
@@ -32,6 +42,7 @@ describe('Desktop installer quit request', () => {
       'if (isDesktopInstallerQuitRequest(argv, process.platform))',
       secondInstance,
     )
+    const backgroundNode = main.indexOf('if (isDesktopBackgroundNodeRequest(argv))', secondInstance)
     const show = main.indexOf('if (!showPreHostSurface()) runtime.show()', secondInstance)
 
     expect(lock).toBeGreaterThanOrEqual(0)
@@ -39,8 +50,9 @@ describe('Desktop installer quit request', () => {
     expect(earlyQuit).toBeLessThan(startup)
     expect(secondInstance).toBeGreaterThan(startup)
     expect(secondQuit).toBeGreaterThan(secondInstance)
-    expect(secondQuit).toBeLessThan(show)
-    expect(show).toBeGreaterThan(secondQuit)
-    expect(main.slice(secondQuit, show)).toContain('requestQuit(0)')
+    expect(backgroundNode).toBeGreaterThan(secondQuit)
+    expect(show).toBeGreaterThan(backgroundNode)
+    expect(main.slice(secondQuit, backgroundNode)).toContain('requestQuit(0)')
+    expect(main.slice(backgroundNode, show)).toContain('return')
   })
 })

--- a/dsh-plugin-desktop/tests/desktop-runtime-environment.spec.ts
+++ b/dsh-plugin-desktop/tests/desktop-runtime-environment.spec.ts
@@ -11,9 +11,9 @@ import {
   symlinkSync,
   writeFileSync,
 } from 'node:fs'
-import { syncBuiltinESMExports } from 'node:module'
+import { createRequire, syncBuiltinESMExports } from 'node:module'
 import { tmpdir } from 'node:os'
-import { basename, delimiter as pathDelimiter, dirname, join } from 'node:path'
+import { basename, delimiter as pathDelimiter, dirname, join, resolve } from 'node:path'
 import { pathToFileURL } from 'node:url'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import {
@@ -101,9 +101,9 @@ describe('desktop Host pnpm runtime', () => {
     expect(node).toContain(`ELECTRON_RUN_AS_NODE=1 exec`)
     expect(node).toContain('--require "$runtime_clear_environment" "$@"')
     expect(node).not.toContain('npm_config_')
-    expect(readFileSync(installation.clearEnvironmentPath, 'utf8')).toContain(
-      "name.toUpperCase() === 'ELECTRON_RUN_AS_NODE'",
-    )
+    const clearEnvironment = readFileSync(installation.clearEnvironmentPath, 'utf8')
+    expect(clearEnvironment).toContain("process.execPath = require('node:path').join(__dirname, 'node-bin', 'node')")
+    expect(clearEnvironment).toContain("name.toUpperCase() === 'ELECTRON_RUN_AS_NODE'")
 
     expect(environment).toEqual({
       ...original,
@@ -136,14 +136,14 @@ describe('desktop Host pnpm runtime', () => {
     expect(environment).toEqual(original)
   })
 
-  it('clears every RunAsNode casing before the requested Node entry executes', () => {
+  it('publishes the POSIX shim as process.execPath and clears every RunAsNode casing', () => {
     const stateDir = join(temporaryDirectory(), 'runtime')
     const installation = installDesktopPnpmRuntime(options(stateDir, 'linux', { PATH: '/usr/bin' }))
     const result = spawnSync(process.execPath, [
       '--import',
       pathToFileURL(installation.clearEnvironmentPath).href,
       '-e',
-      'process.stdout.write(JSON.stringify(Object.keys(process.env).filter(name => name.toUpperCase() === "ELECTRON_RUN_AS_NODE")))',
+      'process.stdout.write(JSON.stringify({ execPath: process.execPath, runAsNode: Object.keys(process.env).filter(name => name.toUpperCase() === "ELECTRON_RUN_AS_NODE") }))',
     ], {
       encoding: 'utf8',
       env: {
@@ -155,7 +155,10 @@ describe('desktop Host pnpm runtime', () => {
 
     expect(result.error).toBeUndefined()
     expect(result.status).toBe(0)
-    expect(result.stdout).toBe('[]')
+    expect(JSON.parse(result.stdout)).toEqual({
+      execPath: installation.nodeShimPath,
+      runAsNode: [],
+    })
     installation.dispose()
   })
 
@@ -200,19 +203,81 @@ describe('desktop Host pnpm runtime', () => {
 
     expect(result.error).toBeUndefined()
     expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(0)
-    expect(JSON.parse(readFileSync(captureOutput, 'utf8'))).toEqual({
+    const capture = JSON.parse(readFileSync(captureOutput, 'utf8')) as Record<string, unknown>
+    expect(capture).toMatchObject({
       ignoresMinimumReleaseAge: true,
-      runAsNode: [],
+      runAsNode: process.platform === 'win32' ? ['ELECTRON_RUN_AS_NODE'] : [],
       runtime: 'electron',
       target: '43.4.0',
       disturl: 'https://electronjs.org/headers',
-      node: installation.nodeShimPath,
-      path: `${installation.nodeBinDir}${pathDelimiter}${environment.PATH ?? ''}`,
     })
+    expect(resolve(String(capture.node))).toBe(resolve(installation.nodeShimPath))
+    const [capturedNodeBinDir, ...capturedPath] = String(capture.path).split(pathDelimiter)
+    expect(resolve(capturedNodeBinDir ?? '')).toBe(resolve(installation.nodeBinDir))
+    expect(capturedPath.join(pathDelimiter)).toBe(environment.PATH ?? '')
     expect(environment).not.toHaveProperty('ELECTRON_RUN_AS_NODE')
     expect(environment).not.toHaveProperty('npm_config_runtime')
     installation.dispose()
   })
+
+  it.runIf(process.platform === 'win32')(
+    'keeps process.execPath descendants in Electron Node mode on Windows',
+    () => {
+      const root = temporaryDirectory()
+      const childEntry = join(root, 'child.mjs')
+      const parentEntry = join(root, 'parent.mjs')
+      const output = join(root, 'result.json')
+      const electronExecutable = createRequire(import.meta.url)('electron') as string
+      writeFileSync(childEntry, [
+        "process.stdout.write('child-stdout')",
+        "process.stderr.write('child-stderr')",
+        'process.exitCode = 23',
+        '',
+      ].join('\n'))
+      writeFileSync(parentEntry, [
+        "import { spawnSync } from 'node:child_process'",
+        "import { writeFileSync } from 'node:fs'",
+        'const [childEntry, output] = process.argv.slice(2)',
+        "const child = spawnSync(process.execPath, [childEntry], { encoding: 'utf8', windowsHide: true })",
+        'writeFileSync(output, JSON.stringify({',
+        '  execPath: process.execPath,',
+        "  runAsNode: Object.keys(process.env).filter(name => name.toUpperCase() === 'ELECTRON_RUN_AS_NODE'),",
+        '  child: { status: child.status, stdout: child.stdout, stderr: child.stderr },',
+        '}))',
+        '',
+      ].join('\n'))
+      const installation = installDesktopPnpmRuntime({
+        ...options(join(root, 'runtime'), 'win32', { Path: process.env.Path }),
+        appExecutable: electronExecutable,
+        pnpmBinPath: parentEntry,
+      })
+
+      const result = spawnSync(electronExecutable, [
+        '--require',
+        installation.clearEnvironmentPath,
+        parentEntry,
+        childEntry,
+        output,
+      ], {
+        encoding: 'utf8',
+        env: { ...process.env, ELECTRON_RUN_AS_NODE: '1' },
+        timeout: 30_000,
+        windowsHide: true,
+      })
+
+      expect(result.error).toBeUndefined()
+      expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(0)
+      const capture = JSON.parse(readFileSync(output, 'utf8')) as Record<string, unknown>
+      expect(resolve(String(capture.execPath))).toBe(resolve(electronExecutable))
+      expect(capture.runAsNode).toEqual(['ELECTRON_RUN_AS_NODE'])
+      expect(capture.child).toEqual({
+        status: 23,
+        stdout: 'child-stdout',
+        stderr: 'child-stderr',
+      })
+      installation.dispose()
+    },
+  )
 
   it('creates Windows batch shims without publishing the private Node directory', () => {
     const stateDir = join(temporaryDirectory(), 'runtime-state')
@@ -243,6 +308,9 @@ describe('desktop Host pnpm runtime', () => {
     expect(node).toContain('set "ELECTRON_RUN_AS_NODE=1"')
     expect(node).toContain('--require "%DSH_RUNTIME_PRIVATE%\\clear-env.cjs" %*')
     expect(node).not.toContain('npm_config_')
+    expect(readFileSync(installation.clearEnvironmentPath, 'utf8')).not.toContain(
+      "name.toUpperCase() === 'ELECTRON_RUN_AS_NODE'",
+    )
 
     expect(environment).toEqual({
       Path: `${installation.pathDir};C:\\Windows\\System32;C:\\Windows`,


### PR DESCRIPTION
## Summary / 摘要

Fix the remaining window-focus regression reported in #822.

修复 #822 中仍然存在的窗口意外获得焦点问题。

The earlier fix in #824 addressed the delayed `ready-to-show` startup race, but it did not cover a separate path: a background Node command could launch the Electron executable through `process.execPath`, causing it to re-enter as a GUI instance. The primary instance would then receive a `second-instance` event and bring the existing window to the foreground.

此前 #824 修复了延迟触发 `ready-to-show` 导致的启动竞态，但没有覆盖另一条路径：后台 Node 命令可能通过 `process.execPath` 再次启动 Electron 可执行文件，使其作为 GUI 实例运行。主实例随后收到 `second-instance` 事件，并将已有窗口带到前台。

This PR:

- Keeps `ELECTRON_RUN_AS_NODE` for Windows descendants that launch through `process.execPath`.
- Uses the private Node shim as `process.execPath` before clearing `ELECTRON_RUN_AS_NODE` on macOS and Linux.
- Prevents background Node re-entry requests from calling `runtime.show()` in the `second-instance` handler.
- Applies the same changes to the Stable and Beta desktop packages.
- Adds regression coverage, including a real Electron subprocess probe on Windows.
- Restores the `deepseek-harness` submodule pointer changed by #824 from `cd5ef814...` to the repository’s expected pinned revision, `d347e703...`.
- Does not modify any source files inside the `deepseek-harness` submodule.

本 PR：

- 在 Windows 上为通过 `process.execPath` 启动的后代进程保留 `ELECTRON_RUN_AS_NODE`。
- 在 macOS 和 Linux 上清除 `ELECTRON_RUN_AS_NODE` 前，将私有 Node shim 设置为 `process.execPath`。
- 阻止后台 Node 重入请求在 `second-instance` 处理器中调用 `runtime.show()`。
- 同步修改 Stable 和 Beta 桌面包。
- 增加回归测试，包括 Windows 上真实的 Electron 子进程测试。
- 将 #824 改动的 `deepseek-harness` submodule 指针从 `cd5ef814...` 恢复到仓库预期的固定版本 `d347e703...`。
- 没有修改 `deepseek-harness` submodule 内的任何源码。

## Related Issues / 关联 Issue

Fixes #822

Related to #830 and #824.

## Type / 类型

- [x] Bug fix / 问题修复
- [ ] Feature / 新功能
- [ ] Documentation / 文档
- [ ] Release or packaging / 发布或打包
- [ ] Tests only / 仅测试
- [ ] Other / 其他

## Platforms / 影响平台

- [x] Windows installer / Windows 安装包
- [x] Windows portable ZIP / Windows 便携版 ZIP
- [x] macOS Apple Silicon
- [x] macOS Intel
- [x] macOS Universal package / macOS 通用安装包
- [x] Linux
- [ ] Not platform-specific / 与平台无关

## Verification / 验证

- [x] `corepack yarn check:layout`
- [ ] `corepack yarn typecheck`
- [ ] `corepack yarn test`
- [ ] `corepack yarn check`
- [ ] Platform package smoke / 平台打包或启动冒烟
- [ ] Manual test / 人工测试

Additional commands actually run:

实际执行的其他命令：

- `corepack yarn --cwd dsh-plugin-desktop typecheck`
- `corepack yarn --cwd dsh-plugin-desktop-beta typecheck`
- `corepack yarn --cwd dsh-plugin-desktop test tests/desktop-installer-quit.spec.ts`
  - 3 tests passed.
- `corepack yarn --cwd dsh-plugin-desktop test tests/desktop-runtime-environment.spec.ts -t "publishes the POSIX shim|keeps process.execPath descendants|creates Windows batch shims"`
  - 3 tests passed; 15 unrelated tests skipped.
- `corepack yarn --cwd dsh-plugin-desktop-beta test tests/desktop-installer-quit.spec.ts`
  - 3 tests passed.
- `corepack yarn --cwd dsh-plugin-desktop-beta test tests/desktop-runtime-environment.spec.ts -t "publishes the POSIX shim|keeps process.execPath descendants|creates Windows batch shims"`
  - 3 tests passed; 15 unrelated tests skipped.

Running the complete `desktop-runtime-environment.spec.ts` file on the current Windows host also encountered two existing `EPERM` failures because the host cannot create test symlinks, plus one existing cross-platform PATH simulation assertion. The regression tests added for this fix passed.

在当前 Windows 环境运行完整的 `desktop-runtime-environment.spec.ts` 时，还有两个既有测试因为系统没有创建测试符号链接的权限而出现 `EPERM`，以及一个既有的跨平台 PATH 模拟断言失败。本次修复新增和涉及的回归测试均已通过。

No packaged application or affected-user manual verification has been completed yet.

尚未完成打包应用冒烟测试或受影响用户环境下的人工验证。

## Release Notes / 发布说明

Fixed an issue where background package-management or Node subprocess activity could unexpectedly bring the DSH Desktop window to the foreground.

修复后台包管理或 Node 子进程活动可能意外将 DSH Desktop 窗口带到前台的问题。