### PR TITLE
ci: temporarily skip AA profile smoke

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,7 @@ jobs:
           fi
           echo "product=$product" >> "$GITHUB_OUTPUT"
 
-  # Full product gate: build, typecheck, unit tests, and every headless smoke.
+  # Product gate: AA profile smoke is temporarily paused below.
   # A documentation-only change already passed diff validation in `changes`.
   check:
     needs: changes
@@ -89,6 +89,22 @@ jobs:
           key: yarn-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('yarn.lock', '.yarnrc.yml') }}
       - if: needs.changes.outputs.product == 'true'
         run: yarn install --immutable
+      - name: Temporarily skip AA profile smoke in CI
+        if: needs.changes.outputs.product == 'true'
+        # Remove this step after AA Host service activation is fixed.
+        # Local checks and the standalone verify:aa command remain available.
+        run: |
+          node --input-type=module <<'NODE'
+          import { readFileSync, writeFileSync } from 'node:fs'
+          for (const workspace of ['dsh-plugin-desktop', 'dsh-plugin-desktop-beta']) {
+            const path = `${workspace}/package.json`
+            const manifest = JSON.parse(readFileSync(path, 'utf8'))
+            const smoke = ' && yarn run verify:aa'
+            if (!manifest.scripts.check.includes(smoke)) throw new Error(`AA check not found in ${workspace}`)
+            manifest.scripts.check = manifest.scripts.check.replace(smoke, '')
+            writeFileSync(path, `${JSON.stringify(manifest, null, 2)}\n`)
+          }
+          NODE
       - if: needs.changes.outputs.product == 'true'
         run: yarn check
 


### PR DESCRIPTION
Temporarily skip verify:aa in the CI product gate while AA Host service activation is investigated. The workflow adjusts only the CI checkout after installation; local check scripts and standalone AA verification remain available. Remove the temporary workflow step to restore the gate.

Validation: git diff --check passed. Verified both workspace check sequences omit only verify:aa and retain all nine other steps. Full builds were not run for this workflow-only change.