### PR TITLE
fix(beta): 恢复出厂设置后清除残留桌面配置

### DIFF
--- a/dsh-plugin-desktop-beta/src/desktop-factory-reset.ts
+++ b/dsh-plugin-desktop-beta/src/desktop-factory-reset.ts
@@ -1,9 +1,15 @@
 /** Recoverable factory reset for the active Desktop-owned DSH data directory. */
 
 import { lstatSync } from 'node:fs'
-import { mkdir } from 'node:fs/promises'
+import { mkdir, readdir } from 'node:fs/promises'
 import { isAbsolute, join, parse, relative, resolve, sep } from 'node:path'
 import { DESKTOP_PACKAGE_NAME } from './product-identity.ts'
+import { clearDesktopProfilePreferences } from './profile-preferences.ts'
+import { clearDesktopProfileCheckpoint } from './profile-checkpoint.ts'
+import { clearDesktopSetupWizardState } from './setup-wizard-state.ts'
+import { selectDesktopMarketProvider } from './desktop-market.ts'
+import { clearDesktopProfilePluginState } from './desktop-plugins.ts'
+import { assertDesktopProfileName } from './profile-manager.ts'
 
 const DIRECTORY_MODE = 0o700
 const MAX_PATH_BYTES = 32 * 1024
@@ -11,6 +17,8 @@ const MAX_PATH_BYTES = 32 * 1024
 export interface DesktopFactoryResetOptions {
   /** Exact active DSH Home selected by the launcher. */
   readonly homeDir: string
+  /** Current edition's Electron user-data directory containing external preferences. */
+  readonly userDataDir: string
   /** Directories that must never be reset or be descendants of the reset root. */
   readonly protectedPaths: readonly string[]
   /** Electron shell.trashItem adapter; injected so the safety boundary is testable. */
@@ -75,8 +83,24 @@ export function assertDesktopFactoryResetTarget(
 export async function resetDesktopDataDirectory(
   options: DesktopFactoryResetOptions,
 ): Promise<string> {
-  const target = assertDesktopFactoryResetTarget(options.homeDir, options.protectedPaths)
+  const userDataDir = canonicalPath(options.userDataDir, 'factory-reset user-data directory')
+  const target = assertDesktopFactoryResetTarget(options.homeDir, [...options.protectedPaths, userDataDir])
+  // Startup always recreates desktop, even when it was removed before reset.
+  const profiles = new Set(['desktop', ...await readdir(join(target, 'profiles'))])
   await options.trashItem(target)
+  // Profile identity is path-based, so rebuilding the same Home would otherwise
+  // restore preferences from before reset into the clean settings document.
+  for (const name of profiles) {
+    const profileDir = join(target, 'profiles', name)
+    await clearDesktopProfilePreferences(userDataDir, profileDir)
+    await clearDesktopSetupWizardState(userDataDir, profileDir)
+    clearDesktopProfileCheckpoint(userDataDir, profileDir)
+    // Staging/dependency entries can exist here but cannot own plugin state.
+    try { assertDesktopProfileName(name) } catch { continue }
+    await clearDesktopProfilePluginState(join(userDataDir, 'plugin-management', 'state.json'), name)
+  }
+  // A fresh Profile imports this legacy machine-level selection on first boot.
+  await selectDesktopMarketProvider(userDataDir, 'disabled')
   await mkdir(target, { recursive: false, mode: DIRECTORY_MODE })
   const recreated = lstatSync(target)
   if (!recreated.isDirectory() || recreated.isSymbolicLink()) {

--- a/dsh-plugin-desktop-beta/src/main.ts
+++ b/dsh-plugin-desktop-beta/src/main.ts
@@ -1007,6 +1007,7 @@ async function start(): Promise<void> {
           try {
             await resetDesktopDataDirectory({
               homeDir: recoveryDataLocation.homeDir,
+              userDataDir: marketUserDataDir,
               protectedPaths: [
                 app.getPath('home'),
                 app.getPath('appData'),

--- a/dsh-plugin-desktop-beta/tests/desktop-factory-reset.spec.ts
+++ b/dsh-plugin-desktop-beta/tests/desktop-factory-reset.spec.ts
@@ -7,6 +7,11 @@ import {
   assertDesktopFactoryResetTarget,
   resetDesktopDataDirectory,
 } from '../src/desktop-factory-reset.ts'
+import { readDesktopProfilePreferences, writeDesktopProfilePreferences } from '../src/profile-preferences.ts'
+import { completeOrSkipDesktopSetupWizard, readDesktopSetupWizardState } from '../src/setup-wizard-state.ts'
+import { readDesktopMarketStateForUserData, selectDesktopMarketProvider } from '../src/desktop-market.ts'
+import { readDesktopSetupWizardSettings } from '../src/setup-wizard-settings.ts'
+import { readDesktopDisabledBundles } from '../src/desktop-plugins.ts'
 
 const roots: string[] = []
 
@@ -25,6 +30,88 @@ afterEach(async () => {
 })
 
 describe('Desktop factory reset', () => {
+  it.each([false, true])('drops old preferences before Setup or skip (default directory removed: %s)', async removedDefault => {
+    const { root, home } = await fixture()
+    const userDataDir = join(root, 'desktop-state')
+    const profiles = ['desktop', 'work'].map(name => join(home, 'profiles', name))
+    const unrelated = join(root, 'other-home', 'profiles', 'desktop')
+    const versions = { desktopVersion: '2.0.5-beta.2', dshVersion: '0.1.3-alpha.2', setupRevision: 1 }
+    const oldPreferences = {
+      mode: 'advanced' as const,
+      openBrowser: false,
+      networkExposure: 'loopback' as const,
+      market: 'community-market' as const,
+      notifications: {
+        enabled: false,
+        notifyOnTurnCompletion: false,
+        notifyOnTurnFailure: false,
+        notifyOnJobCompletion: false,
+        notifyOnJobFailure: false,
+      },
+    }
+    for (const profile of [...profiles, unrelated]) {
+      mkdirSync(profile, { recursive: true })
+      await writeDesktopProfilePreferences(userDataDir, profile, oldPreferences)
+      await completeOrSkipDesktopSetupWizard(userDataDir, profile, 'completed', versions)
+    }
+    await selectDesktopMarketProvider(userDataDir, oldPreferences.market)
+    const pluginStatePath = join(userDataDir, 'plugin-management', 'state.json')
+    mkdirSync(join(userDataDir, 'plugin-management'), { recursive: true, mode: 0o700 })
+    writeFileSync(pluginStatePath, JSON.stringify({
+      version: 1,
+      profiles: ['desktop', 'work', 'unrelated'].map(profileName => ({
+        profileName, disabledBundles: ['third-party-plugin'],
+      })),
+    }), { mode: 0o600 })
+    if (removedDefault) await rm(join(home, 'profiles', 'desktop'), { recursive: true })
+    mkdirSync(join(home, 'profiles', 'node_modules'))
+
+    await resetDesktopDataDirectory({
+      homeDir: home,
+      userDataDir,
+      protectedPaths: [root],
+      trashItem: async path => { await rename(path, join(root, 'trashed-dsh')) },
+    })
+
+    for (const profile of profiles) {
+      expect(readDesktopProfilePreferences(userDataDir, profile)).toBeUndefined()
+      expect(readDesktopSetupWizardState(userDataDir, profile)).toBeUndefined()
+      const settings = join(profile, 'settings.yaml')
+      const defaults = readDesktopSetupWizardSettings(settings)
+      expect(defaults.mode).toBe('compatibility')
+      expect(defaults.notifications.enabled).toBe(true)
+      await completeOrSkipDesktopSetupWizard(userDataDir, profile, 'skipped', versions)
+      expect(readDesktopSetupWizardSettings(settings)).toEqual(defaults)
+    }
+    expect(readDesktopMarketStateForUserData(userDataDir).requested).toBe('disabled')
+    expect([...readDesktopDisabledBundles(pluginStatePath, 'desktop')]).toEqual([])
+    expect([...readDesktopDisabledBundles(pluginStatePath, 'work')]).toEqual([])
+    expect([...readDesktopDisabledBundles(pluginStatePath, 'unrelated')]).toEqual(['third-party-plugin'])
+    expect(readDesktopProfilePreferences(userDataDir, unrelated)).toMatchObject(oldPreferences)
+    expect(readDesktopSetupWizardState(userDataDir, unrelated)?.outcome).toBe('completed')
+  })
+
+  it('preserves external settings when moving the data directory to trash fails', async () => {
+    const { root, home } = await fixture()
+    const userDataDir = join(root, 'desktop-state')
+    const profile = join(home, 'profiles', 'desktop')
+    await selectDesktopMarketProvider(userDataDir, 'community-market')
+    await completeOrSkipDesktopSetupWizard(userDataDir, profile, 'completed', {
+      desktopVersion: '2.0.5-beta.2', dshVersion: '0.1.3-alpha.2', setupRevision: 1,
+    })
+
+    await expect(resetDesktopDataDirectory({
+      homeDir: home,
+      userDataDir,
+      protectedPaths: [root],
+      trashItem: async () => { throw new Error('trash unavailable') },
+    })).rejects.toThrow('trash unavailable')
+
+    expect(readDesktopMarketStateForUserData(userDataDir).requested).toBe('community-market')
+    expect(readDesktopSetupWizardState(userDataDir, profile)?.outcome).toBe('completed')
+    expect(existsSync(profile)).toBe(true)
+  })
+
   it('moves only the validated DSH Home to trash and recreates an empty root', async () => {
     const { root, home } = await fixture()
     const trashed = join(root, 'trashed-dsh')
@@ -32,6 +119,7 @@ describe('Desktop factory reset', () => {
 
     await expect(resetDesktopDataDirectory({
       homeDir: home,
+      userDataDir: join(root, 'desktop-state'),
       protectedPaths: [root, join(root, 'desktop-state')],
       trashItem,
     })).resolves.toBe(home)


### PR DESCRIPTION
## Summary / 摘要

Beta 恢复助手执行恢复出厂设置后，Electron 用户数据目录中的旧 Profile 偏好会被重新写入干净的设置文档，导致设置引导及“跳过设置”沿用重置前的配置。

本次在成功移入废纸篓后，清除对应 Profile 的桌面偏好、设置引导记录、恢复检查点和插件禁用记录，并将旧的应用级市场选择恢复为默认禁用。即使默认 desktop 目录已被删除，也会清理其残留状态，避免重建时恢复旧配置。移入废纸篓失败时保留原状态；保留其他 Profile 的独立状态。

仅修改 beta；新版恢复助手尚未同步稳定版。

## Related Issues / 关联 Issue

N/A

## Type / 类型

- [x] Bug fix / 问题修复

## Platforms / 影响平台

- [x] Not platform-specific / 与平台无关

## Verification / 验证

- [x] `corepack yarn workspace dsh-plugin-desktop-beta test tests/desktop-factory-reset.spec.ts tests/desktop-plugins.spec.ts tests/startup-recovery-window.spec.ts tests/setup-wizard-settings.spec.ts tests/profile-preferences.spec.ts` — 81 项通过
- [x] `corepack yarn workspace dsh-plugin-desktop-beta typecheck`
- [x] `corepack yarn workspace dsh-plugin-desktop-beta build`
- [x] `corepack yarn workspace dsh-plugin-desktop-beta verify:loader`
- [x] `corepack yarn check:desktop-variants`
- [x] `git diff --check`
- [x] `corepack yarn check` — 未运行完整仓库 gate
- [x] Manual test / 人工测试 — 未启动图形应用

## Release Notes / 发布说明

修复 Beta 恢复出厂设置后，设置引导及“跳过设置”沿用旧桌面配置的问题。窗口尺寸、安装标识和浏览器缓存等应用级状态保留。
