### PR TITLE
fix(stable): restore legacy code preset compatibility

### DIFF
--- a/dsh-plugin-desktop/src/agent-preset-compat.ts
+++ b/dsh-plugin-desktop/src/agent-preset-compat.ts
@@ -1,0 +1,127 @@
+/** Compatibility agent presets for Sessions persisted under a renamed preset id. */
+
+import { copyFileSync, existsSync, mkdirSync, readFileSync, readdirSync, rmSync, writeFileSync } from 'node:fs'
+import { dirname, join, relative } from 'node:path'
+import { parse, stringify } from 'yaml'
+
+/** The preset directory holding the alias presets the launcher materializes. */
+export const COMPAT_PRESET_DIRNAME = 'agent-preset-compat'
+
+/** The optional display-metadata file beside a preset's composition (`agent-presets/metadata`). */
+const PRESET_METADATA_FILE = 'preset.yml'
+
+/**
+ * Preset ids a persisted Session may still carry, mapped to the shipped
+ * preset that replaced them.
+ *
+ * Upstream renamed the PTC preset directory from `code` to `ptc` without a
+ * compatibility alias — a deliberate pre-release stance recorded in the
+ * rename's Agent Note — while a Session's header and `agentPreset`
+ * projection keep the id it started with. Every Session created before the
+ * rename therefore fails to resume against the renamed runtime with
+ * `agent-presets: preset "code" not found`, and no upstream migration exists
+ * to rewrite it. The launcher materializes each alias as a real preset
+ * directory instead, so those Sessions mount the composition they always ran
+ * and new Sessions keep choosing the renamed id.
+ */
+export const LEGACY_PRESET_ALIASES: Readonly<Record<string, string>> = {
+  code: 'ptc',
+}
+
+export interface LegacyPresetAliasOptions {
+  /** The shipped preset root the pinned runtime reads. */
+  readonly shippedRoot: string
+  /** Desktop-owned directory the alias presets are materialized into. */
+  readonly compatRoot: string
+}
+
+/**
+ * Copy one read-only preset tree using the ASAR-aware filesystem operations
+ * Electron supports for directories and individual files.
+ *
+ * Electron's `cpSync` bridge tries to extract its source as one file. That
+ * cannot represent a directory inside `app.asar`, while `readdirSync` and
+ * `copyFileSync` retain Electron's normal virtual-filesystem semantics.
+ */
+function copyPresetTree(source: string, target: string): void {
+  mkdirSync(target, { recursive: true })
+  const entries = readdirSync(source, { recursive: true, withFileTypes: true })
+  for (const entry of entries) {
+    const sourcePath = join(entry.parentPath, entry.name)
+    const targetPath = join(target, relative(source, sourcePath))
+    if (entry.isDirectory()) {
+      mkdirSync(targetPath, { recursive: true })
+      continue
+    }
+    if (!entry.isFile()) {
+      throw new Error(`dsh-plugin-desktop: shipped agent preset contains an unsupported entry at ${sourcePath}`)
+    }
+    mkdirSync(dirname(targetPath), { recursive: true })
+    copyFileSync(sourcePath, targetPath)
+  }
+}
+
+/**
+ * Materialize one alias preset per renamed id that the shipped root no
+ * longer supplies.
+ *
+ * Each alias is a verbatim copy of the shipped preset it points at — the
+ * composition mounts exactly what the renamed preset mounts, and relative
+ * references inside the preset directory (skills) travel with the copy —
+ * with rewritten display metadata so a picker can tell the alias from the
+ * preset it shadows. Copying from the shipped root on every preparation
+ * keeps the alias in lock-step with the pinned runtime's composition, and
+ * an id the shipped root supplies again (or never renamed) materializes
+ * nothing, letting the shipped roster stand alone.
+ * @param options - the shipped root to copy from and the desktop-owned root
+ * to materialize into.
+ * @returns the compat root to append after the shipped root, or undefined
+ * when no alias is needed and the root must not be configured.
+ */
+export function materializeLegacyPresetAliases(options: LegacyPresetAliasOptions): string | undefined {
+  const { shippedRoot, compatRoot } = options
+  let materialized = false
+  for (const [legacyId, shippedId] of Object.entries(LEGACY_PRESET_ALIASES)) {
+    if (existsSync(join(shippedRoot, legacyId))) continue
+    const source = join(shippedRoot, shippedId)
+    if (!existsSync(source)) continue
+    const target = join(compatRoot, legacyId)
+    rmSync(target, { recursive: true, force: true })
+    copyPresetTree(source, target)
+    writeFileSync(join(target, PRESET_METADATA_FILE), aliasMetadata(source, legacyId, shippedId))
+    materialized = true
+  }
+  return materialized ? compatRoot : undefined
+}
+
+/**
+ * Display metadata that marks one materialized alias as a compatibility
+ * preset.
+ *
+ * The display name trails the shipped preset's own so the two read as a pair
+ * in a picker, while the description names the legacy id a resumed Session
+ * carries. Reading the shipped metadata mirrors discovery's own tolerance:
+ * an absent or unparsable file degrades to the shipped id, never to a failed
+ * preparation.
+ * @param source - shipped preset directory the alias was copied from.
+ * @param legacyId - the preset id the alias restores.
+ * @param shippedId - the shipped preset id the alias points at.
+ * @returns the alias `preset.yml` document as YAML text.
+ */
+function aliasMetadata(source: string, legacyId: string, shippedId: string): string {
+  let shippedName: string | undefined
+  try {
+    const parsed = parse(readFileSync(join(source, PRESET_METADATA_FILE), 'utf8')) as {
+      name?: unknown
+    } | null
+    const name = parsed?.name
+    if (typeof name === 'string' && name.trim() !== '') shippedName = name.trim()
+  } catch {
+    // Discovery degrades absent and unparsable metadata to no name; the alias degrades the same way.
+  }
+  const displayName = shippedName ?? shippedId
+  return stringify({
+    name: `${displayName}（兼容）`,
+    description: `兼容别名：用于恢复以旧版 "${legacyId}" 预设创建的会话；新会话请选择 ${displayName}。`,
+  })
+}

