### PR TITLE
fix(desktop): keep ASAR profile module fallbacks resolvable

### DIFF
--- a/dsh-plugin-desktop/src/profile.ts
+++ b/dsh-plugin-desktop/src/profile.ts
@@ -42,7 +42,6 @@ import FileSettingsProvider, {
 } from '@deepseek-ai/dsh-settings-file'
 import { parseAllDocuments, parseDocument } from 'yaml'
 import { findOverlayPackage, resolveOverlayPackage } from './package-overlay.ts'
-import { withAsarModuleResolver } from './asar-module-resolver-state.ts'
 import { DESKTOP_DEFAULT_WEB_PORT } from './desktop-port.ts'
 import {
   desktopBrowserAccessEnabled,
@@ -1143,15 +1142,41 @@ export function prepareDesktopProfile(
 }
 
 /** Maintain the upstream module fallback for one fully resolved Desktop profile. */
-export function healDesktopProfileModuleFallback(home: string, profile?: Profile): Promise<void> {
-  const heal = () => healProfilesModuleFallback({
-    installAnchor: INSTALL_ANCHOR,
+export async function healDesktopProfileModuleFallback(
+  home: string,
+  profile?: Profile,
+  installAnchor: string = INSTALL_ANCHOR,
+): Promise<void> {
+  const heal = (): Promise<void> => healProfilesModuleFallback({
+    installAnchor,
     home,
     ...(profile === undefined ? {} : { profile }),
   })
-  if (!/([\\/])app\.asar\1/u.test(INSTALL_ANCHOR)) return heal()
+  if (!/([\\/])app\.asar\1/u.test(installAnchor)) return heal()
   removeObsoleteDesktopSharedModuleFallback(home)
-  return withAsarModuleResolver(heal)
+  // The upstream fallback only materializes ESM proxies for `pkg`
+  // executables. Electron ASAR needs the same proxy layout: ordinary
+  // filesystem symlinks cannot traverse into app.asar, so disk-based
+  // package probes such as agent-presets would report every row broken.
+  // Keep the marker scoped to the heal so upstream's runtime view of the
+  // process remains unchanged.
+  const processWithPkg = process as NodeJS.Process & { pkg?: unknown }
+  const hadPkg = Object.prototype.hasOwnProperty.call(process, 'pkg')
+  const previousPkg = processWithPkg.pkg
+  Object.defineProperty(process, 'pkg', { value: {}, configurable: true, writable: true })
+  try {
+    await heal()
+  } finally {
+    if (hadPkg) {
+      Object.defineProperty(process, 'pkg', {
+        value: previousPkg,
+        configurable: true,
+        writable: true,
+      })
+    } else {
+      delete (processWithPkg as unknown as Record<string, unknown>).pkg
+    }
+  }
 }
 
 function isDshManagedModuleProxy(directory: string): boolean {

--- a/dsh-plugin-desktop/tests/profile.spec.ts
+++ b/dsh-plugin-desktop/tests/profile.spec.ts
@@ -1,5 +1,6 @@
 import {
   existsSync,
+  lstatSync,
   mkdirSync,
   mkdtempSync,
   readFileSync,
@@ -12,13 +13,18 @@ import { tmpdir } from 'node:os'
 import { dirname, join } from 'node:path'
 import { fileURLToPath, pathToFileURL } from 'node:url'
 import { afterEach, describe, expect, it } from 'vitest'
-import { composeEntries, initProfile, PROFILE_TEMPLATES } from '@deepseek-ai/dsh-app-boot'
+import {
+  composeEntries,
+  initProfile,
+  PROFILE_TEMPLATES,
+} from '@deepseek-ai/dsh-app-boot'
 import {
   DESKTOP_PACKAGE_NAME,
   desktopShellModeFromSettings,
   desktopStartupSettingsFromSettings,
   desktopBundleList,
   ensureDesktopProfile,
+  healDesktopProfileModuleFallback,
   prepareDesktopProfile,
   readDesktopShellMode,
   removeObsoleteDesktopSharedModuleFallback,
@@ -129,6 +135,58 @@ describe('desktop profile composition', {
     expect(existsSync(userManagedShape)).toBe(true)
     expect(readFileSync(join(sharedModules, 'user-note.txt'), 'utf8')).toBe('preserve me\n')
     expect(removeObsoleteDesktopSharedModuleFallback(home)).toBe(0)
+  })
+
+  it('materializes ASAR shared fallbacks as physical ESM proxies', async () => {
+    const home = temporaryHome()
+    const resources = join(home, 'resources')
+    const appAsar = join(resources, 'app.asar')
+    const installAnchor = join(appAsar, 'package.json')
+    const dshPackage = join(
+      appAsar,
+      'node_modules',
+      '@deepseek-ai',
+      'dsh-tool-web',
+    )
+    mkdirSync(join(appAsar, 'lib'), { recursive: true })
+    mkdirSync(dshPackage, { recursive: true })
+    writeFileSync(installAnchor, JSON.stringify({
+      name: 'fixture-desktop',
+      version: '1.0.0',
+      type: 'module',
+      exports: { '.': './lib/index.js' },
+      dependencies: { '@deepseek-ai/dsh-tool-web': '1.0.0' },
+    }) + '\n')
+    writeFileSync(join(appAsar, 'lib', 'index.js'), 'export default {}\n')
+    writeFileSync(join(dshPackage, 'package.json'), JSON.stringify({
+      name: '@deepseek-ai/dsh-tool-web',
+      version: '2.0.0',
+      type: 'module',
+      exports: { '.': './index.js' },
+    }) + '\n')
+    const dshEntry = join(dshPackage, 'index.js')
+    writeFileSync(dshEntry, 'export const marker = "tool-web"\n')
+
+    const processWithPkg = process as NodeJS.Process & { pkg?: unknown }
+    const hadPkg = Object.prototype.hasOwnProperty.call(process, 'pkg')
+    const previousPkg = processWithPkg.pkg
+
+    await healDesktopProfileModuleFallback(home, undefined, installAnchor)
+
+    const proxy = join(home, 'profiles', 'node_modules', '@deepseek-ai', 'dsh-tool-web')
+    expect(lstatSync(proxy).isDirectory()).toBe(true)
+    const manifest = JSON.parse(readFileSync(join(proxy, 'package.json'), 'utf8')) as {
+      dsh?: { moduleFallback?: { targets?: Record<string, string> } }
+      exports?: Record<string, string>
+    }
+    expect(manifest.exports?.['.']).toBe('./entry-0.js')
+    expect(manifest.dsh?.moduleFallback?.targets?.['.'])
+      .toBe(pathToFileURL(dshEntry).href)
+    expect(readFileSync(join(proxy, 'entry-0.js'), 'utf8'))
+      .toContain(pathToFileURL(dshEntry).href)
+
+    expect(Object.prototype.hasOwnProperty.call(process, 'pkg')).toBe(hadPkg)
+    expect(processWithPkg.pkg).toBe(previousPkg)
   })
 
   it('ships a PowerShell-backed minimal preset for Windows', () => {


### PR DESCRIPTION
Packaged Electron startup materializes shared profile module fallbacks as physical ESM proxies instead of filesystem symlinks into app.asar. Disk-based package probes such as agent-presets can then resolve preset plugin rows while actual imports still re-export the logical ASAR entries. Development symlinks to the workspace remain unchanged.

## Summary / 摘要

**碰到的问题**：使用打包后的 Electron 安装包初始化工作空间时会报错：

```
23 rows name plugins that cannot be resolved:
- row "persona": @deepseek-ai/dsh-persona
- row "tool-fs": @deepseek-ai/dsh-tool-fs
- row "plan-mode": @deepseek-ai/dsh-plan-mode
- row "tool-workflow": @deepseek-ai/dsh-tool-workflow
- row "tool-web": @deepseek-ai/dsh-tool-web
...
```

persona、tool-fs、plan-mode、tool-workflow、tool-web 等预设插件在初始化时全部被判定为“无法解析”，导致打包版应用无法正常完成工作空间初始化；同一套代码用 `yarn dev` 启动时不会出现该问题。

**根因**：打包后的 Electron 应用运行在 `app.asar` 中。原 `healDesktopProfileModuleFallback` 会把共享 profile 模块回退创建成指向 `app.asar` 内部路径的普通文件系统 symlink，而磁盘上的 `existsSync` 探测无法穿透 asar，所以 agent-presets 等健康检查把所有预设插件行都判为不可解析。dev 模式链接指向真实工作区目录，因此行为正常。

**修复**：本 PR 让 `healDesktopProfileModuleFallback` 在 ASAR 场景下改为物化 pkg 风格的 physical ESM proxy（真实目录 + re-export），使磁盘探测与实际 ESM 导入解析到同一路径；`process.pkg` 标记只在 heal 期间临时生效，结束后恢复原值，dev 模式行为不变。

**复现步骤**：
1. 构建并安装打包版 Electron 应用
2. 在应用内初始化一个新的工作空间
3. 观察 agent-presets 健康检查报 “23 rows name plugins that cannot be resolved”

## Related Issues / 关联 Issue

N/A

## Type / 类型

- [x] Bug fix / 问题修复
- [ ] Feature / 新功能
- [ ] Documentation / 文档
- [ ] Release or packaging / 发布或打包
- [ ] Tests only / 仅测试
- [ ] Other / 其他

## Platforms / 影响平台

- [ ] Windows installer / Windows 安装包
- [ ] Windows portable ZIP / Windows 便携版 ZIP
- [ ] macOS Apple Silicon
- [ ] macOS Intel
- [ ] macOS Universal package / macOS 通用安装包
- [ ] Linux
- [x] Not platform-specific / 与平台无关

## Verification / 验证

本机实际执行并全部通过的命令：

- `corepack yarn workspace dsh-plugin-desktop vitest run tests/profile.spec.ts`（43/43 通过）
- `corepack yarn workspace dsh-plugin-desktop typecheck`
- `dsh-plugin-desktop` 构建阶段（`check` 中的 build 部分）


- [ ] `corepack yarn check:layout`
- [ ] `corepack yarn typecheck`
- [ ] `corepack yarn test`
- [ ] `corepack yarn check`
- [ ] Platform package smoke / 平台打包或启动冒烟
- [ ] Manual test / 人工测试

## Release Notes / 发布说明

N/A