### PR TITLE
fix(desktop): 避免 Windows 安全模式准备时目录重命名失败

### DIFF
--- a/dsh-plugin-desktop-beta/src/safe-mode.ts
+++ b/dsh-plugin-desktop-beta/src/safe-mode.ts
@@ -1,12 +1,10 @@
 /** Disposable, launcher-owned DSH environment used by Desktop Safe Mode. */
 
-import { randomUUID } from 'node:crypto'
 import {
   chmodSync,
   lstatSync,
   mkdirSync,
   readFileSync,
-  renameSync,
   rmSync,
   writeFileSync,
 } from 'node:fs'
@@ -121,34 +119,28 @@ export function cleanupDesktopSafeModeEnvironment(userDataDir: string): boolean 
   return true
 }
 
-/** Create a fresh environment through a sibling staging directory. */
+/** Create a fresh environment and mark it ready only after directory preparation succeeds. */
 export function resetDesktopSafeModeEnvironment(
   userDataDir: string,
   now: () => Date = () => new Date(),
 ): DesktopSafeModePaths {
   const paths = desktopSafeModePaths(userDataDir)
-  const staging = `${paths.rootDir}.creating-${process.pid}-${randomUUID()}`
   cleanupDesktopSafeModeEnvironment(userDataDir)
-  rmSync(staging, { recursive: true, force: true })
   try {
-    const stagingHome = join(staging, 'dsh-home')
-    const stagingUserData = join(staging, 'desktop-state')
-    mkdirSync(stagingHome, { recursive: true, mode: DIRECTORY_MODE })
-    mkdirSync(stagingUserData, { recursive: true, mode: DIRECTORY_MODE })
-    writeFileSync(join(staging, SAFE_MODE_MARKER), `${JSON.stringify({
+    mkdirSync(paths.homeDir, { recursive: true, mode: DIRECTORY_MODE })
+    mkdirSync(paths.userDataDir, { recursive: true, mode: DIRECTORY_MODE })
+    chmodSync(paths.rootDir, DIRECTORY_MODE)
+    chmodSync(paths.homeDir, DIRECTORY_MODE)
+    chmodSync(paths.userDataDir, DIRECTORY_MODE)
+    writeFileSync(markerPath(paths), `${JSON.stringify({
       version: SAFE_MODE_VERSION,
       createdAt: now().toISOString(),
     } satisfies DesktopSafeModeMarkerV1, null, 2)}\n`, {
       flag: 'wx',
       mode: FILE_MODE,
     })
-    renameSync(staging, paths.rootDir)
-    chmodSync(paths.rootDir, DIRECTORY_MODE)
-    chmodSync(paths.homeDir, DIRECTORY_MODE)
-    chmodSync(paths.userDataDir, DIRECTORY_MODE)
     return paths
   } catch (cause) {
-    rmSync(staging, { recursive: true, force: true })
     cleanupDesktopSafeModeEnvironment(userDataDir)
     throw cause
   }

--- a/dsh-plugin-desktop-beta/tests/safe-mode.spec.ts
+++ b/dsh-plugin-desktop-beta/tests/safe-mode.spec.ts
@@ -1,8 +1,9 @@
-import { mkdirSync, readFileSync, writeFileSync } from 'node:fs'
+import * as fileSystem from 'node:fs'
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs'
 import { mkdtemp, rm } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
-import { afterEach, describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import {
   cleanupDesktopSafeModeEnvironment,
   DESKTOP_SAFE_MODE_DEFAULTS,
@@ -12,10 +13,15 @@ import {
   resetDesktopSafeModeEnvironment,
 } from '../src/safe-mode.ts'
 
+vi.mock('node:fs', async (importOriginal) => ({
+  ...await importOriginal<typeof import('node:fs')>(),
+}))
+
 describe('Desktop Safe Mode environment', () => {
   const roots: string[] = []
 
   afterEach(async () => {
+    vi.restoreAllMocks()
     await Promise.all(roots.splice(0).map(async root => { await rm(root, { recursive: true, force: true }) }))
   })
 
@@ -60,6 +66,61 @@ describe('Desktop Safe Mode environment', () => {
       version: 1,
       createdAt: '2026-09-03T00:00:00.000Z',
     })
+  })
+
+  it('creates a usable environment even when directory renames are denied on Windows', async () => {
+    const root = await userData()
+    const rename = vi.spyOn(fileSystem, 'renameSync').mockImplementation(() => {
+      throw Object.assign(new Error('EPERM: operation not permitted, rename'), { code: 'EPERM' })
+    })
+
+    const paths = resetDesktopSafeModeEnvironment(root)
+
+    expect(rename).not.toHaveBeenCalled()
+    expect(existsSync(join(paths.rootDir, 'environment.json'))).toBe(true)
+    expect(ensureDesktopSafeModeEnvironment(root)).toEqual(paths)
+  })
+
+  it('publishes the completion marker only after directories and permissions are ready', async () => {
+    const root = await userData()
+    const paths = desktopSafeModePaths(root)
+    const permissions = vi.spyOn(fileSystem, 'chmodSync')
+
+    resetDesktopSafeModeEnvironment(root, () => {
+      expect(existsSync(paths.homeDir)).toBe(true)
+      expect(existsSync(paths.userDataDir)).toBe(true)
+      expect(permissions).toHaveBeenCalledWith(paths.rootDir, 0o700)
+      expect(permissions).toHaveBeenCalledWith(paths.homeDir, 0o700)
+      expect(permissions).toHaveBeenCalledWith(paths.userDataDir, 0o700)
+      expect(existsSync(join(paths.rootDir, 'environment.json'))).toBe(false)
+      return new Date('2026-09-03T00:00:00.000Z')
+    })
+
+    expect(existsSync(join(paths.rootDir, 'environment.json'))).toBe(true)
+  })
+
+  it('cleans an incomplete environment when writing the completion marker fails', async () => {
+    const root = await userData()
+    const paths = desktopSafeModePaths(root)
+    const failure = Object.assign(new Error('ENOSPC: cannot write completion marker'), { code: 'ENOSPC' })
+    vi.spyOn(fileSystem, 'writeFileSync').mockImplementationOnce(() => { throw failure })
+
+    expect(() => resetDesktopSafeModeEnvironment(root)).toThrow(failure)
+    expect(existsSync(paths.rootDir)).toBe(false)
+    expect(ensureDesktopSafeModeEnvironment(root)).toEqual(paths)
+    expect(existsSync(join(paths.rootDir, 'environment.json'))).toBe(true)
+  })
+
+  it('replaces an interrupted generation that has directories but no completion marker', async () => {
+    const root = await userData()
+    const paths = desktopSafeModePaths(root)
+    mkdirSync(paths.homeDir, { recursive: true })
+    mkdirSync(paths.userDataDir, { recursive: true })
+    writeFileSync(join(paths.homeDir, 'incomplete-session'), 'discard')
+
+    expect(ensureDesktopSafeModeEnvironment(root)).toEqual(paths)
+    expect(existsSync(join(paths.homeDir, 'incomplete-session'))).toBe(false)
+    expect(existsSync(join(paths.rootDir, 'environment.json'))).toBe(true)
   })
 
   it('adopts one prepared Safe Mode generation but resets an invalid environment', async () => {

--- a/dsh-plugin-desktop/src/safe-mode.ts
+++ b/dsh-plugin-desktop/src/safe-mode.ts
@@ -1,12 +1,10 @@
 /** Disposable, launcher-owned DSH environment used by Desktop Safe Mode. */
 
-import { randomUUID } from 'node:crypto'
 import {
   chmodSync,
   lstatSync,
   mkdirSync,
   readFileSync,
-  renameSync,
   rmSync,
   writeFileSync,
 } from 'node:fs'
@@ -122,34 +120,28 @@ export function cleanupDesktopSafeModeEnvironment(userDataDir: string): boolean 
   return true
 }
 
-/** Create a fresh environment through a sibling staging directory. */
+/** Create a fresh environment and mark it ready only after directory preparation succeeds. */
 export function resetDesktopSafeModeEnvironment(
   userDataDir: string,
   now: () => Date = () => new Date(),
 ): DesktopSafeModePaths {
   const paths = desktopSafeModePaths(userDataDir)
-  const staging = `${paths.rootDir}.creating-${process.pid}-${randomUUID()}`
   cleanupDesktopSafeModeEnvironment(userDataDir)
-  rmSync(staging, { recursive: true, force: true })
   try {
-    const stagingHome = join(staging, 'dsh-home')
-    const stagingUserData = join(staging, 'desktop-state')
-    mkdirSync(stagingHome, { recursive: true, mode: DIRECTORY_MODE })
-    mkdirSync(stagingUserData, { recursive: true, mode: DIRECTORY_MODE })
-    writeFileSync(join(staging, SAFE_MODE_MARKER), `${JSON.stringify({
+    mkdirSync(paths.homeDir, { recursive: true, mode: DIRECTORY_MODE })
+    mkdirSync(paths.userDataDir, { recursive: true, mode: DIRECTORY_MODE })
+    chmodSync(paths.rootDir, DIRECTORY_MODE)
+    chmodSync(paths.homeDir, DIRECTORY_MODE)
+    chmodSync(paths.userDataDir, DIRECTORY_MODE)
+    writeFileSync(markerPath(paths), `${JSON.stringify({
       version: SAFE_MODE_VERSION,
       createdAt: now().toISOString(),
     } satisfies DesktopSafeModeMarkerV1, null, 2)}\n`, {
       flag: 'wx',
       mode: FILE_MODE,
     })
-    renameSync(staging, paths.rootDir)
-    chmodSync(paths.rootDir, DIRECTORY_MODE)
-    chmodSync(paths.homeDir, DIRECTORY_MODE)
-    chmodSync(paths.userDataDir, DIRECTORY_MODE)
     return paths
   } catch (cause) {
-    rmSync(staging, { recursive: true, force: true })
     cleanupDesktopSafeModeEnvironment(userDataDir)
     throw cause
   }

--- a/dsh-plugin-desktop/tests/safe-mode.spec.ts
+++ b/dsh-plugin-desktop/tests/safe-mode.spec.ts
@@ -1,3 +1,4 @@
+import * as fileSystem from 'node:fs'
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs'
 import { mkdtemp, rm } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
@@ -13,6 +14,10 @@ import {
   prepareDesktopSafeModeEnvironment,
   resetDesktopSafeModeEnvironment,
 } from '../src/safe-mode.ts'
+
+vi.mock('node:fs', async (importOriginal) => ({
+  ...await importOriginal<typeof import('node:fs')>(),
+}))
 
 describe('Desktop Safe Mode environment', () => {
   const roots: string[] = []
@@ -63,6 +68,61 @@ describe('Desktop Safe Mode environment', () => {
       version: 1,
       createdAt: '2026-09-03T00:00:00.000Z',
     })
+  })
+
+  it('creates a usable environment even when directory renames are denied on Windows', async () => {
+    const root = await userData()
+    const rename = vi.spyOn(fileSystem, 'renameSync').mockImplementation(() => {
+      throw Object.assign(new Error('EPERM: operation not permitted, rename'), { code: 'EPERM' })
+    })
+
+    const paths = resetDesktopSafeModeEnvironment(root)
+
+    expect(rename).not.toHaveBeenCalled()
+    expect(existsSync(join(paths.rootDir, 'environment.json'))).toBe(true)
+    expect(ensureDesktopSafeModeEnvironment(root)).toEqual(paths)
+  })
+
+  it('publishes the completion marker only after directories and permissions are ready', async () => {
+    const root = await userData()
+    const paths = desktopSafeModePaths(root)
+    const permissions = vi.spyOn(fileSystem, 'chmodSync')
+
+    resetDesktopSafeModeEnvironment(root, () => {
+      expect(existsSync(paths.homeDir)).toBe(true)
+      expect(existsSync(paths.userDataDir)).toBe(true)
+      expect(permissions).toHaveBeenCalledWith(paths.rootDir, 0o700)
+      expect(permissions).toHaveBeenCalledWith(paths.homeDir, 0o700)
+      expect(permissions).toHaveBeenCalledWith(paths.userDataDir, 0o700)
+      expect(existsSync(join(paths.rootDir, 'environment.json'))).toBe(false)
+      return new Date('2026-09-03T00:00:00.000Z')
+    })
+
+    expect(existsSync(join(paths.rootDir, 'environment.json'))).toBe(true)
+  })
+
+  it('cleans an incomplete environment when writing the completion marker fails', async () => {
+    const root = await userData()
+    const paths = desktopSafeModePaths(root)
+    const failure = Object.assign(new Error('ENOSPC: cannot write completion marker'), { code: 'ENOSPC' })
+    vi.spyOn(fileSystem, 'writeFileSync').mockImplementationOnce(() => { throw failure })
+
+    expect(() => resetDesktopSafeModeEnvironment(root)).toThrow(failure)
+    expect(existsSync(paths.rootDir)).toBe(false)
+    expect(ensureDesktopSafeModeEnvironment(root)).toEqual(paths)
+    expect(existsSync(join(paths.rootDir, 'environment.json'))).toBe(true)
+  })
+
+  it('replaces an interrupted generation that has directories but no completion marker', async () => {
+    const root = await userData()
+    const paths = desktopSafeModePaths(root)
+    mkdirSync(paths.homeDir, { recursive: true })
+    mkdirSync(paths.userDataDir, { recursive: true })
+    writeFileSync(join(paths.homeDir, 'incomplete-session'), 'discard')
+
+    expect(ensureDesktopSafeModeEnvironment(root)).toEqual(paths)
+    expect(existsSync(join(paths.homeDir, 'incomplete-session'))).toBe(false)
+    expect(existsSync(join(paths.rootDir, 'environment.json'))).toBe(true)
   })
 
   it('adopts one prepared Safe Mode generation but resets an invalid environment', async () => {


### PR DESCRIPTION
## 问题

Windows 运行 `yarn dev` 后进入安全模式，终端记录：

```text
tray command failed: EPERM: operation not permitted, rename
'.../DSH Desktop/safe-mode.creating-...' -> '.../DSH Desktop/safe-mode'
```

失败发生在创建隔离环境时，尚未进入安全模式重启。此前 #849 的恢复窗口修复没有覆盖这个失败点。本次日志能确定失败操作，但尚不能确定拒绝重命名的具体进程或权限因素。

## 修改

- 同步调整 stable / beta 的安全模式环境创建流程，移除 staging 目录整体重命名。
- 清理旧的一次性环境后，直接创建固定隔离目录并设置权限，最后写入 `environment.json` 就绪标记。
- 保留失败清理，以及下次启动对缺失或无效就绪标记的环境重建；不改变正常 DSH Home、Profile 或用户数据路径。
- 两个版本各新增 4 个回归用例：模拟重命名报 `EPERM`、就绪标记写入顺序、标记写入失败清理，以及中断创建后的恢复。

## 验证

- `git diff --check` 通过。
- 按用户要求，本次未在本机运行单元测试、构建或启动 GUI。
- Windows 原生安全模式进入、退出及再次进入仍待用户验证；模拟回归用例不等同于 Windows 实机验证。
- 本 PR 不处理此前 beta 重启时缺包或依赖安装不完整的问题。
