### PR TITLE
fix: macOS 应用菜单同步退出安全模式选项（稳定版 / beta）

### DIFF
--- a/dsh-plugin-desktop-beta/src/electron-runtime.ts
+++ b/dsh-plugin-desktop-beta/src/electron-runtime.ts
@@ -909,6 +909,11 @@ export class ElectronDesktopRuntime implements DesktopRuntime {
     if (tools.length > 0) items.push(...tools)
     if (tools.length > 0 && profiles.length > 0) items.push({ type: 'separator' })
     if (profiles.length > 0) items.push(...profiles)
+    const status = this.contributedTrayItems('status')
+    if (status.length > 0) {
+      if (items.length > 0) items.push({ type: 'separator' })
+      items.push(...status)
+    }
     return items
   }
 }

--- a/dsh-plugin-desktop-beta/tests/electron-runtime.spec.ts
+++ b/dsh-plugin-desktop-beta/tests/electron-runtime.spec.ts
@@ -2154,6 +2154,40 @@ describe('Electron desktop runtime', () => {
     await release()
   })
 
+  it.each(['tray', 'application'] as const)('exits Safe Mode from the localized macOS %s menu', async surface => {
+    vi.spyOn(process, 'platform', 'get').mockReturnValue('darwin')
+    const { ElectronDesktopRuntime } = await import('../src/electron-runtime.ts')
+    const runtime = new ElectronDesktopRuntime(async () => {})
+    const exitSafeMode = vi.fn(async () => {})
+    const registration = runtime.registerTrayItem({
+      group: 'status',
+      order: -100,
+      label: () => desktopTrayLabel(runtime.locale, 'exitSafeMode'),
+      invoke: exitSafeMode,
+    })
+    const release = runtime.schedule(spec)
+    await runtime.mountScheduled()
+
+    type MenuCommand = { label?: string, enabled?: boolean, click?: () => void }
+    const menuItems = (): MenuCommand[] => surface === 'application'
+      ? (electron.applicationMenuTemplates.at(-1)?.[0] as { submenu: MenuCommand[] }).submenu
+      : electron.menuTemplates.at(-1) as MenuCommand[]
+    expect(menuItems()).toEqual(expect.arrayContaining([
+      expect.objectContaining({ label: 'Exit Safe Mode and Restart…', enabled: true }),
+    ]))
+    expect(menuItems().some(item => item.label === 'Enter Safe Mode…')).toBe(false)
+
+    runtime.setLocalePreference('zh')
+    const command = menuItems().find(item => item.label === '退出安全模式并重启…')
+    expect(command?.click).toEqual(expect.any(Function))
+    command?.click?.()
+    await vi.waitFor(() => { expect(exitSafeMode).toHaveBeenCalledOnce() })
+
+    registration.dispose()
+    expect(menuItems().some(item => item.label === '退出安全模式并重启…')).toBe(false)
+    await release()
+  })
+
   it('cancels, coalesces, and suppresses Safe Mode restart requests while quitting', async () => {
     const { ElectronDesktopRuntime } = await import('../src/electron-runtime.ts')
     const restart = vi.fn(async () => {})

--- a/dsh-plugin-desktop/src/electron-runtime.ts
+++ b/dsh-plugin-desktop/src/electron-runtime.ts
@@ -909,6 +909,11 @@ export class ElectronDesktopRuntime implements DesktopRuntime {
     if (tools.length > 0) items.push(...tools)
     if (tools.length > 0 && profiles.length > 0) items.push({ type: 'separator' })
     if (profiles.length > 0) items.push(...profiles)
+    const status = this.contributedTrayItems('status')
+    if (status.length > 0) {
+      if (items.length > 0) items.push({ type: 'separator' })
+      items.push(...status)
+    }
     return items
   }
 }

--- a/dsh-plugin-desktop/tests/electron-runtime.spec.ts
+++ b/dsh-plugin-desktop/tests/electron-runtime.spec.ts
@@ -2151,6 +2151,40 @@ describe('Electron desktop runtime', () => {
     await release()
   })
 
+  it.each(['tray', 'application'] as const)('exits Safe Mode from the localized macOS %s menu', async surface => {
+    vi.spyOn(process, 'platform', 'get').mockReturnValue('darwin')
+    const { ElectronDesktopRuntime } = await import('../src/electron-runtime.ts')
+    const runtime = new ElectronDesktopRuntime(async () => {})
+    const exitSafeMode = vi.fn(async () => {})
+    const registration = runtime.registerTrayItem({
+      group: 'status',
+      order: -100,
+      label: () => desktopTrayLabel(runtime.locale, 'exitSafeMode'),
+      invoke: exitSafeMode,
+    })
+    const release = runtime.schedule(spec)
+    await runtime.mountScheduled()
+
+    type MenuCommand = { label?: string, enabled?: boolean, click?: () => void }
+    const menuItems = (): MenuCommand[] => surface === 'application'
+      ? (electron.applicationMenuTemplates.at(-1)?.[0] as { submenu: MenuCommand[] }).submenu
+      : electron.menuTemplates.at(-1) as MenuCommand[]
+    expect(menuItems()).toEqual(expect.arrayContaining([
+      expect.objectContaining({ label: 'Exit Safe Mode and Restart…', enabled: true }),
+    ]))
+    expect(menuItems().some(item => item.label === 'Enter Safe Mode…')).toBe(false)
+
+    runtime.setLocalePreference('zh')
+    const command = menuItems().find(item => item.label === '退出安全模式并重启…')
+    expect(command?.click).toEqual(expect.any(Function))
+    command?.click?.()
+    await vi.waitFor(() => { expect(exitSafeMode).toHaveBeenCalledOnce() })
+
+    registration.dispose()
+    expect(menuItems().some(item => item.label === '退出安全模式并重启…')).toBe(false)
+    await release()
+  })
+
   it('cancels, coalesces, and suppresses Safe Mode restart requests while quitting', async () => {
     const { ElectronDesktopRuntime } = await import('../src/electron-runtime.ts')
     const restart = vi.fn(async () => {})


### PR DESCRIPTION
## Summary / 摘要

安全模式下，macOS 应用菜单缺少托盘已有的“退出安全模式并重启…”选项。应用菜单现在同步托盘的状态分组，复用现有动作、排序和本地化；稳定版与 beta 同步修复。

增加两版回归测试，覆盖应用菜单和托盘菜单的中英文显示、点击调用和注销后移除。

## Related Issues / 关联 Issue

N/A

## Type / 类型

- [x] Bug fix / 问题修复

## Platforms / 影响平台

- [x] macOS Apple Silicon
- [x] macOS Intel
- [x] macOS Universal package / macOS 通用安装包

## Verification / 验证

以下检查均通过：

- `corepack yarn check:desktop-variants`
- `corepack yarn workspace dsh-plugin-desktop-beta test tests/electron-runtime.spec.ts tests/native-menu.spec.ts`（90 项通过）
- `corepack yarn workspace dsh-plugin-desktop test tests/electron-runtime.spec.ts tests/native-menu.spec.ts`（90 项通过）
- `corepack yarn workspace dsh-plugin-desktop-beta typecheck`
- `corepack yarn workspace dsh-plugin-desktop typecheck`
- `git diff --check`

未运行全量 gate、打包冒烟或图形应用人工验证。

## Release Notes / 发布说明

修复稳定版和 beta 在 macOS 安全模式下无法从左上角应用菜单退出安全模式的问题。
