### PR TITLE
fix(update): remove release response header validation

### DIFF
--- a/dsh-plugin-desktop-beta/src/update-download.ts
+++ b/dsh-plugin-desktop-beta/src/update-download.ts
@@ -143,7 +143,6 @@ export async function downloadDesktopUpdate(options: DownloadDesktopUpdateOption
       { status: response.status },
     )
   }
-  assertReleaseResponse(response, channel, options.version)
   if (response.body === null) {
     throw new UpdateDownloadError('empty-body', 'The update download service returned an empty body.')
   }
@@ -281,19 +280,6 @@ function validatedReleaseVersion(version: string): string {
     throw new UpdateDownloadError('invalid-options', 'The update version must belong to a supported release channel.')
   }
   return version
-}
-
-function assertReleaseResponse(
-  response: Response,
-  channel: DesktopReleaseChannel,
-  version: string,
-): void {
-  const responseChannel = response.headers.get(DESKTOP_RELEASE_CHANNEL_HEADER)
-  const responseVersion = response.headers.get(DESKTOP_TARGET_VERSION_HEADER)
-  if (channel === 'stable' && responseChannel === null && responseVersion === null) return
-  if (responseChannel !== channel || responseVersion !== version) {
-    throw new UpdateDownloadError('invalid-artifact', 'The update service returned a different release channel or version.')
-  }
 }
 
 function validatedUserDataPath(userDataPath: string): string {

--- a/dsh-plugin-desktop-beta/tests/update-download.spec.ts
+++ b/dsh-plugin-desktop-beta/tests/update-download.spec.ts
@@ -103,15 +103,16 @@ describe('desktop update installer download', () => {
       .toBe('DSH-Desktop-Beta-2.0.5-beta.2-mac.dmg')
   })
 
-  it('rejects a Beta artifact without matching response identity', async () => {
+  it('accepts a Beta artifact without response identity headers', async () => {
     const directory = await temporaryDirectory()
-    await expectFailure(downloadDesktopUpdate({
+    const result = await downloadDesktopUpdate({
       platform: 'darwin',
       version: '2.0.5-beta.2',
       channel: 'beta',
       destinationPath: join(directory, 'DSH-Desktop-Beta-2.0.5-beta.2-mac.dmg'),
       request: async () => chunkedResponse([dmgArtifact()]),
-    }), 'invalid-artifact')
+    })
+    expect(result).toBe(join(directory, 'DSH-Desktop-Beta-2.0.5-beta.2-mac.dmg'))
   })
 
   it('streams a macOS DMG from only the fixed endpoint and atomically completes it', async () => {

--- a/dsh-plugin-desktop/src/update-download.ts
+++ b/dsh-plugin-desktop/src/update-download.ts
@@ -143,7 +143,6 @@ export async function downloadDesktopUpdate(options: DownloadDesktopUpdateOption
       { status: response.status },
     )
   }
-  assertReleaseResponse(response, channel, options.version)
   if (response.body === null) {
     throw new UpdateDownloadError('empty-body', 'The update download service returned an empty body.')
   }
@@ -281,19 +280,6 @@ function validatedReleaseVersion(version: string): string {
     throw new UpdateDownloadError('invalid-options', 'The update version must belong to a supported release channel.')
   }
   return version
-}
-
-function assertReleaseResponse(
-  response: Response,
-  channel: DesktopReleaseChannel,
-  version: string,
-): void {
-  const responseChannel = response.headers.get(DESKTOP_RELEASE_CHANNEL_HEADER)
-  const responseVersion = response.headers.get(DESKTOP_TARGET_VERSION_HEADER)
-  if (channel === 'stable' && responseChannel === null && responseVersion === null) return
-  if (responseChannel !== channel || responseVersion !== version) {
-    throw new UpdateDownloadError('invalid-artifact', 'The update service returned a different release channel or version.')
-  }
 }
 
 function validatedUserDataPath(userDataPath: string): string {


### PR DESCRIPTION
## Summary
- remove response header identity validation from Stable and Beta installer downloads
- keep request headers for release channel and target version selection
- update Beta download coverage to accept responses without identity headers

## Verification
- Stable update-download tests: 23 passed
- Beta update-download tests: 25 passed
- git diff --check