### PR TITLE
fix(stable): isolate core bundle overlay from beta profile

### DIFF
--- a/dsh-plugin-desktop-beta/src/module-resolution.ts
+++ b/dsh-plugin-desktop-beta/src/module-resolution.ts
@@ -206,6 +206,36 @@ function isObsoleteProfileFallbackPath(
   return isAsarPath(candidate) || isSharedFallbackPath(registration, candidate)
 }
 
+function isLinkedProfileModule(
+  registration: ProfileResolverRegistration,
+  parentURL: string | undefined,
+): boolean {
+  const candidate = filePath(parentURL)
+  return candidate !== undefined
+    && !isWithin(registration, registration.profileDirectory, candidate)
+}
+
+function canUseProfileSharedDependency(
+  registration: ProfileResolverRegistration,
+  parentURL: string | undefined,
+  candidate: string,
+): boolean {
+  // A linked Profile plugin may keep dependencies in the Profile-level
+  // node_modules directory. That location is obsolete only when selected as
+  // an overlay root, not when it is a dependency of a linked plugin.
+  return isLinkedProfileModule(registration, parentURL)
+    && isSharedFallbackPath(registration, candidate)
+}
+
+function canUseProfileSharedDependencyUrl(
+  registration: ProfileResolverRegistration,
+  parentURL: string | undefined,
+  candidate: string,
+): boolean {
+  const path = filePath(candidate)
+  return path !== undefined && canUseProfileSharedDependency(registration, parentURL, path)
+}
+
 function isPackageLocalSpecifier(specifier: string): boolean {
   return specifier.startsWith('.') || specifier.startsWith('/') || specifier.startsWith('\\')
     || specifier.startsWith('#')
@@ -469,7 +499,10 @@ function resolveFilenameWithState(
   }
   try {
     const resolved = resolveCommonJsNormally(state, thisArg, request, parent, isMain, options)
-    if (parentSource === 'install' || !isObsoleteProfileFallbackPath(registration, resolved)) {
+    if (parentSource === 'install'
+      || !isObsoleteProfileFallbackPath(registration, resolved)
+      || (parentSource === 'profile'
+        && canUseProfileSharedDependency(registration, parentURL, resolved))) {
       track(registration, pathToFileURL(resolved).href, parentSource)
       return resolved
     }
@@ -478,7 +511,9 @@ function resolveFilenameWithState(
   }
   try {
     const resolved = resolveCommonJsFromAnchor(state, registration, request, 'profile')
-    if (!isObsoleteProfileFallbackPath(registration, resolved)) {
+    if (!isObsoleteProfileFallbackPath(registration, resolved)
+      || (parentSource === 'profile'
+        && canUseProfileSharedDependency(registration, parentURL, resolved))) {
       track(registration, pathToFileURL(resolved).href, 'profile')
       return resolved
     }
@@ -498,6 +533,9 @@ function resolveForRegistration(
   nextResolve: Parameters<ResolveHookSync>[2],
 ): ReturnType<ResolveHookSync> {
   const { registration, boundary, source: parentSource } = parentRegistration
+  // Node may mutate the hook context while delegating to its default resolver;
+  // retain the original module owner for Profile shared-dependency policy.
+  const parentURL = context.parentURL
   const packageName = boundary ? resolvablePackageName(specifier) : undefined
   if (packageName !== undefined) {
     const selected = selectedOverlayCandidate(registration, packageName)
@@ -522,7 +560,10 @@ function resolveForRegistration(
 
   try {
     const resolved = nextResolve(specifier, context)
-    if (parentSource === 'install' || !isObsoleteProfileFallbackUrl(registration, resolved.url)) {
+    if (parentSource === 'install'
+      || !isObsoleteProfileFallbackUrl(registration, resolved.url)
+      || (parentSource === 'profile'
+        && canUseProfileSharedDependencyUrl(registration, parentURL, resolved.url))) {
       track(registration, resolved.url, parentSource)
       return resolved
     }
@@ -532,7 +573,9 @@ function resolveForRegistration(
 
   try {
     const resolved = resolveFromAnchor(state, registration, specifier, 'profile', context, nextResolve)
-    if (!isObsoleteProfileFallbackUrl(registration, resolved.url)) {
+    if (!isObsoleteProfileFallbackUrl(registration, resolved.url)
+      || (parentSource === 'profile'
+        && canUseProfileSharedDependencyUrl(registration, parentURL, resolved.url))) {
       track(registration, resolved.url, 'profile')
       return resolved
     }

--- a/dsh-plugin-desktop-beta/tests/module-resolution.spec.ts
+++ b/dsh-plugin-desktop-beta/tests/module-resolution.spec.ts
@@ -360,6 +360,30 @@ describe('installProfilePackageResolver', () => {
     expect(harness.resolve?.('profile-peer', { parentURL: localDependencyUrl }, nextResolve)).toEqual({ url: profilePeerUrl })
   })
 
+  it('allows linked Profile modules to resolve dependencies from shared Profile node_modules', () => {
+    const profileBaseUrl = 'file:///tmp/dsh/profiles/desktop/package.json'
+    const linkedPluginUrl = 'file:///tmp/dsh/linked-plugins/plugin/index.js'
+    const sharedDependencyUrl = 'file:///tmp/dsh/profiles/node_modules/profile-peer/index.js'
+    installProfilePackageResolver(profileBaseUrl)
+    const nextResolve = vi.fn((specifier: string, context: { parentURL?: string }) => {
+      if (specifier === 'plugin' && context.parentURL === profileBaseUrl) return { url: linkedPluginUrl }
+      if (specifier === 'profile-peer' && context.parentURL === linkedPluginUrl) {
+        // Node's default resolver may mutate the hook context before reporting
+        // a miss. The resolver must retain the original linked-module owner.
+        context.parentURL = profileBaseUrl
+        throw missing(specifier, context.parentURL)
+      }
+      if (specifier === 'profile-peer' && context.parentURL === profileBaseUrl) return { url: sharedDependencyUrl }
+      throw missing(specifier, context.parentURL)
+    })
+    const loaderEntryUrl = import.meta.resolve('@deepseek-ai/cordis-plugin-loader')
+
+    expect(harness.resolve?.('plugin', { parentURL: loaderEntryUrl }, nextResolve))
+      .toEqual({ url: linkedPluginUrl })
+    expect(harness.resolve?.('profile-peer', { parentURL: linkedPluginUrl }, nextResolve))
+      .toEqual({ url: sharedDependencyUrl })
+  })
+
   it('allows a Desktop-selected package to use a missing dependency from the Profile overlay', () => {
     const profileBaseUrl = 'file:///C:/Users/test/profile/package.json'
     const desktopPluginUrl = 'file:///Applications/DSH.app/Contents/Resources/app.asar/node_modules/plugin/index.js'

--- a/dsh-plugin-desktop/src/module-resolution.ts
+++ b/dsh-plugin-desktop/src/module-resolution.ts
@@ -206,6 +206,36 @@ function isObsoleteProfileFallbackPath(
   return isAsarPath(candidate) || isSharedFallbackPath(registration, candidate)
 }
 
+function isLinkedProfileModule(
+  registration: ProfileResolverRegistration,
+  parentURL: string | undefined,
+): boolean {
+  const candidate = filePath(parentURL)
+  return candidate !== undefined
+    && !isWithin(registration, registration.profileDirectory, candidate)
+}
+
+function canUseProfileSharedDependency(
+  registration: ProfileResolverRegistration,
+  parentURL: string | undefined,
+  candidate: string,
+): boolean {
+  // A linked Profile plugin may keep dependencies in the Profile-level
+  // node_modules directory. That location is obsolete only when selected as
+  // an overlay root, not when it is a dependency of a linked plugin.
+  return isLinkedProfileModule(registration, parentURL)
+    && isSharedFallbackPath(registration, candidate)
+}
+
+function canUseProfileSharedDependencyUrl(
+  registration: ProfileResolverRegistration,
+  parentURL: string | undefined,
+  candidate: string,
+): boolean {
+  const path = filePath(candidate)
+  return path !== undefined && canUseProfileSharedDependency(registration, parentURL, path)
+}
+
 function isPackageLocalSpecifier(specifier: string): boolean {
   return specifier.startsWith('.') || specifier.startsWith('/') || specifier.startsWith('\\')
     || specifier.startsWith('#')
@@ -469,7 +499,10 @@ function resolveFilenameWithState(
   }
   try {
     const resolved = resolveCommonJsNormally(state, thisArg, request, parent, isMain, options)
-    if (parentSource === 'install' || !isObsoleteProfileFallbackPath(registration, resolved)) {
+    if (parentSource === 'install'
+      || !isObsoleteProfileFallbackPath(registration, resolved)
+      || (parentSource === 'profile'
+        && canUseProfileSharedDependency(registration, parentURL, resolved))) {
       track(registration, pathToFileURL(resolved).href, parentSource)
       return resolved
     }
@@ -478,7 +511,9 @@ function resolveFilenameWithState(
   }
   try {
     const resolved = resolveCommonJsFromAnchor(state, registration, request, 'profile')
-    if (!isObsoleteProfileFallbackPath(registration, resolved)) {
+    if (!isObsoleteProfileFallbackPath(registration, resolved)
+      || (parentSource === 'profile'
+        && canUseProfileSharedDependency(registration, parentURL, resolved))) {
       track(registration, pathToFileURL(resolved).href, 'profile')
       return resolved
     }
@@ -498,6 +533,9 @@ function resolveForRegistration(
   nextResolve: Parameters<ResolveHookSync>[2],
 ): ReturnType<ResolveHookSync> {
   const { registration, boundary, source: parentSource } = parentRegistration
+  // Node may mutate the hook context while delegating to its default resolver;
+  // retain the original module owner for Profile shared-dependency policy.
+  const parentURL = context.parentURL
   const packageName = boundary ? resolvablePackageName(specifier) : undefined
   if (packageName !== undefined) {
     const selected = selectedOverlayCandidate(registration, packageName)
@@ -522,7 +560,10 @@ function resolveForRegistration(
 
   try {
     const resolved = nextResolve(specifier, context)
-    if (parentSource === 'install' || !isObsoleteProfileFallbackUrl(registration, resolved.url)) {
+    if (parentSource === 'install'
+      || !isObsoleteProfileFallbackUrl(registration, resolved.url)
+      || (parentSource === 'profile'
+        && canUseProfileSharedDependencyUrl(registration, parentURL, resolved.url))) {
       track(registration, resolved.url, parentSource)
       return resolved
     }
@@ -532,7 +573,9 @@ function resolveForRegistration(
 
   try {
     const resolved = resolveFromAnchor(state, registration, specifier, 'profile', context, nextResolve)
-    if (!isObsoleteProfileFallbackUrl(registration, resolved.url)) {
+    if (!isObsoleteProfileFallbackUrl(registration, resolved.url)
+      || (parentSource === 'profile'
+        && canUseProfileSharedDependencyUrl(registration, parentURL, resolved.url))) {
       track(registration, resolved.url, 'profile')
       return resolved
     }

--- a/dsh-plugin-desktop/src/profile.ts
+++ b/dsh-plugin-desktop/src/profile.ts
@@ -257,6 +257,22 @@ function requiredWebPatchReload(): ProfilePatchReload {
   return template.patchReload
 }
 
+/**
+ * Resolve an official bundle from this Desktop installation before consulting
+ * the shared Profile. Stable and Beta can share a DSH home, but their bundled
+ * DSH releases are intentionally different; letting a newer Profile copy of
+ * `dsh-web-app` override Stable makes its patch request packages Stable does
+ * not ship (for example, `dsh-client-file-upload`).
+ */
+function resolveRequiredBundle(
+  packageName: string,
+  options: Parameters<typeof resolveOverlayPackage>[1],
+) {
+  const selection = resolveOverlayPackage(packageName, options)
+  if (!REQUIRED_BUNDLE_SET.has(packageName) || selection.install === undefined) return selection
+  return { ...selection, selected: selection.install }
+}
+
 /** Prepared profile inputs consumed by app-boot. */
 export interface PreparedDesktopProfile {
   /** Harness home shared by the launcher and generated command environment. */
@@ -520,7 +536,7 @@ function loadRecoveryFilteredProfile(
     const isDshMarket = packageName === DESKTOP_MARKET_IDENTITIES.dshMarket.packageName
     if (!isDshMarket && desktopPluginBundleMutable(packageName) && disabledBundles.has(packageName)) continue
     try {
-      const packageDir = resolveOverlayPackage(packageName, {
+      const packageDir = resolveRequiredBundle(packageName, {
         installPackageUrl,
         profilePackageUrl,
       }).selected.packageDir

--- a/dsh-plugin-desktop/tests/module-resolution.spec.ts
+++ b/dsh-plugin-desktop/tests/module-resolution.spec.ts
@@ -360,6 +360,30 @@ describe('installProfilePackageResolver', () => {
     expect(harness.resolve?.('profile-peer', { parentURL: localDependencyUrl }, nextResolve)).toEqual({ url: profilePeerUrl })
   })
 
+  it('allows linked Profile modules to resolve dependencies from shared Profile node_modules', () => {
+    const profileBaseUrl = 'file:///tmp/dsh/profiles/desktop/package.json'
+    const linkedPluginUrl = 'file:///tmp/dsh/linked-plugins/plugin/index.js'
+    const sharedDependencyUrl = 'file:///tmp/dsh/profiles/node_modules/profile-peer/index.js'
+    installProfilePackageResolver(profileBaseUrl)
+    const nextResolve = vi.fn((specifier: string, context: { parentURL?: string }) => {
+      if (specifier === 'plugin' && context.parentURL === profileBaseUrl) return { url: linkedPluginUrl }
+      if (specifier === 'profile-peer' && context.parentURL === linkedPluginUrl) {
+        // Node's default resolver may mutate the hook context before reporting
+        // a miss. The resolver must retain the original linked-module owner.
+        context.parentURL = profileBaseUrl
+        throw missing(specifier, context.parentURL)
+      }
+      if (specifier === 'profile-peer' && context.parentURL === profileBaseUrl) return { url: sharedDependencyUrl }
+      throw missing(specifier, context.parentURL)
+    })
+    const loaderEntryUrl = import.meta.resolve('@deepseek-ai/cordis-plugin-loader')
+
+    expect(harness.resolve?.('plugin', { parentURL: loaderEntryUrl }, nextResolve))
+      .toEqual({ url: linkedPluginUrl })
+    expect(harness.resolve?.('profile-peer', { parentURL: linkedPluginUrl }, nextResolve))
+      .toEqual({ url: sharedDependencyUrl })
+  })
+
   it('allows a Desktop-selected package to use a missing dependency from the Profile overlay', () => {
     const profileBaseUrl = 'file:///C:/Users/test/profile/package.json'
     const desktopPluginUrl = 'file:///Applications/DSH.app/Contents/Resources/app.asar/node_modules/plugin/index.js'

--- a/dsh-plugin-desktop/tests/profile.spec.ts
+++ b/dsh-plugin-desktop/tests/profile.spec.ts
@@ -195,6 +195,39 @@ describe('desktop profile composition', {
     ])
   })
 
+  it('keeps Stable core bundles in the Desktop installation when a shared Profile is newer', () => {
+    const home = temporaryHome()
+    const profileDir = ensureDesktopProfile(home)
+    installBundle(
+      home,
+      '@deepseek-ai/dsh-web-app',
+      [
+        '- insert:',
+        '    - id: newer-profile-web',
+        '      name: newer-profile-web',
+        '',
+      ].join('\n'),
+      '99.0.0',
+    )
+    const manifestPath = join(profileDir, 'package.json')
+    const manifest = JSON.parse(readFileSync(manifestPath, 'utf8')) as Record<string, unknown>
+    writeFileSync(manifestPath, JSON.stringify({
+      ...manifest,
+      dsh: { profile: { bundles: ['@deepseek-ai/dsh-base', '@deepseek-ai/dsh-web-app'] } },
+    }) + '\n')
+
+    const prepared = prepareDesktopProfile(undefined, home, 'darwin')
+    const webLayer = prepared.profile.layers.find(layer => layer.packageName === '@deepseek-ai/dsh-web-app')
+
+    expect(webLayer).toBeDefined()
+    expect(webLayer?.packageDir).not.toBe(join(
+      profileDir,
+      'node_modules',
+      '@deepseek-ai',
+      'dsh-web-app',
+    ))
+  })
+
   it('repairs a base-only CLI profile without replacing dependencies', () => {
     const home = temporaryHome()
     const dir = ensureDesktopProfile(home)


### PR DESCRIPTION
## Summary

- keep Stable core bundles resolved from the Stable Desktop installation
- prevent a newer shared Profile bundle from requesting Beta-only packages
- keep the Beta upstream pinned to dsh-v0.1.3-alpha.1 (d347e703)

## Validation

- Stable Profile tests
- Stable typecheck
- verify-layout

Packaging/dist tests were not run.