### PR TITLE
Revert: keep Agents Anywhere submodule off v2

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,3 @@
 [submodule "deepseek-harness"]
 	path = deepseek-harness
 	url = https://github.com/deepseek-ai/deepseek-harness.git
-[submodule "vendor/agents-anywhere-source"]
-	path = vendor/agents-anywhere-source
-	url = https://github.com/anywhere-labs/Agents-Anywhere.git
-	branch = v2


### PR DESCRIPTION
The Agents Anywhere source submodule belongs on master, not the legacy v2 branch. Revert PR #894 before applying the same change to master.