--- a/dsh-plugin-desktop/src/profile.ts
+++ b/dsh-plugin-desktop/src/profile.ts
@@ -41,6 +41,7 @@ import FileSettingsProvider, {
   type Config as SettingsFileConfig,
 } from '@deepseek-ai/dsh-settings-file'
 import { parseAllDocuments, parseDocument } from 'yaml'
+import { COMPAT_PRESET_DIRNAME, materializeLegacyPresetAliases } from './agent-preset-compat.ts'
 import { findOverlayPackage, resolveOverlayPackage } from './package-overlay.ts'
 import { withAsarModuleResolver } from './asar-module-resolver-state.ts'
 import { DESKTOP_DEFAULT_WEB_PORT } from './desktop-port.ts'
@@ -104,6 +105,8 @@ const UPSTREAM_PWSH_SANDBOX_PACKAGE = '@deepseek-ai/dsh-pwsh-sandbox'
 const DESKTOP_WINDOWS_PWSH_SANDBOX_ROW_ID = 'desktop-windows-pwsh-sandbox'
 const DESKTOP_WINDOWS_PWSH_SANDBOX_PACKAGE = `${DESKTOP_PACKAGE_NAME}/windows-pwsh-sandbox`
 const AGENT_PRESETS_ROW_ID = 'agent-presets'
+/** Harness-home directory holding locally authored presets (`agent-presets/discovery`). */
+const USER_PRESET_DIRNAME = '.agent-presets'
 const DEFAULT_DESKTOP_SHELL_MODE: DesktopShellMode = 'compatibility'
 const DEFAULT_DESKTOP_PORT = DESKTOP_DEFAULT_WEB_PORT
 const DESKTOP_WEB_SERVER_ROW_ID = 'desktop-webserver'
