### PR TITLE
chore: add Agents Anywhere source submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,7 @@
 [submodule "deepseek-harness"]
 	path = deepseek-harness
 	url = https://github.com/deepseek-ai/deepseek-harness.git
+[submodule "vendor/agents-anywhere-source"]
+	path = vendor/agents-anywhere-source
+	url = https://github.com/anywhere-labs/Agents-Anywhere.git
+	branch = v2


### PR DESCRIPTION
Adds the Agents Anywhere repository as a pinned source submodule under `vendor/agents-anywhere-source` and tracks its `v2` branch.

The existing packaged `dsh-bridge-next` tarball remains unchanged; this provides the source checkout for the built-in Settings and Setup Wizard integration.