### PR TITLE
fix(desktop): 修复市场目录加载时序与 macOS 路径测试

### DIFF
--- a/dsh-community-market/src/client/MarketSettingsTab.tsx
+++ b/dsh-community-market/src/client/MarketSettingsTab.tsx
@@ -520,6 +520,15 @@ export function MarketSurface({ initialView = 'installable', readLocale, t, show
     }
   }, [loadInstallable, loadState])
 
+  useEffect(() => {
+    // Source state can resolve before React commits it. Load after the view and
+    // state are committed, so a click in that gap cannot miss the first catalog.
+    if (view === 'discover' && state !== undefined && selectedSource(state.sources) !== undefined
+      && catalog === undefined && readRequest.current === undefined) {
+      void loadCatalog(state, appliedQuery, selectedCategories)
+    }
+  }, [view, state, catalog, appliedQuery, selectedCategories, loadCatalog])
+
   const items = useMemo(() => catalog?.results.flatMap(result =>
     (result.snapshot?.items ?? []).map(item => ({ item, source: result.source, stale: result.stale }))) ?? [], [catalog])
   const installableCategoryOptions = installableIndex?.categories ?? []
@@ -680,9 +689,6 @@ export function MarketSurface({ initialView = 'installable', readLocale, t, show
       setInstallableLoading(false)
       setInstallableLoadingMore(false)
       setInstallationsLoading(false)
-      if (state !== undefined && catalog === undefined && readRequest.current === undefined) {
-        void loadCatalog(state, appliedQuery, selectedCategories)
-      }
     } else {
       installableRequest.current?.abort()
       installationsRequest.current?.abort()

--- a/dsh-community-market/tests/market-settings-tab.spec.tsx
+++ b/dsh-community-market/tests/market-settings-tab.spec.tsx
@@ -272,6 +272,25 @@ describe('MarketSettingsTab', () => {
     )
   })
 
+  it.each(['pending', 'resolved before commit'] as const)('loads Discover when source state is %s', async timing => {
+    let resolveState!: (value: MarketStateResponse) => void
+    vi.mocked(readMarketState).mockImplementation(() => new Promise(resolve => { resolveState = resolve }))
+    vi.mocked(readMarketInstallable).mockResolvedValue(installableResponse([]))
+    vi.mocked(readMarketCatalog).mockResolvedValue(catalog)
+    render(<MarketSettingsTab {...({ t, readLocale: () => 'en' } as MarketSettingsTabProps)} />)
+
+    await act(async () => {
+      if (timing === 'pending') fireEvent.click(screen.getByRole('button', { name: en.discover }))
+      resolveState(enabledState)
+      // Finish loadState while React still batches its state updates.
+      await Promise.resolve()
+      if (timing === 'resolved before commit') fireEvent.click(screen.getByRole('button', { name: en.discover }))
+    })
+
+    expect(await screen.findByRole('button', { name: /Fixture Plugin/u })).toBeTruthy()
+    expect(readMarketCatalog).toHaveBeenCalledOnce()
+  })
+
   it('shows a persisted first page while refreshing it for the new Host generation', async () => {
     const persisted = {
       ...catalog,

--- a/dsh-plugin-desktop-beta/tests/desktop-runtime-environment.spec.ts
+++ b/dsh-plugin-desktop-beta/tests/desktop-runtime-environment.spec.ts
@@ -7,6 +7,7 @@ import {
   mkdtempSync,
   readFileSync,
   readdirSync,
+  realpathSync,
   rmSync,
   symlinkSync,
   writeFileSync,
@@ -156,7 +157,8 @@ describe('desktop Host pnpm runtime', () => {
     expect(result.error).toBeUndefined()
     expect(result.status).toBe(0)
     expect(JSON.parse(result.stdout)).toEqual({
-      execPath: installation.nodeShimPath,
+      // Node resolves the preload's __dirname through symlinks (macOS /var -> /private/var).
+      execPath: realpathSync(installation.nodeShimPath),
       runAsNode: [],
     })
     installation.dispose()

--- a/dsh-plugin-desktop/tests/desktop-runtime-environment.spec.ts
+++ b/dsh-plugin-desktop/tests/desktop-runtime-environment.spec.ts
@@ -7,6 +7,7 @@ import {
   mkdtempSync,
   readFileSync,
   readdirSync,
+  realpathSync,
   rmSync,
   symlinkSync,
   writeFileSync,
@@ -156,7 +157,8 @@ describe('desktop Host pnpm runtime', () => {
     expect(result.error).toBeUndefined()
     expect(result.status).toBe(0)
     expect(JSON.parse(result.stdout)).toEqual({
-      execPath: installation.nodeShimPath,
+      // Node resolves the preload's __dirname through symlinks (macOS /var -> /private/var).
+      execPath: realpathSync(installation.nodeShimPath),
       runAsNode: [],
     })
     installation.dispose()


### PR DESCRIPTION
## 变更
- 修复源数据已返回但 React 尚未提交状态时切换到发现页面，导致目录请求遗漏的问题。
- 将首次目录加载检查放在状态提交之后，保留已有在途请求保护；补充两种时序的回归测试。
- 修正稳定版和 Beta 的 POSIX runtime 测试：使用 realpathSync 比较预期 shim 路径，避免 macOS /var 与 /private/var 指向同一文件却字符串不等的问题；不改运行逻辑。

## 验证
- 市场可控时序测试在修复前复现空列表失败；修复后市场包完整 check 通过，263 项测试及构建、类型检查、导出和 Client Loader 验证通过。
- macOS 路径测试修复前复现，修复后通过。
- Desktop 全量测试：稳定版 1257 通过、8 跳过；Beta 1280 通过、7 跳过。
- check:desktop-variants 通过，135 个共享源码文件对齐。
- git diff --check 通过。
- 未启动 GUI，未重新执行完整 dist:mac 安装包构建。