@@ -1007,11 +1010,24 @@ export function prepareDesktopProfile(
   }
   const presets = rows.get(AGENT_PRESETS_ROW_ID)
   if (presets !== undefined) {
-    const config = {
-      ...rowConfig(presets),
-      roots: [{ path: shippedPresetRoot(), trust: 'system' }],
-    }
-    patches.push({ id: AGENT_PRESETS_ROW_ID, config })
+    const shippedRoot = shippedPresetRoot()
+    const roots: Array<{ path: string, trust: 'system' | 'user' }> = [
+      { path: shippedRoot, trust: 'system' },
+      // The harness-home user root, taken over from `includeUserRoot` so it
+      // keeps precedence over the alias root below: a preset authored under a
+      // renamed id must still win over the launcher's alias copy of the
+      // shipped preset.
+      { path: join(home, USER_PRESET_DIRNAME), trust: 'user' },
+    ]
+    const compatRoot = materializeLegacyPresetAliases({
+      shippedRoot,
+      compatRoot: join(profileDir, COMPAT_PRESET_DIRNAME),
+    })
+    if (compatRoot !== undefined) roots.push({ path: compatRoot, trust: 'system' })
+    patches.push({
+      id: AGENT_PRESETS_ROW_ID,
+      config: { ...rowConfig(presets), roots, includeUserRoot: false },
+    })
   }
   const webserver = rows.get('webserver')
   if (webserver === undefined) {

--- a/dsh-plugin-desktop/tests/agent-preset-compat.spec.ts
+++ b/dsh-plugin-desktop/tests/agent-preset-compat.spec.ts
@@ -1,0 +1,85 @@
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
+import { COMPAT_PRESET_DIRNAME, materializeLegacyPresetAliases } from '../src/agent-preset-compat.ts'
+import { shippedPresetRoot } from '../src/profile.ts'
+
+const roots: string[] = []
+
+function temporaryRoot(): string {
+  const root = mkdtempSync(join(tmpdir(), 'dsh-desktop-preset-compat-'))
+  roots.push(root)
+  return root
+}
+
+afterEach(() => {
+  for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true })
+})
+
+describe('legacy agent preset aliases', () => {
+  it('materializes the code alias from the shipped ptc preset of the pinned runtime', () => {
+    const compatRoot = temporaryRoot()
+
+    expect(materializeLegacyPresetAliases({
+      shippedRoot: shippedPresetRoot(),
+      compatRoot,
+    })).toBe(compatRoot)
+
+    const aliasDir = join(compatRoot, 'code')
+    expect(readFileSync(join(aliasDir, 'agent.cordis.yml'), 'utf8'))
+      .toBe(readFileSync(join(shippedPresetRoot(), 'ptc', 'agent.cordis.yml'), 'utf8'))
+    expect(readFileSync(join(aliasDir, 'preset.yml'), 'utf8')).toContain('（兼容）')
+    expect(readFileSync(join(aliasDir, 'preset.yml'), 'utf8')).toContain('"code"')
+  })
+
+  it('re-materializes in place so a runtime update refreshes a stale alias', () => {
+    const compatRoot = temporaryRoot()
+    expect(materializeLegacyPresetAliases({
+      shippedRoot: shippedPresetRoot(),
+      compatRoot,
+    })).toBe(compatRoot)
+    writeFileSync(join(compatRoot, 'code', 'agent.cordis.yml'), 'stale\n')
+
+    expect(materializeLegacyPresetAliases({
+      shippedRoot: shippedPresetRoot(),
+      compatRoot,
+    })).toBe(compatRoot)
+    expect(readFileSync(join(compatRoot, 'code', 'agent.cordis.yml'), 'utf8'))
+      .toBe(readFileSync(join(shippedPresetRoot(), 'ptc', 'agent.cordis.yml'), 'utf8'))
+  })
+
+  it('copies nested assets from a shipped preset', () => {
+    const root = temporaryRoot()
+    const shippedRoot = join(root, 'presets')
+    const compatRoot = join(root, COMPAT_PRESET_DIRNAME)
+    const ptcRoot = join(shippedRoot, 'ptc')
+    const skill = join('skills', 'nested-skill', 'SKILL.md')
+    mkdirSync(join(ptcRoot, 'skills', 'nested-skill'), { recursive: true })
+    writeFileSync(join(ptcRoot, 'agent.cordis.yml'), '[]\n')
+    writeFileSync(join(ptcRoot, 'preset.yml'), 'name: PTC\n')
+    writeFileSync(join(ptcRoot, skill), '# Nested skill\n')
+
+    expect(materializeLegacyPresetAliases({ shippedRoot, compatRoot })).toBe(compatRoot)
+    expect(readFileSync(join(compatRoot, 'code', skill), 'utf8')).toBe('# Nested skill\n')
+  })
+
+  it('materializes nothing when the shipped root supplies the legacy id itself', () => {
+    const shippedRoot = join(temporaryRoot(), 'presets')
+    const compatRoot = join(temporaryRoot(), COMPAT_PRESET_DIRNAME)
+    mkdirSync(join(shippedRoot, 'code'), { recursive: true })
+    writeFileSync(join(shippedRoot, 'code', 'agent.cordis.yml'), '[]\n')
+
+    expect(materializeLegacyPresetAliases({ shippedRoot, compatRoot })).toBeUndefined()
+    expect(existsSync(compatRoot)).toBe(false)
+  })
+
+  it('materializes nothing when the shipped root lost the mapped preset', () => {
+    const shippedRoot = join(temporaryRoot(), 'presets')
+    const compatRoot = join(temporaryRoot(), COMPAT_PRESET_DIRNAME)
+    mkdirSync(shippedRoot, { recursive: true })
+
+    expect(materializeLegacyPresetAliases({ shippedRoot, compatRoot })).toBeUndefined()
+    expect(existsSync(compatRoot)).toBe(false)
+  })
+})

