### PR TITLE
fix(windows): remove dialog bottom spacing

### DIFF
--- a/dsh-plugin-desktop-beta/src/desktop-dialog-window.ts
+++ b/dsh-plugin-desktop-beta/src/desktop-dialog-window.ts
@@ -21,6 +21,14 @@ const DIAGNOSTIC_DIALOG_INITIAL_HEIGHT = 460
 const DIALOG_PREFERRED_HEIGHT_OFFSET = 32
 const DIALOG_REVEAL_FALLBACK_MS = 250
 
+/** Windows includes the action row in preferred-size-changed already. */
+export function desktopDialogPreferredHeight(
+  preferredHeight: number,
+  platform: NodeJS.Platform = process.platform,
+): number {
+  return preferredHeight + (platform === 'win32' ? 0 : DIALOG_PREFERRED_HEIGHT_OFFSET)
+}
+
 export interface DesktopDialogOptions {
   readonly type?: 'none' | 'info' | 'error' | 'question' | 'warning'
   readonly title: string
@@ -169,7 +177,7 @@ export class DesktopDialogWindow {
       window.webContents.on('will-redirect', navigate)
       window.webContents.on('preferred-size-changed', (_event, size) => {
         if (!Number.isSafeInteger(size.height) || size.height <= 0) return
-        preferredHeight = size.height + DIALOG_PREFERRED_HEIGHT_OFFSET
+        preferredHeight = desktopDialogPreferredHeight(size.height)
         applyPreferredSize()
       })
       window.webContents.on('did-finish-load', () => {

--- a/dsh-plugin-desktop-beta/tests/desktop-dialog-window.spec.ts
+++ b/dsh-plugin-desktop-beta/tests/desktop-dialog-window.spec.ts
@@ -51,6 +51,7 @@ vi.mock('electron', () => ({ app: electron.app, BrowserWindow: electron.BrowserW
 
 import {
   DesktopDialogWindow,
+  desktopDialogPreferredHeight,
   parseDesktopDialogResponse,
 } from '../src/desktop-dialog-window.ts'
 
@@ -68,7 +69,13 @@ describe('DesktopDialogWindow', () => {
     expect(parseDesktopDialogResponse('https://response/?id=1', 2)).toBeUndefined()
   })
 
+  it('does not add the legacy action-row offset on Windows', () => {
+    expect(desktopDialogPreferredHeight(134, 'win32')).toBe(134)
+    expect(desktopDialogPreferredHeight(134, 'darwin')).toBe(166)
+  })
+
   it('creates a frameless parented modal shadcn window and returns its explicit response', async () => {
+    vi.spyOn(process, 'platform', 'get').mockReturnValue('win32')
     const parent = new electron.BrowserWindow({})
     const dialog = new DesktopDialogWindow({
       type: 'question',
@@ -112,7 +119,7 @@ describe('DesktopDialogWindow', () => {
     preferredSize?.({}, { width: 492, height: 134 })
     expect(window?.setContentSize).not.toHaveBeenCalled()
     window?.webListeners.get('did-finish-load')?.()
-    expect(window?.setContentSize).toHaveBeenCalledWith(480, 166, false)
+    expect(window?.setContentSize).toHaveBeenCalledWith(480, 134, false)
     expect(window?.setBounds).not.toHaveBeenCalled()
     expect(window?.show).toHaveBeenCalledOnce()
     const event = { preventDefault: vi.fn() }
@@ -124,6 +131,7 @@ describe('DesktopDialogWindow', () => {
   })
 
   it('uses a larger scrollable presentation for detailed recovery failures', async () => {
+    vi.spyOn(process, 'platform', 'get').mockReturnValue('win32')
     const parent = new electron.BrowserWindow({})
     const result = new DesktopDialogWindow({
       type: 'error',
@@ -158,7 +166,7 @@ describe('DesktopDialogWindow', () => {
     window?.onceListeners.get('ready-to-show')?.()
     window?.webListeners.get('preferred-size-changed')?.({}, { width: 680, height: 390 })
     window?.webListeners.get('did-finish-load')?.()
-    expect(window?.setContentSize).toHaveBeenCalledWith(680, 422, false)
+    expect(window?.setContentSize).toHaveBeenCalledWith(680, 390, false)
     window?.webListeners.get('will-navigate')?.(
       { preventDefault: vi.fn() },
       'dsh-desktop-dialog://response?id=0',

--- a/dsh-plugin-desktop/src/desktop-dialog-window.ts
+++ b/dsh-plugin-desktop/src/desktop-dialog-window.ts
@@ -20,6 +20,14 @@ const DIAGNOSTIC_DIALOG_INITIAL_HEIGHT = 460
 const DIALOG_PREFERRED_HEIGHT_OFFSET = 32
 const DIALOG_REVEAL_FALLBACK_MS = 250
 
+/** Windows includes the action row in preferred-size-changed already. */
+export function desktopDialogPreferredHeight(
+  preferredHeight: number,
+  platform: NodeJS.Platform = process.platform,
+): number {
+  return preferredHeight + (platform === 'win32' ? 0 : DIALOG_PREFERRED_HEIGHT_OFFSET)
+}
+
 export interface DesktopDialogOptions {
   readonly type?: 'none' | 'info' | 'error' | 'question' | 'warning'
   readonly title: string
@@ -168,7 +176,7 @@ export class DesktopDialogWindow {
       window.webContents.on('will-redirect', navigate)
       window.webContents.on('preferred-size-changed', (_event, size) => {
         if (!Number.isSafeInteger(size.height) || size.height <= 0) return
-        preferredHeight = size.height + DIALOG_PREFERRED_HEIGHT_OFFSET
+        preferredHeight = desktopDialogPreferredHeight(size.height)
         applyPreferredSize()
       })
       window.webContents.on('did-finish-load', () => {

--- a/dsh-plugin-desktop/tests/desktop-dialog-window.spec.ts
+++ b/dsh-plugin-desktop/tests/desktop-dialog-window.spec.ts
@@ -51,6 +51,7 @@ vi.mock('electron', () => ({ app: electron.app, BrowserWindow: electron.BrowserW
 
 import {
   DesktopDialogWindow,
+  desktopDialogPreferredHeight,
   parseDesktopDialogResponse,
 } from '../src/desktop-dialog-window.ts'
 
@@ -68,7 +69,13 @@ describe('DesktopDialogWindow', () => {
     expect(parseDesktopDialogResponse('https://response/?id=1', 2)).toBeUndefined()
   })
 
+  it('does not add the legacy action-row offset on Windows', () => {
+    expect(desktopDialogPreferredHeight(134, 'win32')).toBe(134)
+    expect(desktopDialogPreferredHeight(134, 'darwin')).toBe(166)
+  })
+
   it('creates a frameless parented modal shadcn window and returns its explicit response', async () => {
+    vi.spyOn(process, 'platform', 'get').mockReturnValue('win32')
     const parent = new electron.BrowserWindow({})
     const dialog = new DesktopDialogWindow({
       type: 'question',
@@ -112,7 +119,7 @@ describe('DesktopDialogWindow', () => {
     preferredSize?.({}, { width: 492, height: 134 })
     expect(window?.setContentSize).not.toHaveBeenCalled()
     window?.webListeners.get('did-finish-load')?.()
-    expect(window?.setContentSize).toHaveBeenCalledWith(480, 166, false)
+    expect(window?.setContentSize).toHaveBeenCalledWith(480, 134, false)
     expect(window?.setBounds).not.toHaveBeenCalled()
     expect(window?.show).toHaveBeenCalledOnce()
     const event = { preventDefault: vi.fn() }
@@ -124,6 +131,7 @@ describe('DesktopDialogWindow', () => {
   })
 
   it('uses a larger scrollable presentation for detailed recovery failures', async () => {
+    vi.spyOn(process, 'platform', 'get').mockReturnValue('win32')
     const parent = new electron.BrowserWindow({})
     const result = new DesktopDialogWindow({
       type: 'error',
@@ -158,7 +166,7 @@ describe('DesktopDialogWindow', () => {
     window?.onceListeners.get('ready-to-show')?.()
     window?.webListeners.get('preferred-size-changed')?.({}, { width: 680, height: 390 })
     window?.webListeners.get('did-finish-load')?.()
-    expect(window?.setContentSize).toHaveBeenCalledWith(680, 422, false)
+    expect(window?.setContentSize).toHaveBeenCalledWith(680, 390, false)
     window?.webListeners.get('will-navigate')?.(
       { preventDefault: vi.fn() },
       'dsh-desktop-dialog://response?id=0',


### PR DESCRIPTION
## Summary
- remove the extra bottom spacing from Windows desktop dialogs
- keep stable and Beta dialog behavior aligned
- update focused dialog window tests

## Tests
- corepack yarn workspace dsh-plugin-desktop exec vitest run tests/desktop-dialog-window.spec.ts
- corepack yarn workspace dsh-plugin-desktop-beta exec vitest run tests/desktop-dialog-window.spec.ts