--- a/dsh-plugin-desktop/tests/profile.spec.ts
+++ b/dsh-plugin-desktop/tests/profile.spec.ts
@@ -409,8 +409,21 @@ virtualStoreDirMaxLength: 60
     }))
     expect(patches).toContainEqual(expect.objectContaining({
       id: 'agent-presets',
-      config: expect.objectContaining({ roots: [expect.objectContaining({ trust: 'system' })] }),
+      config: expect.objectContaining({
+        roots: [
+          { path: shippedPresetRoot(), trust: 'system' },
+          { path: join(home, '.agent-presets'), trust: 'user' },
+          { path: join(prepared.profile.dir, 'agent-preset-compat'), trust: 'system' },
+        ],
+        includeUserRoot: false,
+      }),
     }))
+    expect(existsSync(join(
+      prepared.profile.dir,
+      'agent-preset-compat',
+      'code',
+      'agent.cordis.yml',
+    ))).toBe(true)
     expect(readFileSync(prepared.rootConfig, 'utf8')).toBe('[]\n')
     expect(prepared.homeDir).toBe(home)
     expect(fileURLToPath(prepared.bareModuleBaseUrl)).toBe(join(prepared.profile.dir, 'package.json'))
@@ -470,6 +483,30 @@ virtualStoreDirMaxLength: 60
     expect(rows.find(row => row.id === 'desktop-profiles')).toEqual(expect.objectContaining({
       name: 'dsh-plugin-desktop/profiles',
     }))
+  })
+
+  it('keeps a user-authored code preset ahead of the compatibility alias', () => {
+    const home = temporaryHome()
+    const userCodeDir = join(home, '.agent-presets', 'code')
+    mkdirSync(userCodeDir, { recursive: true })
+    writeFileSync(join(userCodeDir, 'agent.cordis.yml'), '[]\n')
+
+    const prepared = prepareDesktopProfile(undefined, home, 'darwin')
+    const rows = composeEntries([prepared.patches])
+    const presets = rows.find(row => row.id === 'agent-presets') as
+      | { config?: { roots?: Array<{ path: string }> } }
+      | undefined
+    const roots = presets?.config?.roots ?? []
+
+    expect(roots.map(root => root.path)).toEqual([
+      shippedPresetRoot(),
+      join(home, '.agent-presets'),
+      join(prepared.profile.dir, 'agent-preset-compat'),
+    ])
+    // The alias is still materialized for Sessions without a user preset,
+    // but discovery meets the user root first so it never shadows user data.
+    expect(existsSync(join(prepared.profile.dir, 'agent-preset-compat', 'code', 'agent.cordis.yml'))).toBe(true)
+    expect(existsSync(join(userCodeDir, 'agent.cordis.yml'))).toBe(true)
   })
 
   it('merges a frozen LAN IPv4 snapshot into existing Web runtime trust', () => {
@@ -1043,7 +1080,12 @@ virtualStoreDirMaxLength: 60
     expect(rows.find(row => row.id === 'agent-presets')).toEqual(expect.objectContaining({
       name: '@deepseek-ai/dsh-agent-presets',
       config: expect.objectContaining({
-        roots: [{ path: shippedPresetRoot(), trust: 'system' }],
+        roots: [
+          { path: shippedPresetRoot(), trust: 'system' },
+          { path: join(home, '.agent-presets'), trust: 'user' },
+          { path: join(prepared.profile.dir, 'agent-preset-compat'), trust: 'system' },
+        ],
+        includeUserRoot: false,
       }),
     }))
     expect(rows.find(row => row.id === 'agent-presets')?.disabled).toBeFalsy()


### PR DESCRIPTION
## Summary / 摘要

Stable (Windows installer channel) fails to resume Sessions persisted under the old `code` preset id: `agent-presets: preset "code" not found (available: standard, ptc, minimal, cordis)`. The pinned 0.1.2-rc.1 runtime renamed `code` to `ptc` without an alias. The `code -> ptc` compatibility behavior was previously accepted (df9992ff, Fixes #727) but was moved to beta-only during the Stable/Beta split (964b838c82 renamed `agent-preset-compat` to `dsh-plugin-desktop-beta/` and stripped the Stable wiring), so Stable lost it while still shipping the renamed runtime.

This mirrors the existing, tested Beta implementation into Stable: materialize a verbatim `code` alias from the shipped `ptc` preset at profile preparation and append the compat root after the harness-home user root, so user-authored presets keep precedence. New sessions still default to `ptc`; no session-storage migration; no fallback for arbitrary unknown preset ids; no unrelated refactor.

## Related Issues / 关联 Issue

Fixes #871

## Type / 类型

- [x] Bug fix / 问题修复
- [ ] Feature / 新功能
- [ ] Documentation / 文档
- [ ] Release or packaging / 发布或打包
- [ ] Tests only / 仅测试
- [ ] Other / 其他

## Platforms / 影响平台

- [x] Windows installer / Windows 安装包
- [ ] Windows portable ZIP / Windows 便携版 ZIP
- [ ] macOS Apple Silicon
- [ ] macOS Intel
- [ ] macOS Universal package / macOS 通用安装包
- [ ] Linux
- [ ] Not platform-specific / 与平台无关

## Verification / 验证

- [x] `corepack yarn workspace dsh-plugin-desktop typecheck` (pass)
- [x] `corepack yarn workspace dsh-plugin-desktop vitest run tests/agent-preset-compat.spec.ts tests/profile.spec.ts` (48/48 pass, incl. 5 new compat tests + new user-precedence test)
- [x] `corepack yarn check:desktop-variants` (143 shared files aligned)
- [x] `git diff --check` (clean)
- [ ] `corepack yarn check:layout`
- [ ] `corepack yarn typecheck`
- [ ] `corepack yarn test` (full stable suite: 1096 pass; 27 failures in 15 files reproduced identically on clean master via stash comparison, pre-existing environment failures unrelated to this change)
- [ ] `corepack yarn check`
- [ ] Platform package smoke / 平台打包或启动冒烟
- [ ] Manual test / 人工测试

Deterministic before/after proof (isolated temp home, no paid API, loader-level only — no packaged/GUI proof claimed): BEFORE, Stable prepared `agent-presets` roots = [shipped] with shipped roster {standard, ptc, minimal, cordis}, zero roots resolving `code`. AFTER, roots = [shipped(system), user(user), compat(system)] with exactly the compat root resolving `code`, alias `agent.cordis.yml` byte-identical to shipped `ptc`.

## Release Notes / 发布说明

- 修复：Stable 升级后，旧版 PTC 模式（`code` 预设）创建的历史会话发言时报 `preset "code" not found`。升级后无需任何操作，旧会话可直接继续；新会话请继续选择 PTC 模式。
