### PR TITLE
feat(beta): isolate DSH Host and native framed chrome

### DIFF
--- a/.agents/notes/implemented/architecture/2026-09-10-beta-isolated-host.md
+++ b/.agents/notes/implemented/architecture/2026-09-10-beta-isolated-host.md
@@ -1,0 +1,36 @@
+# Beta isolated Host experiment
+
+Status: opt-in experiment; stable is unchanged.
+
+English | [中文](2026-09-10-beta-isolated-host.zh.md)
+
+## Boundary
+
+`DSH_DESKTOP_ISOLATED_HOST=1` starts the Beta Cordis Host in an Electron utility process. The main process still owns windows, native menus, dialogs, update networking, and OS-protected certificate access. The existing Web server, authentication, HTTP/WebSocket transport, client-module composition, and Desktop client visuals remain in their existing layers. No chat requests or model streams are proxied through the new control channel.
+
+AA Host services move with Cordis when enabled; the Python Connector remains its existing subprocess. This isolates the Electron event loop from Host CPU work. It does not fix slow Host tasks, AA compatibility, or plugin-inventory package resolution.
+
+The private control channel transports native commands and snapshots. Functions stay in their owning process and are addressed by callback IDs. Environment layers retain their provenance. Host logs use the Beta user-data `logs/host` directory. Native update requests still use the original Electron adapter; cancellation crosses the channel. Interactive dialogs and downloads are not subject to the ordinary RPC deadline.
+
+## Try locally
+
+From this worktree, install locked dependencies and build the Beta package:
+
+```sh
+corepack yarn install --immutable
+corepack yarn workspace dsh-plugin-desktop-beta build
+corepack yarn workspace dsh-plugin-desktop-beta prepare:electron-native
+corepack yarn workspace dsh-plugin-desktop-beta start:isolated
+```
+
+The Yarn script works on Windows as well as macOS. Close the running Beta first. Ordinary `start` without the environment variable uses the original in-process path. Do not use the same Profile simultaneously in two instances.
+
+## Verification and promotion
+
+Headless tests cover bidirectional native calls, cancellation, environment provenance, shell/tray callbacks, supervisor exit handling, and a real Node subprocess booting the DSH Web profile. The real-process fixture adapts Node IPC to the utility-process port API; it does not validate Electron utility-process behavior or OS packaging. It verifies distinct PIDs, authentication, a third-party client entry and its served bundle, and orderly Web-server shutdown.
+
+Before enabling this by default or porting it to stable, validate Windows and macOS packaged utility processes, ASAR module paths and native addons; window materials and controls in each mode; settings, tray refresh and Profile changes; LAN certificates; Host crash/hang and application shutdown; AA startup and large-history sync; and actual client plugin activation/HMR in a browser. Verify no Connector/tool descendants survive shutdown. Do not claim a Windows responsiveness improvement without measuring it.
+
+Unexpected Host exit is reported without automatic restart or replay. Shutdown first requests disposal, then terminates a nonresponsive child with a bounded exit wait. Recovery mutations remain unavailable if termination cannot be confirmed. Forced termination of arbitrary plugin descendants is not proven by the current headless fixture.
+
+The isolated bootstrap currently mirrors the existing bootstrap while this experiment is opt-in. Consolidate the two implementations before default adoption to avoid lifecycle drift. The image-reported request-extension inventory failure needs its own packaged-layout regression and fix.

--- a/.agents/notes/implemented/architecture/2026-09-10-beta-isolated-host.md
+++ b/.agents/notes/implemented/architecture/2026-09-10-beta-isolated-host.md
@@ -1,12 +1,12 @@
 # Beta isolated Host experiment
 
-Status: opt-in experiment; stable is unchanged.
+Status: default in Beta; experimental; stable is unchanged.
 
 English | [中文](2026-09-10-beta-isolated-host.zh.md)
 
 ## Boundary
 
-`DSH_DESKTOP_ISOLATED_HOST=1` starts the Beta Cordis Host in an Electron utility process. The main process still owns windows, native menus, dialogs, update networking, and OS-protected certificate access. The existing Web server, authentication, HTTP/WebSocket transport, client-module composition, and Desktop client visuals remain in their existing layers. No chat requests or model streams are proxied through the new control channel.
+Beta starts its Cordis Host by default in an Electron utility process. The main process still owns windows, native menus, dialogs, update networking, and OS-protected certificate access. The existing Web server, authentication, HTTP/WebSocket transport, client-module composition, and Desktop client visuals remain in their existing layers. No chat requests or model streams are proxied through the new control channel.
 
 AA Host services move with Cordis when enabled; the Python Connector remains its existing subprocess. This isolates the Electron event loop from Host CPU work. It does not fix slow Host tasks, AA compatibility, or plugin-inventory package resolution.
 
@@ -20,17 +20,21 @@ From this worktree, install locked dependencies and build the Beta package:
 corepack yarn install --immutable
 corepack yarn workspace dsh-plugin-desktop-beta build
 corepack yarn workspace dsh-plugin-desktop-beta prepare:electron-native
-corepack yarn workspace dsh-plugin-desktop-beta start:isolated
+corepack yarn workspace dsh-plugin-desktop-beta start
 ```
 
-The Yarn script works on Windows as well as macOS. Close the running Beta first. Ordinary `start` without the environment variable uses the original in-process path. Do not use the same Profile simultaneously in two instances.
+The Yarn script works on Windows as well as macOS. Close the running Beta first. Set `DSH_DESKTOP_ISOLATED_HOST=0` to compare with the original in-process path. Do not use the same Profile simultaneously in two instances.
 
 ## Verification and promotion
 
-Headless tests cover bidirectional native calls, cancellation, environment provenance, shell/tray callbacks, supervisor exit handling, and a real Node subprocess booting the DSH Web profile. The real-process fixture adapts Node IPC to the utility-process port API; it does not validate Electron utility-process behavior or OS packaging. It verifies distinct PIDs, authentication, a third-party client entry and its served bundle, and orderly Web-server shutdown.
+Headless tests cover bidirectional native calls, cancellation, environment provenance, shell/tray callbacks, supervisor exit handling, and a real Node subprocess booting the DSH Web profile. The real-process fixture adapts Node IPC to the utility-process port API; it does not validate Electron utility-process behavior or OS packaging. It verifies distinct PIDs, authentication, a third-party client entry and its served bundle, AA service activation with AA enabled or disabled, and orderly Web-server shutdown.
 
-Before enabling this by default or porting it to stable, validate Windows and macOS packaged utility processes, ASAR module paths and native addons; window materials and controls in each mode; settings, tray refresh and Profile changes; LAN certificates; Host crash/hang and application shutdown; AA startup and large-history sync; and actual client plugin activation/HMR in a browser. Verify no Connector/tool descendants survive shutdown. Do not claim a Windows responsiveness improvement without measuring it.
+Before porting it to stable, validate Windows and macOS packaged utility processes, ASAR module paths and native addons; window materials and controls in each mode; settings, tray refresh and Profile changes; LAN certificates; Host crash/hang and application shutdown; AA startup and large-history sync; and actual client plugin activation/HMR in a browser. Verify no Connector/tool descendants survive shutdown. Do not claim a Windows responsiveness improvement without measuring it.
 
 Unexpected Host exit is reported without automatic restart or replay. Shutdown first requests disposal, then terminates a nonresponsive child with a bounded exit wait. Recovery mutations remain unavailable if termination cannot be confirmed. Forced termination of arbitrary plugin descendants is not proven by the current headless fixture.
 
-The isolated bootstrap currently mirrors the existing bootstrap while this experiment is opt-in. Consolidate the two implementations before default adoption to avoid lifecycle drift. The image-reported request-extension inventory failure needs its own packaged-layout regression and fix.
+The isolated bootstrap currently mirrors the existing bootstrap during the Beta experiment. Consolidate the two implementations before stable adoption to avoid lifecycle drift. The image-reported request-extension inventory failure needs its own packaged-layout regression and fix.
+
+## Native frame isolation
+
+On macOS and Windows, both compatibility and extended modes place the packaged titlebar in a separate sandboxed WebContentsView. DSH content starts below its 36px native bounds, with no extra inset or Portal titlebar inside the content document. Frontend plugin DOM/CSS and slots cannot reach the chrome document. This is a frontend boundary, not a sandbox for arbitrary privileged Host code. Enhanced macOS mode reserves the full 32px drag strip above main/rightbar content, retaining the sidebar inset. Native GUI validation remains manual.

--- a/.agents/notes/implemented/architecture/2026-09-10-beta-isolated-host.zh.md
+++ b/.agents/notes/implemented/architecture/2026-09-10-beta-isolated-host.zh.md
@@ -1,0 +1,36 @@
+# Beta 独立 Host 进程实验
+
+状态：显式启用的实验；稳定版保持原样。
+
+[English](2026-09-10-beta-isolated-host.md) | 中文
+
+## 运行边界
+
+设置 `DSH_DESKTOP_ISOLATED_HOST=1` 后，Beta 在 Electron utility process 中启动 Cordis Host。主进程继续管理窗口、原生菜单、对话框、更新网络请求及系统保护的证书访问。现有 Web 服务、认证、HTTP/WebSocket 通信、客户端插件装配和 Desktop 前端视觉保留原有职责。聊天请求和模型输出不经过新增的控制通道。
+
+启用 AA 时，AA Host 服务随 Cordis 移动；Python Connector 仍使用原有子进程。此改动隔离 Host 与 Electron 的事件循环，并不修复 Host 慢任务、AA 兼容性或插件清单的包解析错误。
+
+私有控制通道只传递原生操作和状态快照。函数保留在所属进程，以回调 ID 调用。启动环境保留各层来源信息。Host 日志位于 Beta 用户数据目录的 `logs/host`。更新请求仍使用原来的 Electron 适配器，取消信号跨进程传递；交互对话框和下载不受普通 RPC 超时限制。
+
+## 本地尝试
+
+在本 worktree 安装锁定依赖并构建 Beta：
+
+```sh
+corepack yarn install --immutable
+corepack yarn workspace dsh-plugin-desktop-beta build
+corepack yarn workspace dsh-plugin-desktop-beta prepare:electron-native
+corepack yarn workspace dsh-plugin-desktop-beta start:isolated
+```
+
+Yarn 脚本同时适用于 Windows 和 macOS。请先退出已有 Beta。未设置环境变量的普通 `start` 仍使用原有同进程路径。不要让两个实例同时使用同一 Profile。
+
+## 验证与推广
+
+Headless 测试覆盖双向原生调用、取消、环境来源、窗口与托盘回调、退出管理，以及真实 Node 子进程中的 DSH Web Profile 启动。真实进程夹具将 Node IPC 适配为 utility-process 的端口接口，不验证 Electron utility process 或系统打包行为。它验证不同 PID、认证、第三方客户端插件条目及其脚本下载，以及 Web 服务正常关闭。
+
+默认启用或推广到稳定版前，需要验证 Windows/macOS 安装包的 utility process、ASAR 路径与原生模块；各模式窗口材质和控制；设置、托盘刷新与 Profile 切换；LAN 证书；Host 崩溃/卡死和退出；AA 启动与大量历史同步；浏览器中的插件实际激活与 HMR。还要确认退出后没有残留 Connector/工具子进程。未测量前不能宣称已改善 Windows 响应。
+
+Host 意外退出时报告错误，不自动重启或重放请求。退出先请求正常清理，再终止无响应子进程并限时等待退出；若无法确认终止，恢复操作继续受保护。当前夹具未证明强制终止时任意插件后代进程的清理。
+
+实验阶段独立启动器暂时保留了与原启动器对应的实现。默认启用前应统一两条启动实现，避免生命周期逻辑分叉。截图里的请求扩展清单错误仍需要单独的打包布局回归测试与修复。

--- a/.agents/notes/implemented/architecture/2026-09-10-beta-isolated-host.zh.md
+++ b/.agents/notes/implemented/architecture/2026-09-10-beta-isolated-host.zh.md
@@ -1,12 +1,12 @@
 # Beta 独立 Host 进程实验
 
-状态：显式启用的实验；稳定版保持原样。
+状态：Beta 默认启用的实验；稳定版保持原样。
 
 [English](2026-09-10-beta-isolated-host.md) | 中文
 
 ## 运行边界
 
-设置 `DSH_DESKTOP_ISOLATED_HOST=1` 后，Beta 在 Electron utility process 中启动 Cordis Host。主进程继续管理窗口、原生菜单、对话框、更新网络请求及系统保护的证书访问。现有 Web 服务、认证、HTTP/WebSocket 通信、客户端插件装配和 Desktop 前端视觉保留原有职责。聊天请求和模型输出不经过新增的控制通道。
+Beta 默认在 Electron utility process 中启动 Cordis Host。主进程继续管理窗口、原生菜单、对话框、更新网络请求及系统保护的证书访问。现有 Web 服务、认证、HTTP/WebSocket 通信、客户端插件装配和 Desktop 前端视觉保留原有职责。聊天请求和模型输出不经过新增的控制通道。
 
 启用 AA 时，AA Host 服务随 Cordis 移动；Python Connector 仍使用原有子进程。此改动隔离 Host 与 Electron 的事件循环，并不修复 Host 慢任务、AA 兼容性或插件清单的包解析错误。
 
@@ -20,17 +20,21 @@
 corepack yarn install --immutable
 corepack yarn workspace dsh-plugin-desktop-beta build
 corepack yarn workspace dsh-plugin-desktop-beta prepare:electron-native
-corepack yarn workspace dsh-plugin-desktop-beta start:isolated
+corepack yarn workspace dsh-plugin-desktop-beta start
 ```
 
-Yarn 脚本同时适用于 Windows 和 macOS。请先退出已有 Beta。未设置环境变量的普通 `start` 仍使用原有同进程路径。不要让两个实例同时使用同一 Profile。
+Yarn 脚本同时适用于 Windows 和 macOS。请先退出已有 Beta。设置 `DSH_DESKTOP_ISOLATED_HOST=0` 可回退到原有同进程路径进行对比。不要让两个实例同时使用同一 Profile。
 
 ## 验证与推广
 
 Headless 测试覆盖双向原生调用、取消、环境来源、窗口与托盘回调、退出管理，以及真实 Node 子进程中的 DSH Web Profile 启动。真实进程夹具将 Node IPC 适配为 utility-process 的端口接口，不验证 Electron utility process 或系统打包行为。它验证不同 PID、认证、第三方客户端插件条目及其脚本下载，以及 Web 服务正常关闭。
 
-默认启用或推广到稳定版前，需要验证 Windows/macOS 安装包的 utility process、ASAR 路径与原生模块；各模式窗口材质和控制；设置、托盘刷新与 Profile 切换；LAN 证书；Host 崩溃/卡死和退出；AA 启动与大量历史同步；浏览器中的插件实际激活与 HMR。还要确认退出后没有残留 Connector/工具子进程。未测量前不能宣称已改善 Windows 响应。
+推广到稳定版前，需要验证 Windows/macOS 安装包的 utility process、ASAR 路径与原生模块；各模式窗口材质和控制；设置、托盘刷新与 Profile 切换；LAN 证书；Host 崩溃/卡死和退出；AA 启动与大量历史同步；浏览器中的插件实际激活与 HMR。还要确认退出后没有残留 Connector/工具子进程。未测量前不能宣称已改善 Windows 响应。
 
 Host 意外退出时报告错误，不自动重启或重放请求。退出先请求正常清理，再终止无响应子进程并限时等待退出；若无法确认终止，恢复操作继续受保护。当前夹具未证明强制终止时任意插件后代进程的清理。
 
-实验阶段独立启动器暂时保留了与原启动器对应的实现。默认启用前应统一两条启动实现，避免生命周期逻辑分叉。截图里的请求扩展清单错误仍需要单独的打包布局回归测试与修复。
+实验阶段独立启动器暂时保留了与原启动器对应的实现。推广到稳定版前应统一两条启动实现，避免生命周期逻辑分叉。截图里的请求扩展清单错误仍需要单独的打包布局回归测试与修复。
+
+## 原生顶栏隔离
+
+macOS 和 Windows 的兼容模式与扩展模式都将打包的顶栏放在独立、沙箱化的 WebContentsView 中。DSH 内容从 36px 原生边界下方开始，内容文档不再额外预留高度或挂载 Portal 顶栏。前端插件的 DOM、CSS 和插槽无法访问顶栏文档。这是前端边界，不是任意高权限 Host 代码的安全沙箱。macOS 增强模式为主面板与右侧面板预留完整的 32px 拖拽条高度，保留侧栏原有间距。原生界面仍需手动验证。

--- a/dsh-plugin-desktop-beta/docs/compatibility-chrome-isolation.md
+++ b/dsh-plugin-desktop-beta/docs/compatibility-chrome-isolation.md
@@ -2,7 +2,7 @@
 
 This optimization from PR #868 is beta-only. Stable uses the original single-document compatibility frame. Renderer crash recovery from PR #869 remains enabled in both variants.
 
-On macOS and Windows, compatibility mode uses two documents in one native window:
+On macOS and Windows, compatibility and extended modes use two documents in one native window:
 
 - A transparent, Desktop-owned WebContentsView loads the packaged `native-ui/compatibility-chrome.html` in an ephemeral, Desktop-only session. Its preload exposes only fixed chrome commands and locale/version state.
 - A WebContentsView loads the upstream DSH page in `persist:dsh-desktop-renderer`. It retains the existing file-path preload, authentication exchange, request capability, navigation policy, boot monitoring, reload, zoom, and developer-tools behavior.
@@ -15,7 +15,7 @@ On macOS and Windows, compatibility mode uses two documents in one native window
 - IPC is registered on the chrome WebContents, validates its exact packaged top-level document, and rejects arbitrary commands and other frames. The DSH preload exposes no chrome bridge. No renderer-supplied JavaScript, URL, or filesystem path is executed by the command handler.
 - Teardown removes handlers/listeners and explicitly closes both child WebContents. The chrome document does not load Cordis, DSH, or third-party client plugins.
 
-Linux compatibility mode retains the native-titlebar fallback. Extended and advanced modes keep their existing rendering paths; this change does not introduce Shadow DOM there.
+Linux compatibility mode retains the native-titlebar fallback. Extended mode uses the same isolated chrome on macOS and Windows; advanced mode retains its integrated layout. This change does not introduce Shadow DOM.
 
 ## Verification
 

--- a/dsh-plugin-desktop-beta/package.json
+++ b/dsh-plugin-desktop-beta/package.json
@@ -124,6 +124,7 @@
     "check:win-package": "yarn workspace dsh-community-market build && yarn run build && yarn run typecheck && vitest run tests/package.spec.ts tests/package-win.spec.ts tests/desktop-installer-quit.spec.ts tests/installer-nsh.spec.ts tests/update-checker.spec.ts tests/update-download.spec.ts tests/verify-win-installer.spec.ts tests/verify-win-portable.spec.ts tests/verify-packaged-runtime.spec.ts tests/windows-pwsh-sandbox.spec.ts tests/windows-volume-diagnostics.spec.ts tests/window-options.spec.ts tests/safe-mode.spec.ts && yarn run verify:closure",
     "check:mac-package": "yarn workspace dsh-community-market build && yarn run build && yarn run typecheck && vitest run tests/package.spec.ts tests/package-mac.spec.ts tests/verify-mac-smoke.spec.ts tests/verify-packaged-runtime.spec.ts tests/mac-universal.spec.ts && yarn run verify:closure",
     "start": "node lib/bin.js",
+    "start:isolated": "DSH_DESKTOP_ISOLATED_HOST=1 node lib/bin.js",
     "dev": "yarn run build && yarn run prepare:electron-native && node lib/bin.js",
     "package:dir": "yarn run build && yarn run prepare:electron-native && node scripts/package-dir.mjs",
     "dist:mac": "node scripts/release-mac.ts",

--- a/dsh-plugin-desktop-beta/src/client/extended-shell.ts
+++ b/dsh-plugin-desktop-beta/src/client/extended-shell.ts
@@ -4,15 +4,8 @@ import type { Context as ClientContext } from '@deepseek-ai/cordis'
 import type {} from '@deepseek-ai/dsh-client-ui-theme/client'
 import type {} from './contracts.ts'
 import { ExtendedFrame } from './ExtendedFrame.tsx'
-import { createDesktopSettingsApi } from './desktop-settings-api.ts'
-import {
-  DESKTOP_SETTINGS_LOCALE_NAMESPACE,
-  DESKTOP_SHELL_SETTINGS_NAMESPACE,
-  type DesktopSettingsClientControl,
-} from './desktop-settings.ts'
-import type { DesktopShellSettings } from './DesktopSettingsSection.tsx'
+import type { DesktopSettingsClientControl } from './desktop-settings.ts'
 import type { DesktopClientEnvironment } from './environment.ts'
-import { DesktopFrameTitlebar } from './ExtendedTitlebar.tsx'
 import { installExtendedStyles } from './extended-styles.ts'
 import { DesktopLayoutState } from './layout-state.ts'
 import { installDesktopLayout } from './layout-service.ts'
@@ -55,19 +48,11 @@ function applyExtendedOwnedShell(ctx: ClientContext, environment: DesktopClientE
 export function applyFramedShell(
   ctx: ClientContext,
   environment: DesktopClientEnvironment,
-  settingsControl?: DesktopSettingsClientControl,
+  _settingsControl?: DesktopSettingsClientControl,
 ): void {
   if (environment.mode !== 'compatibility' && environment.mode !== 'extended') {
     throw new Error(`dsh-plugin-desktop: framed shell received mode ${JSON.stringify(environment.mode)}`)
   }
-  const api = settingsControl?.api ?? createDesktopSettingsApi()
-  const setMode = settingsControl?.setMode ?? (async (mode: DesktopShellSettings['mode']) => {
-    const desktopSettings = ctx.settingsScope.bind<DesktopShellSettings>({
-      namespace: DESKTOP_SHELL_SETTINGS_NAMESPACE,
-    })
-    await desktopSettings.set('mode', mode)
-  })
-
   ctx.effect(() => {
     const contentViewport = document.getElementById('root')
     if (contentViewport === null) {
@@ -86,14 +71,6 @@ export function applyFramedShell(
       delete document.body.dataset.dshDesktopMaterial
     }
   }, `desktop: independent ${environment.mode} frame styles`)
-
-  ctx.slots.inject('shell.overlay', () => ctx.slots.register({
-    name: 'shell.overlay',
-    id: 'desktop-frame-titlebar',
-    order: -1000,
-    locale: DESKTOP_SETTINGS_LOCALE_NAMESPACE,
-    inject: () => ({ api, environment, setMode }),
-  }, DesktopFrameTitlebar))
 }
 
 /** Compose the extended-owned layout beneath its independent Desktop frame. */

--- a/dsh-plugin-desktop-beta/src/client/extended-styles.ts
+++ b/dsh-plugin-desktop-beta/src/client/extended-styles.ts
@@ -16,7 +16,7 @@ body:is([data-dsh-desktop-mode="compatibility"], [data-dsh-desktop-mode="extende
   height: 100%;
 }
 body:is([data-dsh-desktop-mode="compatibility"], [data-dsh-desktop-mode="extended"]) {
-  --dsh-desktop-frame-height: ${DESKTOP_FRAME_HEIGHT}px;
+  --dsh-desktop-frame-height: 0px;
   margin: 0;
   overflow: hidden;
   background: transparent !important;
@@ -24,7 +24,7 @@ body:is([data-dsh-desktop-mode="compatibility"], [data-dsh-desktop-mode="extende
 body:is([data-dsh-desktop-mode="compatibility"], [data-dsh-desktop-mode="extended"]) #root {
   box-sizing: border-box;
   position: fixed;
-  top: ${DESKTOP_FRAME_HEIGHT}px;
+  top: 0;
   right: 0;
   bottom: 0;
   left: 0;

--- a/dsh-plugin-desktop-beta/src/client/styles.ts
+++ b/dsh-plugin-desktop-beta/src/client/styles.ts
@@ -20,7 +20,7 @@ body:is([data-dsh-desktop-mode="extended"], [data-dsh-desktop-mode="advanced"]) 
 body:is([data-dsh-desktop-mode="extended"], [data-dsh-desktop-mode="advanced"]) [data-slot="sidebar.footer.action"] > * { flex: none; min-width: 0; }
 .dshDesktopFrame[data-desktop-mode="advanced"][data-desktop-platform="darwin"] .dshDesktopUpstreamSidebar { padding-top: ${ADVANCED_MACOS_CONTENT_INSET}px; }
 .dshDesktopFrame[data-desktop-mode="advanced"][data-desktop-platform="darwin"][data-sidebar-collapsed] .dshDesktopUpstreamSidebar { width: ${SIDEBAR_COLLAPSED}px; margin: 0 auto; }
-.dshDesktopFrame[data-desktop-mode="advanced"][data-desktop-platform="darwin"] { grid-template-rows: ${ADVANCED_MACOS_CONTENT_INSET}px minmax(0, 1fr); }
+.dshDesktopFrame[data-desktop-mode="advanced"][data-desktop-platform="darwin"] { grid-template-rows: ${ADVANCED_MACOS_DRAG_REGION_HEIGHT}px minmax(0, 1fr); }
 .dshDesktopFrame[data-desktop-mode="advanced"][data-desktop-platform="darwin"] .dshDesktopSidebarSurface { grid-row: 1 / -1; }
 .dshDesktopFrame[data-desktop-mode="advanced"][data-desktop-platform="darwin"] .dshDesktopConversationSurface,
 .dshDesktopFrame[data-desktop-mode="advanced"][data-desktop-platform="darwin"] .dshDesktopRightbarSurface { grid-row: 2; }

--- a/dsh-plugin-desktop-beta/src/client/window-service.ts
+++ b/dsh-plugin-desktop-beta/src/client/window-service.ts
@@ -2,12 +2,10 @@
 
 import type { Context as ClientContext } from '@deepseek-ai/cordis'
 import {
-  ADVANCED_MACOS_CONTENT_INSET,
   ADVANCED_MACOS_DRAG_REGION_HEIGHT,
   ADVANCED_WINDOWS_TITLEBAR_HEIGHT,
   MACOS_TRAFFIC_LIGHT_SAFE_WIDTH,
   WINDOWS_CAPTION_CONTROLS_WIDTH,
-  DESKTOP_FRAME_HEIGHT,
 } from '../window-chrome.ts'
 import type { DesktopWindowService } from './contracts.ts'
 import type { DesktopClientEnvironment } from './environment.ts'
@@ -29,7 +27,7 @@ export function desktopWindowService(environment: DesktopClientEnvironment): Des
         ? ['off', 'mica'] as const
         : ['off'] as const
       : ['off'] as const)
-  if (environment.mode === 'compatibility') {
+  if (environment.mode === 'compatibility' || environment.mode === 'extended') {
     return Object.freeze({
       ...environment,
       availableMaterials,
@@ -37,23 +35,11 @@ export function desktopWindowService(environment: DesktopClientEnvironment): Des
       dragRegion: frozenDragRegion(0, 0, 0),
     })
   }
-  if (environment.mode === 'extended') {
-    return Object.freeze({
-      ...environment,
-      availableMaterials,
-      safeAreaInsets: frozenInsets(DESKTOP_FRAME_HEIGHT),
-      dragRegion: frozenDragRegion(
-        DESKTOP_FRAME_HEIGHT,
-        environment.platform === 'darwin' ? MACOS_TRAFFIC_LIGHT_SAFE_WIDTH : 0,
-        environment.platform === 'win32' ? WINDOWS_CAPTION_CONTROLS_WIDTH : 0,
-      ),
-    })
-  }
   if (environment.platform === 'darwin') {
     return Object.freeze({
       ...environment,
       availableMaterials,
-      safeAreaInsets: frozenInsets(ADVANCED_MACOS_CONTENT_INSET),
+      safeAreaInsets: frozenInsets(ADVANCED_MACOS_DRAG_REGION_HEIGHT),
       dragRegion: frozenDragRegion(
         ADVANCED_MACOS_DRAG_REGION_HEIGHT,
         MACOS_TRAFFIC_LIGHT_SAFE_WIDTH,

--- a/dsh-plugin-desktop-beta/src/compatibility-chrome-contract.ts
+++ b/dsh-plugin-desktop-beta/src/compatibility-chrome-contract.ts
@@ -3,9 +3,10 @@ import type { DesktopLocale, DesktopPlatform } from './runtime.ts'
 export const COMPATIBILITY_CHROME_CHANNEL = 'dsh-desktop:compatibility-chrome'
 export const COMPATIBILITY_CHROME_STATE = 'dsh-desktop:compatibility-chrome-state'
 
-export type CompatibilityChromeCommand = 'state' | 'check-for-updates' | 'mode-extended' | 'mode-advanced' | 'terminal' | 'restart' | 'restart-recovery' | 'reload' | 'developer' | 'expand' | 'collapse'
+export type CompatibilityChromeCommand = 'mode-compatibility' | 'state' | 'check-for-updates' | 'mode-extended' | 'mode-advanced' | 'terminal' | 'restart' | 'restart-recovery' | 'reload' | 'developer' | 'expand' | 'collapse'
 
 export interface CompatibilityChromeState {
+  readonly mode: 'compatibility' | 'extended'
   readonly locale: DesktopLocale
   readonly platform: DesktopPlatform
   readonly version: string

--- a/dsh-plugin-desktop-beta/src/compatibility-shell.ts
+++ b/dsh-plugin-desktop-beta/src/compatibility-shell.ts
@@ -92,7 +92,7 @@ export class CompatibilityShell {
   }
 
   private state(): CompatibilityChromeState {
-    return { locale: this.actions.locale(), version: this.actions.version, platform: this.platform, material: this.spec.material }
+    return { mode: this.spec.mode === 'extended' ? 'extended' : 'compatibility', locale: this.actions.locale(), version: this.actions.version, platform: this.platform, material: this.spec.material }
   }
 
   private readonly resize = (): void => {
@@ -133,6 +133,7 @@ export class CompatibilityShell {
       case 'collapse': this.collapse(); return
       case 'terminal': this.actions.openTerminal(); return
       case 'check-for-updates': return this.actions.checkForUpdates()
+      case 'mode-compatibility': return this.spec.requestModeChange('compatibility')
       case 'mode-extended': return this.spec.requestModeChange('extended')
       case 'mode-advanced': return this.spec.requestModeChange('advanced')
       case 'restart': return this.actions.restart()

--- a/dsh-plugin-desktop-beta/src/electron-shell-generation.ts
+++ b/dsh-plugin-desktop-beta/src/electron-shell-generation.ts
@@ -262,7 +262,7 @@ export class ElectronShellGeneration {
     } catch (cause) {
       this.options.logError(`dsh-plugin-desktop: failed to restore main-window state: ${cause instanceof Error ? cause.message : String(cause)}`)
     }
-    const isolated = spec.mode === 'compatibility' && platform.platform !== 'linux'
+    const isolated = spec.mode !== 'advanced' && platform.platform !== 'linux'
     const windowOptions = desktopWindowOptions(spec, icon, platform.platform, this.options.preloadPath)
     const window = new BrowserWindow({
       ...windowOptions,

--- a/dsh-plugin-desktop-beta/src/host-bootstrap.ts
+++ b/dsh-plugin-desktop-beta/src/host-bootstrap.ts
@@ -49,7 +49,7 @@ export interface DesktopHostOptions {
 export async function bootDesktopHost(options: DesktopHostOptions, runtime: DesktopRuntime,
   browserAccess: DesktopBrowserAccess, lanHttps: DesktopLanHttpsRuntime,
   bindHost: (host: DesktopStartupGenerationHost) => void, requestQuit: (code: number) => void,
-): Promise<{ aaRuntime: boolean; aaOnboarding: boolean }> {
+): Promise<() => { aaRuntime: boolean; aaOnboarding: boolean }> {
   const { prepared, profilePreferences, homeDir, activeProfileName, pluginManagementStatePath,
     selectionStatePath, marketUserDataDir, releaseUserDataLocations, desktopLaunchEnvironment,
     desktopPnpmBootstrap } = options
@@ -273,5 +273,5 @@ export async function bootDesktopHost(options: DesktopHostOptions, runtime: Desk
         )
       })
     })
-  return { aaRuntime: ctx.get('agentsAnywhereRuntime') !== undefined, aaOnboarding: ctx.get('agentsAnywhereOnboarding') !== undefined }
+  return () => ({ aaRuntime: ctx.get('agentsAnywhereRuntime') !== undefined, aaOnboarding: ctx.get('agentsAnywhereOnboarding') !== undefined })
 }

--- a/dsh-plugin-desktop-beta/src/host-bootstrap.ts
+++ b/dsh-plugin-desktop-beta/src/host-bootstrap.ts
@@ -1,0 +1,277 @@
+/** Headless bootstrap for the Beta isolated Host experiment. */
+import { boot, resolveProfileDir } from '@deepseek-ai/dsh-app-boot'
+import { provideCmdline } from '@deepseek-ai/dsh-cmdline'
+import { DSH_LAUNCH_ENVIRONMENT_KEY, type LaunchEnvironmentSnapshot } from '@deepseek-ai/dsh-launch-environment'
+import { DESKTOP_PACKAGE_NAME as BIN_NAME } from './product-identity.ts'
+import { DESKTOP_SETTINGS_NAMESPACE, type DesktopSettings } from './index.ts'
+import { DESKTOP_NOTIFICATIONS_SETTINGS_NAMESPACE, type DesktopNotificationSettings } from './notifications.ts'
+import { installProfilePackageResolver } from './module-resolution.ts'
+import { createDesktopWebProfile, listDesktopProfiles, canDeleteDesktopProfile, deleteDesktopProfile, selectDesktopProfile } from './profile-manager.ts'
+import { DesktopProfileService } from './profile-service.ts'
+import { DesktopActionsService } from './desktop-actions.ts'
+import { clearDesktopProfilePluginState, DesktopPluginsService } from './desktop-plugins.ts'
+import { desktopMarketSnapshotWithEffective, selectDesktopMarketProvider, type DesktopMarketProvider, type DesktopMarketSnapshot } from './desktop-market.ts'
+import DesktopSettingsController from './desktop-settings-controller.ts'
+import { clearDesktopProfilePreferences, desktopProfilePreferencesFromSettings, writeDesktopProfilePreferences, type DesktopProfilePreferences, type DesktopProfilePreferencesStateV1 } from './profile-preferences.ts'
+import { clearDesktopProfileUsageHistory, type DesktopReleaseUserDataLocations } from './profile-channel-admission.ts'
+import { desktopInstallAnchor, type PreparedDesktopProfile } from './profile.ts'
+import { desktopLanBrowserUrls, desktopLoopbackBrowserUrl } from './desktop-network.ts'
+import { DESKTOP_LAN_HTTPS_CA_PATH, type DesktopLanHttpsRuntime } from './lan-https-runtime.ts'
+import type { DesktopBrowserAccess } from './desktop-browser-access.ts'
+import type { DesktopPnpmBootstrap } from './pnpm.ts'
+import type { DesktopRuntime } from './runtime.ts'
+import type { DesktopStartupGenerationHost } from './startup-generation.ts'
+import { FileExporter } from './file-exporter.ts'
+import { LogFileSink } from './log-files.ts'
+
+function desktopProfileMarketSnapshot(market: DesktopMarketProvider): DesktopMarketSnapshot {
+  return Object.freeze({
+    requested: market,
+    effective: market,
+    legacyDefaulted: false,
+  })
+}
+
+export interface DesktopHostOptions {
+  prepared: PreparedDesktopProfile
+  profilePreferences: DesktopProfilePreferences
+  homeDir: string
+  activeProfileName: string
+  pluginManagementStatePath: string
+  selectionStatePath: string
+  marketUserDataDir: string
+  releaseUserDataLocations: DesktopReleaseUserDataLocations
+  desktopLaunchEnvironment: LaunchEnvironmentSnapshot
+  desktopPnpmBootstrap: DesktopPnpmBootstrap
+  logDirectory: string
+}
+
+export async function bootDesktopHost(options: DesktopHostOptions, runtime: DesktopRuntime,
+  browserAccess: DesktopBrowserAccess, lanHttps: DesktopLanHttpsRuntime,
+  bindHost: (host: DesktopStartupGenerationHost) => void, requestQuit: (code: number) => void,
+): Promise<{ aaRuntime: boolean; aaOnboarding: boolean }> {
+  const { prepared, profilePreferences, homeDir, activeProfileName, pluginManagementStatePath,
+    selectionStatePath, marketUserDataDir, releaseUserDataLocations, desktopLaunchEnvironment,
+    desktopPnpmBootstrap } = options
+  const createFreshDesktopProfile = (name: string) => {
+    const created = createDesktopWebProfile(homeDir, name)
+    clearDesktopProfileUsageHistory(releaseUserDataLocations, created.dir)
+    return created
+  }
+  const logSink = new LogFileSink(options.logDirectory, {
+    maxFileBytes: 10 * 1024 * 1024, maxDirectoryBytes: 200 * 1024 * 1024,
+  })
+  let fileExporter: FileExporter | undefined
+    let currentProfilePreferences: DesktopProfilePreferences = profilePreferences
+    let profilePreferencesWriteTail: Promise<void> = Promise.resolve()
+    let profilePreferencesStopping = false
+    const enqueueProfilePreferencesWrite = (
+      update: (current: DesktopProfilePreferences) => DesktopProfilePreferences,
+    ): Promise<DesktopProfilePreferencesStateV1> => {
+      if (profilePreferencesStopping) {
+        return Promise.reject(new Error(`${BIN_NAME}: Profile preferences are stopping`))
+      }
+      const write = profilePreferencesWriteTail.then(async () => {
+        const next = update(currentProfilePreferences)
+        const stored = await writeDesktopProfilePreferences(
+          marketUserDataDir,
+          prepared.profile.dir,
+          next,
+        )
+        currentProfilePreferences = stored
+        return stored
+      })
+      profilePreferencesWriteTail = write.then(() => undefined, () => undefined)
+      return write
+    }
+    const flushProfilePreferencesWrites = async (): Promise<void> => {
+      profilePreferencesStopping = true
+      await profilePreferencesWriteTail
+    }
+    const releasePackageResolver = installProfilePackageResolver(prepared.bareModuleBaseUrl)
+    const ctx = await boot(
+      BIN_NAME,
+      prepared.rootConfig,
+      prepared.patches,
+      async (hostCtx) => {
+        // Keep Host imports and browser bundle discovery on the same public
+        // profile-overlay resolver used by packaged Electron.
+        hostCtx.loader.internal = undefined
+        bindHost(hostCtx)
+        hostCtx.effect(() => () => logSink.close(), 'dsh-plugin-desktop: Host log sink')
+        hostCtx.effect(
+          () => async () => { await flushProfilePreferencesWrites() },
+          'dsh-plugin-desktop: flush Profile preference writes',
+        )
+        hostCtx.effect(
+          () => releasePackageResolver,
+          'dsh-plugin-desktop: profile package resolution',
+        )
+        hostCtx.provide(DSH_LAUNCH_ENVIRONMENT_KEY, desktopLaunchEnvironment)
+        hostCtx.provide('desktopBrowserAccess', browserAccess)
+        hostCtx.provide('desktopLanHttps', lanHttps)
+        hostCtx.provide('desktopRuntime', runtime)
+        hostCtx.provide('desktopPnpmBootstrap', desktopPnpmBootstrap)
+        await hostCtx.plugin(DesktopActionsService, {
+          openTerminal: () => { runtime.openTerminal() },
+          requestRestart: () => runtime.requestRestart(),
+        })
+        if (prepared.market.effective === 'community-market') {
+          await hostCtx.plugin(DesktopPluginsService, {
+            profileName: activeProfileName,
+            homeDir,
+            statePath: pluginManagementStatePath,
+            installAnchor: desktopInstallAnchor(),
+          })
+        }
+        if (logSink !== undefined) {
+          fileExporter = new FileExporter(logSink)
+          hostCtx.logger.exporter(fileExporter)
+        }
+        await hostCtx.plugin(DesktopProfileService, {
+          current: {
+            name: activeProfileName,
+            dir: prepared.profile.dir,
+          },
+          create: name => createFreshDesktopProfile(name),
+          list: () => listDesktopProfiles(homeDir),
+          canDelete: name => canDeleteDesktopProfile({
+            home: homeDir,
+            selectionStatePath,
+            currentProfileName: activeProfileName,
+          }, name),
+          delete: async name => {
+            const profileDir = resolveProfileDir(name, homeDir)
+            await deleteDesktopProfile({
+              home: homeDir,
+              selectionStatePath,
+              currentProfileName: activeProfileName,
+              clearDisabledState: () => clearDesktopProfilePluginState(pluginManagementStatePath, name),
+              clearCheckpoint: async () => {
+                clearDesktopProfileUsageHistory(releaseUserDataLocations, profileDir)
+              },
+            }, name)
+            try {
+              await clearDesktopProfilePreferences(marketUserDataDir, profileDir)
+            } catch (cause) {
+              hostCtx.logger.error(
+                `${BIN_NAME}: deleted Profile left stale preference state: ${cause instanceof Error ? cause.message : String(cause)}`,
+              )
+            }
+          },
+          persistSelection: name => { selectDesktopProfile(selectionStatePath, homeDir, name) },
+          requestRestart: () => runtime.requestRestart(),
+        })
+        let pendingSettingsRestart: ReturnType<typeof setImmediate> | undefined
+        const scheduleSettingsRestart = (): void => {
+          pendingSettingsRestart ??= setImmediate(() => {
+            pendingSettingsRestart = undefined
+            void runtime.requestRestart().catch((cause: unknown) => {
+              hostCtx.logger.error(
+                `${BIN_NAME}: failed to restart after Desktop setting change: ${cause instanceof Error ? cause.message : String(cause)}`,
+              )
+            })
+          })
+        }
+        hostCtx.effect(() => () => {
+          if (pendingSettingsRestart !== undefined) clearImmediate(pendingSettingsRestart)
+          pendingSettingsRestart = undefined
+        }, 'dsh-plugin-desktop: pending Desktop settings restart')
+        const readMarket = () => desktopMarketSnapshotWithEffective(
+          desktopProfileMarketSnapshot(currentProfilePreferences.market),
+          prepared.market.effective,
+        )
+        hostCtx.provide('desktopSettingsController', new DesktopSettingsController({
+          profiles: hostCtx.desktopProfiles,
+          readMarket,
+          readAa: () => ({ requested: currentProfilePreferences.aaEnabled === true, effective: prepared.aaEnabled }),
+          selectAa: async enabled => {
+            await enqueueProfilePreferencesWrite(current => desktopProfilePreferencesFromSettings(
+              current,
+              current.notifications,
+              current.market,
+              enabled,
+            ))
+          },
+          readWeb: () => {
+            const lan = lanHttps.snapshot()
+            const lanOrigins = lan.state === 'ready' && lan.actualPort !== null
+              ? desktopLanBrowserUrls(lan.actualPort, lan.addresses)
+              : []
+            return {
+              localUrl: hostCtx.connection.authenticatedUrl(
+                desktopLoopbackBrowserUrl(hostCtx.webServer.port),
+              ),
+              lanUrls: lanOrigins.map(url => hostCtx.connection.authenticatedUrl(url)),
+              lanState: lan.state,
+              lanError: lan.errorCode,
+              lanCaFingerprint: lan.caFingerprint,
+              lanCaUrls: lanOrigins.map((origin) => {
+                return new URL(DESKTOP_LAN_HTTPS_CA_PATH, origin).href
+              }),
+            }
+          },
+          selectMarket: async provider => {
+            await enqueueProfilePreferencesWrite(current => desktopProfilePreferencesFromSettings(
+              current,
+              current.notifications,
+              provider,
+              current.aaEnabled === true,
+            ))
+            return desktopMarketSnapshotWithEffective(
+              await selectDesktopMarketProvider(marketUserDataDir, provider),
+              prepared.market.effective,
+            )
+          },
+          scheduleRestart: scheduleSettingsRestart,
+          scheduleRecoveryRestart: () => {
+            void runtime.requestRecoveryRestart().catch((cause: unknown) => {
+              hostCtx.logger.error(
+                `${BIN_NAME}: failed to restart in recovery mode: ${cause instanceof Error ? cause.message : String(cause)}`,
+              )
+            })
+          },
+          openTerminal: () => { runtime.openTerminal() },
+          reloadRenderer: () => { runtime.reloadRenderer() },
+          toggleDeveloperTools: () => { runtime.toggleDeveloperTools() },
+          exportDiagnostics: () => runtime.exportDiagnostics(),
+        }))
+        provideCmdline(hostCtx, {
+          args: [
+            '--port',
+            String(prepared.port),
+          ],
+          exit: requestQuit,
+        })
+      },
+      prepared.bareModuleBaseUrl,
+    ).catch((cause: unknown) => {
+      releasePackageResolver()
+      throw cause
+    })
+    bindHost(ctx)
+    fileExporter?.setThreshold((ctx.settings.get(DESKTOP_SETTINGS_NAMESPACE) as DesktopSettings | undefined)?.logLevel ?? 'info')
+    ctx.on('settings/updated', (namespace, next) => {
+      if (namespace === DESKTOP_SETTINGS_NAMESPACE) {
+        fileExporter?.setThreshold((next as DesktopSettings).logLevel)
+      }
+      if (namespace !== DESKTOP_SETTINGS_NAMESPACE
+        && namespace !== DESKTOP_NOTIFICATIONS_SETTINGS_NAMESPACE) return
+      const write = enqueueProfilePreferencesWrite(current => desktopProfilePreferencesFromSettings(
+        namespace === DESKTOP_SETTINGS_NAMESPACE
+          ? next as DesktopSettings
+          : ctx.settings.get(DESKTOP_SETTINGS_NAMESPACE) as DesktopSettings,
+        namespace === DESKTOP_NOTIFICATIONS_SETTINGS_NAMESPACE
+          ? next as DesktopNotificationSettings
+          : ctx.settings.get(DESKTOP_NOTIFICATIONS_SETTINGS_NAMESPACE) as DesktopNotificationSettings,
+        current.market,
+        current.aaEnabled === true,
+      ))
+      void write.catch((cause: unknown) => {
+        ctx.logger.error(
+          `${BIN_NAME}: failed to capture active Profile settings: ${cause instanceof Error ? cause.message : String(cause)}`,
+        )
+      })
+    })
+  return { aaRuntime: ctx.get('agentsAnywhereRuntime') !== undefined, aaOnboarding: ctx.get('agentsAnywhereOnboarding') !== undefined }
+}

--- a/dsh-plugin-desktop-beta/src/host-launch-environment.ts
+++ b/dsh-plugin-desktop-beta/src/host-launch-environment.ts
@@ -1,0 +1,20 @@
+/** Preserve environment provenance across the private child channel. */
+import type { LaunchEnvironmentLayerInput, LaunchEnvironmentSnapshot } from '@deepseek-ai/dsh-launch-environment'
+
+// loadLayeredEnv materializes all layer names into process.env before launch.
+// Keep every source, including shadowed values, instead of flattening trust levels.
+export function serializeHostEnvironment(snapshot: LaunchEnvironmentSnapshot,
+  names: readonly string[] = [...Object.keys(process.env), 'DSH_HOME'],
+): LaunchEnvironmentLayerInput[] {
+  return (['process', 'project-env', 'user-env'] as const).map(source => {
+    const values: Record<string, string> = {}
+    let path: string | undefined
+    for (const name of names) {
+      const entry = snapshot.getFrom(name, [source])
+      if (!entry) continue
+      values[name] = entry.value
+      path ??= entry.path
+    }
+    return { source, values, ...(path ? { path } : {}) }
+  })
+}

--- a/dsh-plugin-desktop-beta/src/host-process-entry.ts
+++ b/dsh-plugin-desktop-beta/src/host-process-entry.ts
@@ -18,6 +18,8 @@ const rpc = new HostRpc({
   },
 }, 120_000)
 let host: DesktopStartupGenerationHost | undefined
+let inspectServices = () => ({ aaRuntime: false, aaOnboarding: false })
+rpc.handle('status', () => ({ pid: process.pid, services: inspectServices() }))
 let starting = false
 let stopping = false
 let lan: DesktopLanHttpsRuntime | undefined
@@ -37,9 +39,9 @@ rpc.handle('boot', async args => {
     addresses: options.prepared.lanAddresses, requestedPort: 0,
     prepareCertificate: () => rpc.call('certificate'),
   })
-  const services = await bootDesktopHost(options, runtime, browser, lan,
+  inspectServices = await bootDesktopHost(options, runtime, browser, lan,
     value => { host = value }, code => { void rpc.call('quit', [code]).catch(() => {}) })
   if (stopping) { await host?.fiber.dispose(); throw new Error('DSH Host stopped during startup') }
   await runtime.mountScheduled()
-  return { pid: process.pid, services }
+  return { pid: process.pid }
 })

--- a/dsh-plugin-desktop-beta/src/host-process-entry.ts
+++ b/dsh-plugin-desktop-beta/src/host-process-entry.ts
@@ -1,0 +1,45 @@
+/** Utility-process entrypoint. No BrowserWindow or Electron main APIs are imported here. */
+import { createLaunchEnvironmentSnapshot, type LaunchEnvironmentLayerInput } from '@deepseek-ai/dsh-launch-environment'
+import { HostRpc } from './host-rpc.ts'
+import { createHostRuntime, type RuntimeSnapshot } from './host-runtime-bridge.ts'
+import { bootDesktopHost, type DesktopHostOptions } from './host-bootstrap.ts'
+import { createDesktopBrowserAccess } from './desktop-browser-access.ts'
+import { DesktopLanHttpsRuntime } from './lan-https-runtime.ts'
+import type { DesktopStartupGenerationHost } from './startup-generation.ts'
+
+const parentPort = process.parentPort
+if (!parentPort) throw new Error('DSH Host must be started by the Desktop supervisor')
+const rpc = new HostRpc({
+  send: message => parentPort.postMessage(message),
+  listen: receive => {
+    const listener = (event: { data: unknown }) => receive(event.data)
+    parentPort.on('message', listener)
+    return () => { parentPort.removeListener('message', listener) }
+  },
+}, 120_000)
+let host: DesktopStartupGenerationHost | undefined
+let starting = false
+let stopping = false
+let lan: DesktopLanHttpsRuntime | undefined
+rpc.handle('stop', async () => {
+  stopping = true
+  await host?.fiber.dispose()
+  await lan?.stop()
+})
+rpc.handle('boot', async args => {
+  const [wire, snapshot, token] = args as [Omit<DesktopHostOptions, 'desktopLaunchEnvironment'> & { launchEnvironmentLayers: LaunchEnvironmentLayerInput[] }, RuntimeSnapshot, string]
+  const options: DesktopHostOptions = { ...wire, desktopLaunchEnvironment: createLaunchEnvironmentSnapshot(wire.launchEnvironmentLayers) }
+  if (starting || stopping) throw new Error('DSH Host generation already started or stopped')
+  starting = true
+  const runtime = createHostRuntime(rpc, snapshot)
+  const browser = createDesktopBrowserAccess(options.prepared.mode === 'compatibility' && options.prepared.openBrowser, token)
+  lan = new DesktopLanHttpsRuntime({
+    addresses: options.prepared.lanAddresses, requestedPort: 0,
+    prepareCertificate: () => rpc.call('certificate'),
+  })
+  const services = await bootDesktopHost(options, runtime, browser, lan,
+    value => { host = value }, code => { void rpc.call('quit', [code]).catch(() => {}) })
+  if (stopping) { await host?.fiber.dispose(); throw new Error('DSH Host stopped during startup') }
+  await runtime.mountScheduled()
+  return { pid: process.pid, services }
+})

--- a/dsh-plugin-desktop-beta/src/host-process.ts
+++ b/dsh-plugin-desktop-beta/src/host-process.ts
@@ -1,0 +1,74 @@
+/** Electron owns the child lifetime; the child owns the unchanged DSH Web server. */
+import { serializeHostEnvironment } from './host-launch-environment.ts'
+import { utilityProcess } from 'electron'
+import { fileURLToPath } from 'node:url'
+import { HostRpc } from './host-rpc.ts'
+import { bindNativeRuntime, runtimeSnapshot } from './host-runtime-bridge.ts'
+import type { DesktopHostOptions } from './host-bootstrap.ts'
+import type { DesktopRuntime } from './runtime.ts'
+import type { DesktopStartupGenerationHost } from './startup-generation.ts'
+import type { DesktopLanHttpsRuntimeOptions } from './lan-https-runtime.ts'
+
+export interface IsolatedHostOptions {
+  host: DesktopHostOptions
+  runtime: DesktopRuntime
+  rendererToken: string
+  prepareCertificate: NonNullable<DesktopLanHttpsRuntimeOptions['prepareCertificate']>
+  bindHost(host: DesktopStartupGenerationHost): void
+  requestQuit(code: number): void
+  onFailure(error: Error): void
+}
+
+export async function startIsolatedDesktopHost(options: IsolatedHostOptions): Promise<void> {
+  const child = utilityProcess.fork(fileURLToPath(new URL('./host-process-entry.js', import.meta.url)), [], {
+    serviceName: 'DSH Host', stdio: 'pipe', cwd: process.cwd(), env: { ...process.env },
+  })
+  // Keep normal Host logs in its own files; stderr includes bootstrap failures.
+  child.stdout?.on('data', (data: Buffer) => { process.stdout.write(data) })
+  child.stderr?.on('data', (data: Buffer) => { process.stderr.write(data) })
+  const rpc = new HostRpc({
+    send: message => child.postMessage(message),
+    listen: receive => { child.on('message', receive); return () => { child.removeListener('message', receive) } },
+  }, 120_000)
+  const releaseNative = bindNativeRuntime(rpc, options.runtime)
+  rpc.handle('certificate', () => options.prepareCertificate())
+  rpc.handle('quit', ([code]) => { setImmediate(() => options.requestQuit(code)) })
+  let stopping = false
+  let exited = false
+  let booted = false
+  let resolveExit!: () => void
+  const exit = new Promise<void>(resolve => { resolveExit = resolve })
+  child.once('exit', (code) => {
+    exited = true
+    rpc.close(`DSH Host exited (${code})`)
+    resolveExit()
+    if (!stopping && booted) options.onFailure(new Error(`DSH Host exited (${code}); restart the application to reconnect`))
+  })
+  let stopTask: Promise<void> | undefined
+  const stop = (): Promise<void> => stopTask ??= (async () => {
+    stopping = true
+    if (!exited) {
+      const controller = new AbortController()
+      const timeout = setTimeout(() => controller.abort(), 3_000)
+      try { await rpc.call('stop', [], controller.signal) } catch { /* terminate an unresponsive Host */ }
+      finally { clearTimeout(timeout) }
+      if (!exited) child.kill()
+      const timeoutExit = new Promise<never>((_resolve, reject) => {
+        const timer = setTimeout(() => reject(new Error('DSH Host termination was not confirmed')), 1_000)
+        void exit.then(() => clearTimeout(timer))
+      })
+      await Promise.race([exit, timeoutExit])
+    }
+    await releaseNative()
+    rpc.close()
+  })()
+  options.bindHost({ fiber: { dispose: stop } })
+  try {
+    const { desktopLaunchEnvironment, ...host } = options.host
+    await rpc.call('boot', [{ ...host, launchEnvironmentLayers: serializeHostEnvironment(desktopLaunchEnvironment) }, runtimeSnapshot(options.runtime), options.rendererToken])
+    booted = true
+  } catch (cause) {
+    await stop()
+    throw cause
+  }
+}

--- a/dsh-plugin-desktop-beta/src/host-rpc.ts
+++ b/dsh-plugin-desktop-beta/src/host-rpc.ts
@@ -1,0 +1,85 @@
+/** Private, asynchronous control channel. Web traffic never passes through this channel. */
+export interface HostPort {
+  send(message: unknown): void
+  listen(receive: (message: unknown) => void): () => void
+}
+type Handler = (args: any[], signal: AbortSignal) => unknown | Promise<unknown>
+type Pending = { resolve(value: any): void; reject(error: Error): void; cleanup(): void }
+
+export class HostRpc {
+  private sequence = 0
+  private closed = false
+  private readonly pending = new Map<number, Pending>()
+  private readonly active = new Map<number, AbortController>()
+  private readonly handlers = new Map<string, Handler>()
+  private readonly unlisten: () => void
+  constructor(private readonly port: HostPort, private readonly timeoutMs = 30_000) {
+    this.unlisten = port.listen(message => { void this.receive(message) })
+  }
+  handle(name: string, handler: Handler): () => void {
+    if (this.handlers.has(name)) throw new Error(`Duplicate Host handler: ${name}`)
+    this.handlers.set(name, handler)
+    return () => { this.handlers.delete(name) }
+  }
+  call<T = void>(method: string, args: unknown[] = [], signal?: AbortSignal, timeoutMs = this.timeoutMs): Promise<T> {
+    if (this.closed) return Promise.reject(new Error('DSH Host channel closed'))
+    if (signal?.aborted) return Promise.reject(new Error('DSH Host call cancelled'))
+    const id = ++this.sequence
+    return new Promise<T>((resolve, reject) => {
+      const abort = () => {
+        this.pending.delete(id)
+        cleanup()
+        try { this.port.send({ kind: 'cancel', id }) } catch { /* channel already gone */ }
+        reject(new Error('DSH Host call cancelled or timed out'))
+      }
+      const timer = timeoutMs === 0 ? undefined : setTimeout(abort, timeoutMs)
+      const cleanup = () => { clearTimeout(timer); signal?.removeEventListener('abort', abort) }
+      this.pending.set(id, { resolve, reject, cleanup })
+      signal?.addEventListener('abort', abort, { once: true })
+      try { this.port.send({ kind: 'call', id, method, args }) }
+      catch (cause) {
+        this.pending.delete(id); cleanup()
+        reject(cause instanceof Error ? cause : new Error(String(cause)))
+      }
+    })
+  }
+  close(reason = 'DSH Host channel closed'): void {
+    if (this.closed) return
+    this.closed = true
+    this.unlisten()
+    for (const item of this.pending.values()) { item.cleanup(); item.reject(new Error(reason)) }
+    this.pending.clear()
+    for (const controller of this.active.values()) controller.abort()
+    this.active.clear()
+    this.handlers.clear()
+  }
+  private async receive(value: unknown): Promise<void> {
+    if (this.closed || !value || typeof value !== 'object') return
+    const message = value as Record<string, any>
+    if (!Number.isSafeInteger(message.id) || message.id < 1) return
+    const id = message.id as number
+    if (message.kind === 'result') {
+      const pending = this.pending.get(id)
+      if (!pending) return
+      this.pending.delete(id); pending.cleanup()
+      if (typeof message.error === 'string') pending.reject(new Error(message.error))
+      else pending.resolve(message.value)
+    } else if (message.kind === 'cancel') {
+      this.active.get(id)?.abort()
+    } else if (message.kind === 'call' && typeof message.method === 'string' && Array.isArray(message.args)) {
+      const controller = new AbortController()
+      this.active.set(id, controller)
+      try {
+        const handler = this.handlers.get(message.method)
+        if (!handler) throw new Error(`Unknown Host operation: ${message.method}`)
+        const result = await handler(message.args, controller.signal)
+        if (!this.closed) this.port.send({ kind: 'result', id, value: result })
+      } catch (cause) {
+        if (!this.closed) {
+          try { this.port.send({ kind: 'result', id, error: cause instanceof Error ? cause.message : String(cause) }) }
+          catch { /* transport owner handles exit */ }
+        }
+      } finally { this.active.delete(id) }
+    }
+  }
+}

--- a/dsh-plugin-desktop-beta/src/host-runtime-bridge.ts
+++ b/dsh-plugin-desktop-beta/src/host-runtime-bridge.ts
@@ -1,0 +1,172 @@
+/** Native capability adapters; frontend HTTP and WebSocket connections are unchanged. */
+import type { DesktopRuntime, DesktopShellSpec, DesktopTrayItem, DesktopTrayItemRegistration, DesktopUpdateAdapter } from './runtime.ts'
+import { HostRpc } from './host-rpc.ts'
+
+export type RuntimeSnapshot = Pick<DesktopRuntime, 'platform' | 'windowsBuild' | 'locale'> & {
+  updates: Omit<DesktopUpdateAdapter, 'request' | 'confirmDownload' | 'showManualCheckResult' | 'downloadAndOpen' | 'notify'>
+}
+export function runtimeSnapshot(runtime: DesktopRuntime): RuntimeSnapshot {
+  const { isPackaged, canDownload, currentVersion, releaseChannel, statePath, installationId } = runtime.updates
+  return { platform: runtime.platform, windowsBuild: runtime.windowsBuild, locale: runtime.locale,
+    updates: { isPackaged, canDownload, currentVersion, statePath,
+      ...(releaseChannel ? { releaseChannel } : {}), ...(installationId ? { installationId } : {}) } }
+}
+
+/** Keep functions in their owning process and send snapshots plus opaque callback IDs. */
+export function createHostRuntime(rpc: HostRpc, snapshot: RuntimeSnapshot): DesktopRuntime {
+  let sequence = 0
+  let locale = snapshot.locale
+  const calls = new Set<Promise<unknown>>()
+  const setup: Promise<unknown>[] = []
+  let booting = true
+  const trayPublishers = new Map<string, () => void>()
+  const trackSetup = (task: Promise<unknown>) => { if (booting) setup.push(task) }
+  const shellSpecs = new Map<string, DesktopShellSpec>()
+  const send = <T = void>(method: string, args: unknown[] = [], signal?: AbortSignal): Promise<T> => {
+    const interactive = ['update:confirmDownload', 'update:showManualCheckResult', 'update:downloadAndOpen',
+      'native:pickDirectory', 'native:exportDiagnostics'].includes(method)
+    const task = rpc.call<T>(method, args, signal, interactive ? 0 : undefined)
+    calls.add(task)
+    // Report fire-and-forget failures without creating an unhandled rejection.
+    void task.then(() => calls.delete(task), error => { calls.delete(task); process.stderr.write(`${String(error)}\n`) })
+    return task
+  }
+  const callbacks = (handlers: Record<string, (...args: any[]) => unknown>) => {
+    const id = `callback:${++sequence}`
+    const releases = Object.entries(handlers).map(([name, handler]) => rpc.handle(`${id}:${name}`, args => handler(...args)))
+    return { id, release: () => releases.forEach(dispose => dispose()) }
+  }
+  const runtime: DesktopRuntime = {
+    platform: snapshot.platform, windowsBuild: snapshot.windowsBuild,
+    get locale() { return locale },
+    updates: {
+      ...snapshot.updates,
+      request: async (url, init) => {
+        const { signal, ...options } = init
+        const response = await send<{ body: string; status: number; headers: [string, string][] }>('update:request',
+          [url, { ...options, headers: [...new Headers(init.headers).entries()] }], signal ?? undefined)
+        return new Response([204, 205, 304].includes(response.status) ? null : response.body, { status: response.status, headers: response.headers })
+      },
+      confirmDownload: (version, channel) => send('update:confirmDownload', [version, channel]),
+      showManualCheckResult: result => send('update:showManualCheckResult', [result]),
+      downloadAndOpen: (version, signal, channel) => send('update:downloadAndOpen', [version, channel], signal),
+      notify: notification => { void send('update:notify', [notification]) },
+    },
+    schedule(spec) {
+      const callback = callbacks({ quit: spec.requestQuit, mode: spec.requestModeChange })
+      const { readLocalePreference, readThemeSource, requestQuit: _quit, requestModeChange: _mode, ...data } = spec
+      shellSpecs.set(callback.id, spec)
+      trackSetup(send('shell:schedule', [callback.id, data, readLocalePreference(), readThemeSource()]))
+      return async () => { try { await send('shell:dispose', [callback.id]) } finally { shellSpecs.delete(callback.id); callback.release() } }
+    },
+    // The parent mounts only after Host boot and this barrier finish.
+    async mountScheduled() {
+      await Promise.all(setup)
+      setup.length = 0
+      booting = false
+      for (const [id, spec] of shellSpecs) {
+        await send('shell:preferences', [id, spec.readLocalePreference(), spec.readThemeSource()])
+      }
+    },
+    registerTrayItem(item) {
+      const id = `tray:${++sequence}`
+      let releases: (() => void)[] = []
+      const publish = () => {
+        for (const release of releases) release()
+        releases = []
+        const project = (entry: DesktopTrayItem | NonNullable<ReturnType<NonNullable<DesktopTrayItem['submenu']>>>[number], index: number) => {
+          const method = `${id}:${index}`
+          releases.push(rpc.handle(method, () => entry.invoke()))
+          return { label: entry.label(), enabled: entry.enabled?.() ?? true,
+            checked: 'checked' in entry ? entry.checked?.() ?? false : false, type: 'type' in entry ? entry.type : undefined, method }
+        }
+        trackSetup(send('tray:set', [id, { ...project(item, -1), group: item.group, order: item.order, id: item.id,
+          submenu: item.submenu?.().map((entry, index) => project(entry, index)) }]))
+      }
+      trayPublishers.set(id, publish)
+      publish()
+      return { refresh: publish, dispose() { trayPublishers.delete(id); releases.forEach(release => release()); void send('tray:dispose', [id]) } }
+    },
+    show() { void send('native:show') },
+    notifyAttention(value) { void send('native:notifyAttention', [value]) },
+    openTerminal() { void send('native:openTerminal') },
+    reloadRenderer() { void send('native:reloadRenderer') },
+    toggleDeveloperTools() { void send('native:toggleDeveloperTools') },
+    exportDiagnostics: () => send('native:exportDiagnostics'),
+    pickDirectory: () => send('native:pickDirectory'),
+    validateDirectory: path => send('native:validateDirectory', [path]),
+    reportRendererBoot: report => { void send('native:reportRendererBoot', [report]) },
+    setLocalePreference(preference) { locale = preference ?? snapshot.locale; trayPublishers.forEach(publish => publish()); void send('native:setLocalePreference', [preference]) },
+    setThemeSource(source) { void send('native:setThemeSource', [source]) },
+    requestRestart: () => send('native:requestRestart'),
+    requestRecoveryRestart: () => send('native:requestRecoveryRestart'),
+    prepareToQuit() { void send('native:prepareToQuit') },
+    openProfileCreateWindow(options) {
+      const callback = callbacks({
+        submit: async name => { await options.onSubmit(name); callback.release() },
+        cancel: () => { options.onCancel?.(); callback.release() },
+      })
+      void send('native:openProfileCreateWindow', [callback.id])
+    },
+  }
+  return runtime
+}
+
+/** Install only the declared native surface; never expose arbitrary Electron APIs. */
+export function bindNativeRuntime(rpc: HostRpc, runtime: DesktopRuntime): () => Promise<void> {
+  const trays = new Map<string, DesktopTrayItemRegistration>()
+  const shells = new Map<string, () => Promise<void>>()
+  const preferences = new Map<string, { locale: any; theme: any }>()
+  const releases: (() => void)[] = []
+  const handle = (name: string, fn: (args: any[], signal: AbortSignal) => unknown) => { releases.push(rpc.handle(name, fn)) }
+  const callback = (method: string, args: unknown[] = []) => rpc.call(method, args)
+  const report = (promise: Promise<unknown>) => { void promise.catch(error => process.stderr.write(`${String(error)}\n`)) }
+  for (const method of ['show', 'notifyAttention', 'openTerminal', 'reloadRenderer', 'toggleDeveloperTools',
+    'exportDiagnostics', 'pickDirectory', 'validateDirectory', 'reportRendererBoot', 'setLocalePreference',
+    'setThemeSource', 'prepareToQuit'] as const) {
+    handle(`native:${method}`, args => (runtime[method] as (...args: any[]) => unknown).apply(runtime, args))
+  }
+  // Acknowledge restart before teardown can close the channel used by this call.
+  for (const method of ['requestRestart', 'requestRecoveryRestart'] as const) {
+    handle(`native:${method}`, () => { setImmediate(() => report(runtime[method]())) })
+  }
+  handle('native:openProfileCreateWindow', ([id]) => runtime.openProfileCreateWindow({
+    onSubmit: name => callback(`${id}:submit`, [name]), onCancel: () => report(callback(`${id}:cancel`)),
+  }))
+  handle('shell:schedule', ([id, data, locale, theme]) => {
+    if (shells.has(id)) throw new Error('Duplicate Host shell')
+    const state = { locale, theme }
+    preferences.set(id, state)
+    shells.set(id, runtime.schedule({ ...data,
+      readLocalePreference: () => state.locale, readThemeSource: () => state.theme,
+      requestQuit: code => report(callback(`${id}:quit`, [code])),
+      requestModeChange: mode => callback(`${id}:mode`, [mode]),
+    } as DesktopShellSpec))
+  })
+  handle('shell:preferences', ([id, locale, theme]) => {
+    const state = preferences.get(id)
+    if (!state) throw new Error('Host shell is unavailable')
+    state.locale = locale; state.theme = theme
+  })
+  handle('shell:dispose', async ([id]) => { const dispose = shells.get(id); shells.delete(id); preferences.delete(id); await dispose?.() })
+  handle('tray:set', ([id, data]) => {
+    trays.get(id)?.dispose()
+    const project = (entry: any) => ({ ...entry, label: () => entry.label, enabled: () => entry.enabled,
+      checked: () => entry.checked, invoke: () => callback(entry.method) })
+    trays.set(id, runtime.registerTrayItem({ ...project(data), submenu: data.submenu ? () => data.submenu.map(project) : undefined }))
+  })
+  handle('tray:dispose', ([id]) => { trays.get(id)?.dispose(); trays.delete(id) })
+  handle('update:request', async ([url, init], signal) => {
+    const response = await runtime.updates.request(url, { ...init, signal })
+    return { body: await response.text(), status: response.status, headers: [...response.headers.entries()] }
+  })
+  handle('update:confirmDownload', ([version, channel]) => runtime.updates.confirmDownload(version, channel))
+  handle('update:showManualCheckResult', ([result]) => runtime.updates.showManualCheckResult(result))
+  handle('update:downloadAndOpen', ([version, channel], signal) => runtime.updates.downloadAndOpen(version, signal, channel))
+  handle('update:notify', ([value]) => runtime.updates.notify(value))
+  return async () => {
+    trays.forEach(tray => tray.dispose()); trays.clear()
+    await Promise.all([...shells.values()].map(dispose => dispose())); shells.clear(); preferences.clear()
+    releases.forEach(release => release())
+  }
+}

--- a/dsh-plugin-desktop-beta/src/main.ts
+++ b/dsh-plugin-desktop-beta/src/main.ts
@@ -1402,7 +1402,7 @@ async function start(): Promise<void> {
     if (profilePreferences === undefined) {
       throw new Error(`${BIN_NAME}: active Profile preferences were not initialized`)
     }
-    if (process.env.DSH_DESKTOP_ISOLATED_HOST === '1') {
+    if (process.env.DSH_DESKTOP_ISOLATED_HOST !== '0') {
       startupStage = 'host-boot'
       lifecycleRecorder.transitionStartupStage(startupStage)
       await startIsolatedDesktopHost({

--- a/dsh-plugin-desktop-beta/src/main.ts
+++ b/dsh-plugin-desktop-beta/src/main.ts
@@ -1,5 +1,6 @@
 /** DSH Desktop executable: minimal Electron bootstrap around the Host Cordis root. */
 
+import { startIsolatedDesktopHost } from './host-process.ts'
 import { app, crashReporter, safeStorage, shell } from 'electron'
 import { randomUUID } from 'node:crypto'
 import { existsSync } from 'node:fs'
@@ -1361,27 +1362,26 @@ async function start(): Promise<void> {
         `${BIN_NAME}: requested Market provider ${prepared.market.requested} was disabled for this generation: ${prepared.marketFailure}`,
       )
     }
+    const prepareHostCertificate = async () => {
+      if (prepared.lanAddresses.length === 0) return { failureCode: 'no-address' }
+      const { createLanHttpsCertificate, DesktopLanHttpsCertificateError } = await import('./lan-https-certificate.ts')
+      try {
+        const certificate = await createLanHttpsCertificate(
+          marketUserDataDir,
+          prepared.lanAddresses,
+          desktopLanHttpsPrivateKeyProtector(),
+        )
+        return { certificate }
+      } catch (cause) {
+        const failureCode = cause instanceof DesktopLanHttpsCertificateError ? cause.code : 'certificate-state'
+        electronLogger.error(
+          `${BIN_NAME}: LAN HTTPS certificate setup is unavailable: ${cause instanceof Error ? cause.message : String(cause)}`,
+        )
+        return { failureCode }
+      }
+    }
     const lanHttps = new DesktopLanHttpsRuntime({
-      addresses: prepared.lanAddresses,
-      prepareCertificate: async () => {
-        if (prepared.lanAddresses.length === 0) return { failureCode: 'no-address' }
-        const { createLanHttpsCertificate, DesktopLanHttpsCertificateError } = await import('./lan-https-certificate.ts')
-        try {
-          const certificate = await createLanHttpsCertificate(
-            marketUserDataDir,
-            prepared.lanAddresses,
-            desktopLanHttpsPrivateKeyProtector(),
-          )
-          return { certificate }
-        } catch (cause) {
-          const failureCode = cause instanceof DesktopLanHttpsCertificateError ? cause.code : 'certificate-state'
-          electronLogger.error(
-            `${BIN_NAME}: LAN HTTPS certificate setup is unavailable: ${cause instanceof Error ? cause.message : String(cause)}`,
-          )
-          return { failureCode }
-        }
-      },
-      requestedPort: 0,
+      addresses: prepared.lanAddresses, prepareCertificate: prepareHostCertificate, requestedPort: 0,
     })
     const browserAccess = createDesktopBrowserAccess(
       prepared.mode === 'compatibility' && prepared.openBrowser,
@@ -1402,228 +1402,245 @@ async function start(): Promise<void> {
     if (profilePreferences === undefined) {
       throw new Error(`${BIN_NAME}: active Profile preferences were not initialized`)
     }
-    let currentProfilePreferences: DesktopProfilePreferences = profilePreferences
-    let profilePreferencesWriteTail: Promise<void> = Promise.resolve()
-    let profilePreferencesStopping = false
-    const enqueueProfilePreferencesWrite = (
-      update: (current: DesktopProfilePreferences) => DesktopProfilePreferences,
-    ): Promise<DesktopProfilePreferencesStateV1> => {
-      if (profilePreferencesStopping) {
-        return Promise.reject(new Error(`${BIN_NAME}: Profile preferences are stopping`))
-      }
-      const write = profilePreferencesWriteTail.then(async () => {
-        const next = update(currentProfilePreferences)
-        const stored = await writeDesktopProfilePreferences(
-          marketUserDataDir,
-          prepared.profile.dir,
-          next,
-        )
-        currentProfilePreferences = stored
-        return stored
+    if (process.env.DSH_DESKTOP_ISOLATED_HOST === '1') {
+      startupStage = 'host-boot'
+      lifecycleRecorder.transitionStartupStage(startupStage)
+      await startIsolatedDesktopHost({
+        host: { prepared, profilePreferences, homeDir, activeProfileName, pluginManagementStatePath,
+          selectionStatePath, marketUserDataDir, releaseUserDataLocations, desktopLaunchEnvironment,
+          desktopPnpmBootstrap, logDirectory: join(desktopUserDataDir, 'logs', 'host') },
+        runtime, rendererToken: browserAccess.rendererHeader.value,
+        prepareCertificate: prepareHostCertificate,
+        bindHost: host => generation.bindHost(host), requestQuit,
+        onFailure: error => {
+          electronLogger.error(error.message)
+          runtime.notifyAttention({ title: PRODUCT_NAME, body: error.message })
+        },
       })
-      profilePreferencesWriteTail = write.then(() => undefined, () => undefined)
-      return write
-    }
-    const flushProfilePreferencesWrites = async (): Promise<void> => {
-      profilePreferencesStopping = true
-      await profilePreferencesWriteTail
-    }
-    startupStage = 'host-boot'
-    lifecycleRecorder.transitionStartupStage(startupStage)
-    const releasePackageResolver = installProfilePackageResolver(prepared.bareModuleBaseUrl)
-    const ctx = await boot(
-      BIN_NAME,
-      prepared.rootConfig,
-      prepared.patches,
-      async (hostCtx) => {
-        // Keep Host imports and browser bundle discovery on the same public
-        // profile-overlay resolver used by packaged Electron.
-        hostCtx.loader.internal = undefined
-        generation.bindHost(hostCtx)
-        hostCtx.effect(
-          () => async () => { await flushProfilePreferencesWrites() },
-          'dsh-plugin-desktop: flush Profile preference writes',
-        )
-        hostCtx.effect(
-          () => releasePnpmRuntime,
-          'dsh-plugin-desktop: packaged pnpm runtime PATH',
-        )
-        if (dshRuntime !== undefined) {
-          hostCtx.effect(
-            () => releaseDshRuntime,
-            'dsh-plugin-desktop: packaged dsh runtime PATH',
+    } else {
+      let currentProfilePreferences: DesktopProfilePreferences = profilePreferences
+      let profilePreferencesWriteTail: Promise<void> = Promise.resolve()
+      let profilePreferencesStopping = false
+      const enqueueProfilePreferencesWrite = (
+        update: (current: DesktopProfilePreferences) => DesktopProfilePreferences,
+      ): Promise<DesktopProfilePreferencesStateV1> => {
+        if (profilePreferencesStopping) {
+          return Promise.reject(new Error(`${BIN_NAME}: Profile preferences are stopping`))
+        }
+        const write = profilePreferencesWriteTail.then(async () => {
+          const next = update(currentProfilePreferences)
+          const stored = await writeDesktopProfilePreferences(
+            marketUserDataDir,
+            prepared.profile.dir,
+            next,
           )
-        }
-        hostCtx.effect(
-          () => releasePackageResolver,
-          'dsh-plugin-desktop: profile package resolution',
-        )
-        hostCtx.provide(DSH_LAUNCH_ENVIRONMENT_KEY, desktopLaunchEnvironment)
-        hostCtx.provide('desktopBrowserAccess', browserAccess)
-        hostCtx.provide('desktopLanHttps', lanHttps)
-        hostCtx.provide('desktopRuntime', runtime)
-        hostCtx.provide('desktopPnpmBootstrap', desktopPnpmBootstrap)
-        await hostCtx.plugin(DesktopActionsService, {
-          openTerminal: () => { runtime.openTerminal() },
-          requestRestart: () => runtime.requestRestart(),
+          currentProfilePreferences = stored
+          return stored
         })
-        if (prepared.market.effective === 'community-market') {
-          await hostCtx.plugin(DesktopPluginsService, {
-            profileName: activeProfileName,
-            homeDir,
-            statePath: pluginManagementStatePath,
-            installAnchor: desktopInstallAnchor(),
+        profilePreferencesWriteTail = write.then(() => undefined, () => undefined)
+        return write
+      }
+      const flushProfilePreferencesWrites = async (): Promise<void> => {
+        profilePreferencesStopping = true
+        await profilePreferencesWriteTail
+      }
+      startupStage = 'host-boot'
+      lifecycleRecorder.transitionStartupStage(startupStage)
+      const releasePackageResolver = installProfilePackageResolver(prepared.bareModuleBaseUrl)
+      const ctx = await boot(
+        BIN_NAME,
+        prepared.rootConfig,
+        prepared.patches,
+        async (hostCtx) => {
+          // Keep Host imports and browser bundle discovery on the same public
+          // profile-overlay resolver used by packaged Electron.
+          hostCtx.loader.internal = undefined
+          generation.bindHost(hostCtx)
+          hostCtx.effect(
+            () => async () => { await flushProfilePreferencesWrites() },
+            'dsh-plugin-desktop: flush Profile preference writes',
+          )
+          hostCtx.effect(
+            () => releasePnpmRuntime,
+            'dsh-plugin-desktop: packaged pnpm runtime PATH',
+          )
+          if (dshRuntime !== undefined) {
+            hostCtx.effect(
+              () => releaseDshRuntime,
+              'dsh-plugin-desktop: packaged dsh runtime PATH',
+            )
+          }
+          hostCtx.effect(
+            () => releasePackageResolver,
+            'dsh-plugin-desktop: profile package resolution',
+          )
+          hostCtx.provide(DSH_LAUNCH_ENVIRONMENT_KEY, desktopLaunchEnvironment)
+          hostCtx.provide('desktopBrowserAccess', browserAccess)
+          hostCtx.provide('desktopLanHttps', lanHttps)
+          hostCtx.provide('desktopRuntime', runtime)
+          hostCtx.provide('desktopPnpmBootstrap', desktopPnpmBootstrap)
+          await hostCtx.plugin(DesktopActionsService, {
+            openTerminal: () => { runtime.openTerminal() },
+            requestRestart: () => runtime.requestRestart(),
           })
-        }
-        if (logSink !== undefined) {
-          fileExporter = new FileExporter(logSink)
-          hostCtx.logger.exporter(fileExporter)
-        }
-        await hostCtx.plugin(DesktopProfileService, {
-          current: {
-            name: activeProfileName,
-            dir: prepared.profile.dir,
-          },
-          create: name => createFreshDesktopProfile(name),
-          list: () => listDesktopProfiles(homeDir),
-          canDelete: name => canDeleteDesktopProfile({
-            home: homeDir,
-            selectionStatePath,
-            currentProfileName: activeProfileName,
-          }, name),
-          delete: async name => {
-            const profileDir = resolveProfileDir(name, homeDir)
-            await deleteDesktopProfile({
+          if (prepared.market.effective === 'community-market') {
+            await hostCtx.plugin(DesktopPluginsService, {
+              profileName: activeProfileName,
+              homeDir,
+              statePath: pluginManagementStatePath,
+              installAnchor: desktopInstallAnchor(),
+            })
+          }
+          if (logSink !== undefined) {
+            fileExporter = new FileExporter(logSink)
+            hostCtx.logger.exporter(fileExporter)
+          }
+          await hostCtx.plugin(DesktopProfileService, {
+            current: {
+              name: activeProfileName,
+              dir: prepared.profile.dir,
+            },
+            create: name => createFreshDesktopProfile(name),
+            list: () => listDesktopProfiles(homeDir),
+            canDelete: name => canDeleteDesktopProfile({
               home: homeDir,
               selectionStatePath,
               currentProfileName: activeProfileName,
-              clearDisabledState: () => clearDesktopProfilePluginState(pluginManagementStatePath, name),
-              clearCheckpoint: async () => {
-                clearDesktopProfileUsageHistory(releaseUserDataLocations, profileDir)
-              },
-            }, name)
-            try {
-              await clearDesktopProfilePreferences(marketUserDataDir, profileDir)
-            } catch (cause) {
-              hostCtx.logger.error(
-                `${BIN_NAME}: deleted Profile left stale preference state: ${cause instanceof Error ? cause.message : String(cause)}`,
-              )
-            }
-          },
-          persistSelection: name => { selectDesktopProfile(selectionStatePath, homeDir, name) },
-          requestRestart: () => runtime.requestRestart(),
-        })
-        let pendingSettingsRestart: ReturnType<typeof setImmediate> | undefined
-        const scheduleSettingsRestart = (): void => {
-          pendingSettingsRestart ??= setImmediate(() => {
-            pendingSettingsRestart = undefined
-            void runtime.requestRestart().catch((cause: unknown) => {
-              hostCtx.logger.error(
-                `${BIN_NAME}: failed to restart after Desktop setting change: ${cause instanceof Error ? cause.message : String(cause)}`,
-              )
-            })
+            }, name),
+            delete: async name => {
+              const profileDir = resolveProfileDir(name, homeDir)
+              await deleteDesktopProfile({
+                home: homeDir,
+                selectionStatePath,
+                currentProfileName: activeProfileName,
+                clearDisabledState: () => clearDesktopProfilePluginState(pluginManagementStatePath, name),
+                clearCheckpoint: async () => {
+                  clearDesktopProfileUsageHistory(releaseUserDataLocations, profileDir)
+                },
+              }, name)
+              try {
+                await clearDesktopProfilePreferences(marketUserDataDir, profileDir)
+              } catch (cause) {
+                hostCtx.logger.error(
+                  `${BIN_NAME}: deleted Profile left stale preference state: ${cause instanceof Error ? cause.message : String(cause)}`,
+                )
+              }
+            },
+            persistSelection: name => { selectDesktopProfile(selectionStatePath, homeDir, name) },
+            requestRestart: () => runtime.requestRestart(),
           })
-        }
-        hostCtx.effect(() => () => {
-          if (pendingSettingsRestart !== undefined) clearImmediate(pendingSettingsRestart)
-          pendingSettingsRestart = undefined
-        }, 'dsh-plugin-desktop: pending Desktop settings restart')
-        const readMarket = () => desktopMarketSnapshotWithEffective(
-          desktopProfileMarketSnapshot(currentProfilePreferences.market),
-          prepared.market.effective,
-        )
-        hostCtx.provide('desktopSettingsController', new DesktopSettingsController({
-          profiles: hostCtx.desktopProfiles,
-          readMarket,
-          readAa: () => ({ requested: currentProfilePreferences.aaEnabled === true, effective: prepared.aaEnabled }),
-          selectAa: async enabled => {
-            await enqueueProfilePreferencesWrite(current => desktopProfilePreferencesFromSettings(
-              current,
-              current.notifications,
-              current.market,
-              enabled,
-            ))
-          },
-          readWeb: () => {
-            const lan = lanHttps.snapshot()
-            const lanOrigins = lan.state === 'ready' && lan.actualPort !== null
-              ? desktopLanBrowserUrls(lan.actualPort, lan.addresses)
-              : []
-            return {
-              localUrl: hostCtx.connection.authenticatedUrl(
-                desktopLoopbackBrowserUrl(hostCtx.webServer.port),
-              ),
-              lanUrls: lanOrigins.map(url => hostCtx.connection.authenticatedUrl(url)),
-              lanState: lan.state,
-              lanError: lan.errorCode,
-              lanCaFingerprint: lan.caFingerprint,
-              lanCaUrls: lanOrigins.map((origin) => {
-                return new URL(DESKTOP_LAN_HTTPS_CA_PATH, origin).href
-              }),
-            }
-          },
-          selectMarket: async provider => {
-            await enqueueProfilePreferencesWrite(current => desktopProfilePreferencesFromSettings(
-              current,
-              current.notifications,
-              provider,
-              current.aaEnabled === true,
-            ))
-            return desktopMarketSnapshotWithEffective(
-              await selectDesktopMarketProvider(marketUserDataDir, provider),
-              prepared.market.effective,
-            )
-          },
-          scheduleRestart: scheduleSettingsRestart,
-          scheduleRecoveryRestart: () => {
-            void runtime.requestRecoveryRestart().catch((cause: unknown) => {
-              hostCtx.logger.error(
-                `${BIN_NAME}: failed to restart in recovery mode: ${cause instanceof Error ? cause.message : String(cause)}`,
-              )
+          let pendingSettingsRestart: ReturnType<typeof setImmediate> | undefined
+          const scheduleSettingsRestart = (): void => {
+            pendingSettingsRestart ??= setImmediate(() => {
+              pendingSettingsRestart = undefined
+              void runtime.requestRestart().catch((cause: unknown) => {
+                hostCtx.logger.error(
+                  `${BIN_NAME}: failed to restart after Desktop setting change: ${cause instanceof Error ? cause.message : String(cause)}`,
+                )
+              })
             })
-          },
-          openTerminal: () => { runtime.openTerminal() },
-          reloadRenderer: () => { runtime.reloadRenderer() },
-          toggleDeveloperTools: () => { runtime.toggleDeveloperTools() },
-          exportDiagnostics: () => runtime.exportDiagnostics(),
-        }))
-        provideCmdline(hostCtx, {
-          args: [
-            '--port',
-            String(prepared.port),
-          ],
-          exit: requestQuit,
-        })
-      },
-      prepared.bareModuleBaseUrl,
-    ).catch((cause: unknown) => {
-      releasePackageResolver()
-      throw cause
-    })
-    generation.bindHost(ctx)
-    fileExporter?.setThreshold((ctx.settings.get(DESKTOP_SETTINGS_NAMESPACE) as DesktopSettings | undefined)?.logLevel ?? 'info')
-    ctx.on('settings/updated', (namespace, next) => {
-      if (namespace === DESKTOP_SETTINGS_NAMESPACE) {
-        fileExporter?.setThreshold((next as DesktopSettings).logLevel)
-      }
-      if (namespace !== DESKTOP_SETTINGS_NAMESPACE
-        && namespace !== DESKTOP_NOTIFICATIONS_SETTINGS_NAMESPACE) return
-      const write = enqueueProfilePreferencesWrite(current => desktopProfilePreferencesFromSettings(
-        namespace === DESKTOP_SETTINGS_NAMESPACE
-          ? next as DesktopSettings
-          : ctx.settings.get(DESKTOP_SETTINGS_NAMESPACE) as DesktopSettings,
-        namespace === DESKTOP_NOTIFICATIONS_SETTINGS_NAMESPACE
-          ? next as DesktopNotificationSettings
-          : ctx.settings.get(DESKTOP_NOTIFICATIONS_SETTINGS_NAMESPACE) as DesktopNotificationSettings,
-        current.market,
-        current.aaEnabled === true,
-      ))
-      void write.catch((cause: unknown) => {
-        ctx.logger.error(
-          `${BIN_NAME}: failed to capture active Profile settings: ${cause instanceof Error ? cause.message : String(cause)}`,
-        )
+          }
+          hostCtx.effect(() => () => {
+            if (pendingSettingsRestart !== undefined) clearImmediate(pendingSettingsRestart)
+            pendingSettingsRestart = undefined
+          }, 'dsh-plugin-desktop: pending Desktop settings restart')
+          const readMarket = () => desktopMarketSnapshotWithEffective(
+            desktopProfileMarketSnapshot(currentProfilePreferences.market),
+            prepared.market.effective,
+          )
+          hostCtx.provide('desktopSettingsController', new DesktopSettingsController({
+            profiles: hostCtx.desktopProfiles,
+            readMarket,
+            readAa: () => ({ requested: currentProfilePreferences.aaEnabled === true, effective: prepared.aaEnabled }),
+            selectAa: async enabled => {
+              await enqueueProfilePreferencesWrite(current => desktopProfilePreferencesFromSettings(
+                current,
+                current.notifications,
+                current.market,
+                enabled,
+              ))
+            },
+            readWeb: () => {
+              const lan = lanHttps.snapshot()
+              const lanOrigins = lan.state === 'ready' && lan.actualPort !== null
+                ? desktopLanBrowserUrls(lan.actualPort, lan.addresses)
+                : []
+              return {
+                localUrl: hostCtx.connection.authenticatedUrl(
+                  desktopLoopbackBrowserUrl(hostCtx.webServer.port),
+                ),
+                lanUrls: lanOrigins.map(url => hostCtx.connection.authenticatedUrl(url)),
+                lanState: lan.state,
+                lanError: lan.errorCode,
+                lanCaFingerprint: lan.caFingerprint,
+                lanCaUrls: lanOrigins.map((origin) => {
+                  return new URL(DESKTOP_LAN_HTTPS_CA_PATH, origin).href
+                }),
+              }
+            },
+            selectMarket: async provider => {
+              await enqueueProfilePreferencesWrite(current => desktopProfilePreferencesFromSettings(
+                current,
+                current.notifications,
+                provider,
+                current.aaEnabled === true,
+              ))
+              return desktopMarketSnapshotWithEffective(
+                await selectDesktopMarketProvider(marketUserDataDir, provider),
+                prepared.market.effective,
+              )
+            },
+            scheduleRestart: scheduleSettingsRestart,
+            scheduleRecoveryRestart: () => {
+              void runtime.requestRecoveryRestart().catch((cause: unknown) => {
+                hostCtx.logger.error(
+                  `${BIN_NAME}: failed to restart in recovery mode: ${cause instanceof Error ? cause.message : String(cause)}`,
+                )
+              })
+            },
+            openTerminal: () => { runtime.openTerminal() },
+            reloadRenderer: () => { runtime.reloadRenderer() },
+            toggleDeveloperTools: () => { runtime.toggleDeveloperTools() },
+            exportDiagnostics: () => runtime.exportDiagnostics(),
+          }))
+          provideCmdline(hostCtx, {
+            args: [
+              '--port',
+              String(prepared.port),
+            ],
+            exit: requestQuit,
+          })
+        },
+        prepared.bareModuleBaseUrl,
+      ).catch((cause: unknown) => {
+        releasePackageResolver()
+        throw cause
       })
-    })
+      generation.bindHost(ctx)
+      fileExporter?.setThreshold((ctx.settings.get(DESKTOP_SETTINGS_NAMESPACE) as DesktopSettings | undefined)?.logLevel ?? 'info')
+      ctx.on('settings/updated', (namespace, next) => {
+        if (namespace === DESKTOP_SETTINGS_NAMESPACE) {
+          fileExporter?.setThreshold((next as DesktopSettings).logLevel)
+        }
+        if (namespace !== DESKTOP_SETTINGS_NAMESPACE
+          && namespace !== DESKTOP_NOTIFICATIONS_SETTINGS_NAMESPACE) return
+        const write = enqueueProfilePreferencesWrite(current => desktopProfilePreferencesFromSettings(
+          namespace === DESKTOP_SETTINGS_NAMESPACE
+            ? next as DesktopSettings
+            : ctx.settings.get(DESKTOP_SETTINGS_NAMESPACE) as DesktopSettings,
+          namespace === DESKTOP_NOTIFICATIONS_SETTINGS_NAMESPACE
+            ? next as DesktopNotificationSettings
+            : ctx.settings.get(DESKTOP_NOTIFICATIONS_SETTINGS_NAMESPACE) as DesktopNotificationSettings,
+          current.market,
+          current.aaEnabled === true,
+        ))
+        void write.catch((cause: unknown) => {
+          ctx.logger.error(
+            `${BIN_NAME}: failed to capture active Profile settings: ${cause instanceof Error ? cause.message : String(cause)}`,
+          )
+        })
+      })
+    }
     startupStage = 'renderer-startup'
     lifecycleRecorder.transitionStartupStage(startupStage)
     lifecycleRecorder.startRendererBoot()

--- a/dsh-plugin-desktop-beta/src/native-ui/compatibility-chrome/main.tsx
+++ b/dsh-plugin-desktop-beta/src/native-ui/compatibility-chrome/main.tsx
@@ -43,8 +43,8 @@ export function Chrome() {
     key={generation}
     api={api}
     t={key => copy[key]}
-    environment={{ ...state, mode: 'compatibility', material: state.material === 'off' ? 'off' : state.platform === 'darwin' ? 'transparent' : 'mica', micaSupported: state.material === 'mica' }}
-    setMode={mode => mode === 'compatibility' ? Promise.resolve() : invoke(mode === 'extended' ? 'mode-extended' : 'mode-advanced')}
+    environment={{ ...state, material: state.material === 'off' ? 'off' : state.platform === 'darwin' ? 'transparent' : 'mica', micaSupported: state.material === 'mica' }}
+    setMode={mode => mode === state.mode ? Promise.resolve() : invoke(`mode-${mode}`)}
   />
 }
 

--- a/dsh-plugin-desktop-beta/tests/client-environment.spec.ts
+++ b/dsh-plugin-desktop-beta/tests/client-environment.spec.ts
@@ -199,7 +199,7 @@ describe('advanced desktop layout', () => {
       expect(css).not.toMatch(/data-desktop-mode="extended"[^{}]*data-sidebar-collapsed[^{}]*\.dshDesktopUpstreamSidebar/)
       expect(css).toMatch(new RegExp(`data-desktop-mode="advanced"\\]\\[data-desktop-platform="darwin"\\] \\.dshDesktopUpstreamSidebar \\{[^}]*padding-top: ${ADVANCED_MACOS_CONTENT_INSET}px;`))
       expect(css).not.toMatch(/\.dshDesktopUpstreamSidebar \{[^}]*-webkit-app-region: no-drag;/)
-      expect(css).toContain(`grid-template-rows: ${ADVANCED_MACOS_CONTENT_INSET}px minmax(0, 1fr)`)
+      expect(css).toContain(`grid-template-rows: ${ADVANCED_MACOS_DRAG_REGION_HEIGHT}px minmax(0, 1fr)`)
       expect(css).toMatch(/\.dshDesktopFrame\[data-desktop-mode="advanced"\]\[data-desktop-platform="darwin"\] \.dshDesktopSidebarSurface \{[^}]*grid-row: 1 \/ -1;/)
       expect(css).not.toMatch(/data-desktop-platform="darwin"\] \.dshDesktopSidebarSurface \{[^}]*-webkit-app-region: no-drag;/)
       expect(css).toMatch(/\.dshDesktopFrame\[data-desktop-mode="advanced"\]\[data-desktop-platform="darwin"\] \.dshDesktopConversationSurface,\s*\.dshDesktopFrame\[data-desktop-mode="advanced"\]\[data-desktop-platform="darwin"\] \.dshDesktopRightbarSurface \{ grid-row: 2; \}/)
@@ -383,7 +383,7 @@ describe('advanced desktop layout', () => {
       material: 'transparent',
       micaSupported: false,
       availableMaterials: ['off', 'transparent'],
-      safeAreaInsets: { top: ADVANCED_MACOS_CONTENT_INSET, right: 0, bottom: 0, left: 0 },
+      safeAreaInsets: { top: ADVANCED_MACOS_DRAG_REGION_HEIGHT, right: 0, bottom: 0, left: 0 },
       dragRegion: {
         height: ADVANCED_MACOS_DRAG_REGION_HEIGHT,
         leftInset: MACOS_TRAFFIC_LIGHT_SAFE_WIDTH,
@@ -418,11 +418,11 @@ describe('advanced desktop layout', () => {
       material: 'mica',
       micaSupported: true,
       availableMaterials: ['off', 'mica'],
-      safeAreaInsets: { top: DESKTOP_FRAME_HEIGHT, right: 0, bottom: 0, left: 0 },
+      safeAreaInsets: { top: 0, right: 0, bottom: 0, left: 0 },
       dragRegion: {
-        height: DESKTOP_FRAME_HEIGHT,
+        height: 0,
         leftInset: 0,
-        rightInset: WINDOWS_CAPTION_CONTROLS_WIDTH,
+        rightInset: 0,
       },
     })
 
@@ -486,7 +486,7 @@ describe('advanced desktop layout', () => {
 })
 
 describe('independent Desktop frame', () => {
-  it('reserves a command bar for both framed modes and limits the inverted-L surface to extended mode', () => {
+  it('fills the native content viewport for both framed modes and limits the inverted-L surface to extended mode', () => {
     let css = ''
     const remove = vi.fn()
     const style = {
@@ -503,7 +503,7 @@ describe('independent Desktop frame', () => {
 
     try {
       const dispose = installExtendedStyles()
-      expect(css).toContain(`top: ${DESKTOP_FRAME_HEIGHT}px`)
+      expect(css).toContain(`--dsh-desktop-frame-height: 0px`)
       expect(DESKTOP_FRAME_HEIGHT).toBe(36)
       expect(css).toMatch(/#root \{[^}]*position: fixed;[^}]*right: 0;[^}]*bottom: 0;[^}]*left: 0;[^}]*padding-top: 0;[^}]*transform: translateZ\(0\);/)
       expect(css).toMatch(/\[data-shell-overlay\] \{[^}]*overflow: hidden;[^}]*transform: translateZ\(0\);/)
@@ -612,18 +612,8 @@ describe('independent Desktop frame', () => {
       })
       expect(rootInject).not.toHaveProperty('mode')
       expect(occupants[0]).toBe(ExtendedFrame)
-      expect(registrations[1]).toMatchObject({
-        name: 'shell.overlay',
-        id: 'desktop-frame-titlebar',
-      })
-      expect(registrations[1]).not.toHaveProperty('children')
-      expect(registrations[1]?.inject).toBeTypeOf('function')
-      expect((registrations[1]?.inject as () => Record<string, unknown>)()).toMatchObject({
-        environment: { mode: 'extended', platform: 'win32', material: 'off' },
-        api: expect.any(Object),
-        setMode: expect.any(Function),
-      })
-      expect(registrations).toHaveLength(2)
+      expect(registrations).toHaveLength(1)
+      expect(ctx.slots.inject).not.toHaveBeenCalled()
       expect(dataset).toMatchObject({
         dshDesktopMode: 'extended',
         dshDesktopPlatform: 'win32',
@@ -675,16 +665,8 @@ describe('independent Desktop frame', () => {
         material: 'transparent',
         micaSupported: false,
       })
-      expect(injectedSlots).toEqual(['shell.overlay'])
-      expect(registrations).toHaveLength(1)
-      expect(registrations[0]).toMatchObject({
-        name: 'shell.overlay',
-        id: 'desktop-frame-titlebar',
-      })
-      expect(registrations[0]).not.toHaveProperty('children')
-      expect((registrations[0]?.inject as () => Record<string, unknown>)()).toMatchObject({
-        setMode: expect.any(Function),
-      })
+      expect(injectedSlots).toEqual([])
+      expect(registrations).toHaveLength(0)
       expect(JSON.stringify(registrations)).not.toContain('desktop.titlebar.action')
       expect(dataset).toMatchObject({
         dshDesktopMode: 'compatibility',

--- a/dsh-plugin-desktop-beta/tests/compatibility-shell.spec.ts
+++ b/dsh-plugin-desktop-beta/tests/compatibility-shell.spec.ts
@@ -27,7 +27,7 @@ vi.mock('electron', () => ({
   },
 }))
 
-function fixture(platform: 'darwin' | 'win32' = 'darwin') {
+function fixture(platform: 'darwin' | 'win32' = 'darwin', mode: 'compatibility' | 'extended' = 'compatibility') {
   const ipc = { handle: vi.fn(), removeHandler: vi.fn() }
   const webContents = Object.assign(new EventEmitter(), {
     ipc,
@@ -53,7 +53,7 @@ function fixture(platform: 'darwin' | 'win32' = 'darwin') {
     reload: vi.fn(), developerTools: vi.fn(),
     checkForUpdates: vi.fn(async () => {}),
   }
-  const spec = { material: 'off', requestModeChange: vi.fn(async () => {}) } as unknown as DesktopShellSpec
+  const spec = { mode, material: 'off', requestModeChange: vi.fn(async () => {}) } as unknown as DesktopShellSpec
   const shell = new CompatibilityShell(window as unknown as BrowserWindow, spec, platform, '/desktop/preload.cjs', actions)
   const handler = ipc.handle.mock.calls[0]?.[1] as (event: unknown, command: unknown) => unknown
   const event = () => ({ sender: webContents, senderFrame: webContents.mainFrame })
@@ -65,9 +65,10 @@ describe('isolated compatibility shell', () => {
     vi.clearAllMocks()
   })
 
-  it('loads only the packaged chrome and reserves native bounds outside the content document', async () => {
-    const { shell, window, webContents } = fixture()
+  it.each(['compatibility', 'extended'] as const)('isolates %s chrome with native bounds outside the content document', async mode => {
+    const { shell, window, webContents, handler, event } = fixture('darwin', mode)
     await shell.load()
+    expect(handler(event(), 'state')).toMatchObject({ mode })
     expect(webContents.loadFile).toHaveBeenCalledWith(expect.stringMatching(/native-ui\/compatibility-chrome\.html$/))
     expect(window.contentView.addChildView).toHaveBeenCalledWith(shell.content)
     expect(shell.content).toMatchObject({ options: { webPreferences: {
@@ -87,7 +88,7 @@ describe('isolated compatibility shell', () => {
   it('rejects other renderers, child frames, navigated chrome, and arbitrary commands', async () => {
     const { shell, handler, event, webContents, actions } = fixture()
     await shell.load()
-    expect(handler(event(), 'state')).toEqual({ locale: 'en', platform: 'darwin', version: '2.0.3', material: 'off' })
+    expect(handler(event(), 'state')).toEqual({ mode: 'compatibility', locale: 'en', platform: 'darwin', version: '2.0.3', material: 'off' })
     expect(() => handler({ ...event(), sender: electron.content }, 'terminal')).toThrow('untrusted')
     expect(() => handler({ ...event(), senderFrame: { url: webContents.mainFrame.url } }, 'terminal')).toThrow('untrusted')
     expect(() => handler(event(), { command: 'terminal' })).toThrow('unsupported')
@@ -140,6 +141,8 @@ describe('isolated compatibility shell', () => {
     await shell.load()
     await handler(event(), 'terminal')
     await handler(event(), 'check-for-updates')
+    await handler(event(), 'mode-compatibility')
+    expect(spec.requestModeChange).toHaveBeenCalledWith('compatibility')
     await handler(event(), 'mode-extended')
     expect(spec.requestModeChange).toHaveBeenCalledWith('extended')
     expect(actions.restart).not.toHaveBeenCalled()

--- a/dsh-plugin-desktop-beta/tests/electron-runtime.spec.ts
+++ b/dsh-plugin-desktop-beta/tests/electron-runtime.spec.ts
@@ -2703,7 +2703,7 @@ describe('Electron desktop runtime', () => {
       backgroundColor: '#202124',
       titleBarOverlay: expect.objectContaining({ height: DESKTOP_FRAME_HEIGHT }),
     }))
-    expect(electron.contentViews).toHaveLength(0)
+    expect(electron.contentViews).toHaveLength(2)
     expect(electron.browserWindowOptions[0]).not.toHaveProperty('transparent')
     expect(electron.browserWindowOptions[0]).not.toHaveProperty('backgroundMaterial')
     expect(electron.menuTemplates[0]).toEqual(expect.arrayContaining([

--- a/dsh-plugin-desktop-beta/tests/fixtures/isolated-host/child.mjs
+++ b/dsh-plugin-desktop-beta/tests/fixtures/isolated-host/child.mjs
@@ -1,0 +1,7 @@
+import { EventEmitter } from 'node:events'
+const port = Object.assign(new EventEmitter(), { postMessage: message => process.send(message) })
+process.parentPort = port
+await import('../../../lib/host-process-entry.js')
+process.on('message', data => port.emit('message', { data }))
+process.on('disconnect', () => process.exit(0))
+process.send({ ready: true })

--- a/dsh-plugin-desktop-beta/tests/host-launch-environment.spec.ts
+++ b/dsh-plugin-desktop-beta/tests/host-launch-environment.spec.ts
@@ -1,0 +1,15 @@
+import { expect, it } from 'vitest'
+import { createLaunchEnvironmentSnapshot } from '@deepseek-ai/dsh-launch-environment'
+import { serializeHostEnvironment } from '../src/host-launch-environment.ts'
+it('retains shadowed environment values and their trust sources across structured clone', () => {
+  const snapshot = createLaunchEnvironmentSnapshot([
+    { source: 'process', values: { EXAMPLE: 'inherited' } },
+    { source: 'project-env', path: '/fixture/project/.env', values: { EXAMPLE: 'project' } },
+    { source: 'user-env', path: '/fixture/user/.env', values: { EXAMPLE: 'user', ONLY_USER: 'value' } },
+  ])
+  const restored = createLaunchEnvironmentSnapshot(structuredClone(serializeHostEnvironment(snapshot, ['EXAMPLE', 'ONLY_USER'])))
+  expect(restored.get('EXAMPLE')).toEqual(snapshot.get('EXAMPLE'))
+  expect(restored.getFrom('EXAMPLE', ['project-env'])).toEqual(snapshot.getFrom('EXAMPLE', ['project-env']))
+  expect(restored.getFrom('ONLY_USER', ['process'])).toBeUndefined()
+  expect(restored.get('ONLY_USER')).toEqual(snapshot.get('ONLY_USER'))
+})

--- a/dsh-plugin-desktop-beta/tests/host-process-integration.spec.ts
+++ b/dsh-plugin-desktop-beta/tests/host-process-integration.spec.ts
@@ -1,0 +1,111 @@
+import { fork, type Serializable } from 'node:child_process'
+import { once } from 'node:events'
+import { mkdtempSync, writeFileSync, mkdirSync, rmSync, readFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { expect, it } from 'vitest'
+import { prepareDesktopProfile } from '../src/profile.ts'
+import { desktopReleaseUserDataLocations } from '../src/profile-channel-admission.ts'
+import { installDesktopPnpmRuntime } from '../src/desktop-runtime-environment.ts'
+import { HostRpc } from '../src/host-rpc.ts'
+import { bindNativeRuntime, runtimeSnapshot } from '../src/host-runtime-bridge.ts'
+import type { DesktopRuntime, DesktopShellSpec } from '../src/runtime.ts'
+
+it.each([false, true])('boots a separate Web Host with client plugins (AA enabled: %s)', async aaEnabled => {
+  const home = mkdtempSync(join(tmpdir(), 'dsh-isolated-host-'))
+  const token = Buffer.alloc(32, 7).toString('base64url')
+  let child: ReturnType<typeof fork> | undefined
+  let rpc: HostRpc | undefined
+  let releaseNative: (() => Promise<void>) | undefined
+  let pnpm: ReturnType<typeof installDesktopPnpmRuntime> | undefined
+  let stderr = ''
+  try {
+    writeFileSync(join(home, 'settings.yaml'), 'dsh-desktop:\n  mode: advanced\nagent-presets:\n  default: minimal\n')
+    const prepared = prepareDesktopProfile('1', home, 'win32', undefined, undefined, undefined, { aaEnabled })
+    if (aaEnabled) prepared.patches.push({ id: 'agents-anywhere-bridge-next', config: { dshHome: home, stateRoot: join(home, 'aa-state') } })
+    prepared.port = 0
+    const plugin = join(prepared.profile.dir, 'node_modules', 'isolated-client-fixture')
+    mkdirSync(plugin, { recursive: true })
+    writeFileSync(join(plugin, 'package.json'), JSON.stringify({ name: 'isolated-client-fixture', version: '1.0.0', type: 'module',
+      exports: { '.': './index.js', './client': './client.js', './package.json': './package.json' }, dsh: { client: { platform: 'web' } } }))
+    writeFileSync(join(plugin, 'index.js'), 'export function apply() {}\n')
+    writeFileSync(join(plugin, 'client.js'), 'export function apply(ctx) { ctx.provide("isolatedClientFixture", true) }\n')
+    prepared.patches.push({ insert: [{ id: 'isolated-client-fixture', name: 'isolated-client-fixture' }] })
+    const packageRoot = new URL('../', import.meta.url)
+    const pnpmBinPath = fileURLToPath(new URL('node_modules/pnpm/bin/pnpm.mjs', packageRoot))
+    const electronVersion = JSON.parse(readFileSync(new URL('node_modules/electron/package.json', packageRoot), 'utf8')).version
+    pnpm = installDesktopPnpmRuntime({ platform: process.platform, appExecutable: process.execPath, pnpmBinPath,
+      electronVersion, stateDir: join(home, 'runtime'), environment: process.env })
+    child = fork(fileURLToPath(new URL('./fixtures/isolated-host/child.mjs', import.meta.url)), [], {
+      execArgv: [], stdio: ['ignore', 'pipe', 'pipe', 'ipc'], serialization: 'advanced',
+    })
+    child.stderr?.on('data', data => { stderr += String(data) })
+    const [ready] = await once(child, 'message')
+    expect(ready).toEqual({ ready: true })
+    const worker = child
+    rpc = new HostRpc({ send: data => worker.send(data as Serializable),
+      listen: receive => { worker.on('message', receive); return () => { worker.off('message', receive) } },
+    }, 30_000)
+    child.on('exit', () => rpc?.close(stderr || 'worker exited'))
+    let shell: DesktopShellSpec | undefined
+    const runtime = {
+      platform: 'win32', windowsBuild: 22631, locale: 'en',
+      updates: { isPackaged: false, canDownload: false, currentVersion: '2.0.7-beta.1', statePath: join(home, 'updates') },
+      schedule(spec: DesktopShellSpec) { shell = spec; return async () => {} },
+      registerTrayItem() { return { refresh() {}, dispose() {} } },
+      setLocalePreference() {}, setThemeSource() {},
+    } as unknown as DesktopRuntime
+    releaseNative = bindNativeRuntime(rpc, runtime)
+    rpc.handle('certificate', () => ({ failureCode: 'test-disabled' }))
+    rpc.handle('quit', () => {})
+    const result = await rpc.call<{ pid: number; services: { aaRuntime: boolean; aaOnboarding: boolean } }>('boot', [{
+      prepared, profilePreferences: { mode: 'advanced', openBrowser: false, networkExposure: 'loopback',
+        macosMaterial: 'auto', windowsMaterial: 'auto', market: 'disabled', notifications: { enabled: false }, aaEnabled },
+      homeDir: home, activeProfileName: prepared.profile.name, pluginManagementStatePath: join(home, 'plugins.json'),
+      selectionStatePath: join(home, 'selection.json'), marketUserDataDir: join(home, 'userdata'),
+      releaseUserDataLocations: desktopReleaseUserDataLocations(home, join(home, 'userdata')),
+      launchEnvironmentLayers: [],
+      desktopPnpmBootstrap: { activeProfileName: prepared.profile.name, activeProfileDir: prepared.profile.dir, homeDir: home,
+        appExecutable: process.execPath, pnpmBinPath, electronVersion, nodeBinDir: pnpm.nodeBinDir,
+        nodeShimPath: pnpm.nodeShimPath, clearEnvironmentPath: pnpm.clearEnvironmentPath,
+        dshBootstrapPath: fileURLToPath(new URL('../lib/desktop-cli.js', import.meta.url)) },
+      logDirectory: join(home, 'logs'),
+    }, runtimeSnapshot(runtime), token])
+    expect(result.services).toEqual({ aaRuntime: aaEnabled, aaOnboarding: aaEnabled })
+    expect(result.pid).toBe(child.pid)
+    expect(result.pid).not.toBe(process.pid)
+    expect(shell).toBeDefined()
+    const spec = shell!
+    const headers = { [spec.rendererAccessHeader.name]: spec.rendererAccessHeader.value }
+    const unauthorized = await fetch(spec.url, { headers })
+    await unauthorized.body?.cancel()
+    expect(unauthorized.status).toBe(401)
+    const authentication = await fetch(spec.authenticationUrl, { headers, redirect: 'manual' })
+    await authentication.body?.cancel()
+    expect(authentication.status).toBe(303)
+    const cookie = authentication.headers.get('set-cookie')!.split(';')[0]!
+    const response = await fetch(spec.url, { headers: { ...headers, Cookie: cookie } })
+    expect(response.status).toBe(200)
+    const html = await response.text()
+    const match = html.match(/(?:window\.__DSH_BOOT__|globalThis\["__DSH_BOOT__"\]) = (\{.*?\})<\/script>/u)
+    expect(match).not.toBeNull()
+    const graph = JSON.parse(match![1]!) as { entries: { id: string; url: string }[] }
+    const pluginEntry = graph.entries.find(entry => entry.id === 'isolated-client-fixture')
+    expect(pluginEntry).toBeDefined()
+    const bundle = await fetch(new URL(pluginEntry!.url, spec.url), { headers: { ...headers, Cookie: cookie } })
+    expect(bundle.status).toBe(200)
+    expect(await bundle.text()).toContain('isolatedClientFixture')
+    expect(html).toContain('dsh-plugin-desktop-beta')
+    await rpc.call('stop')
+    await expect(fetch(spec.url, { headers })).rejects.toThrow()
+  } catch (error) {
+    throw new Error(`${error instanceof Error ? error.stack : String(error)}\n${stderr}`)
+  } finally {
+    await releaseNative?.()
+    rpc?.close()
+    if (child && child.exitCode === null) { const exit = once(child, 'exit'); child.kill(); await exit }
+    pnpm?.dispose()
+    rmSync(home, { recursive: true, force: true })
+  }
+}, 60_000)

--- a/dsh-plugin-desktop-beta/tests/host-process-integration.spec.ts
+++ b/dsh-plugin-desktop-beta/tests/host-process-integration.spec.ts
@@ -72,7 +72,6 @@ it.each([false, true])('boots a separate Web Host with client plugins (AA enable
         dshBootstrapPath: fileURLToPath(new URL('../lib/desktop-cli.js', import.meta.url)) },
       logDirectory: join(home, 'logs'),
     }, runtimeSnapshot(runtime), token])
-    expect(result.services).toEqual({ aaRuntime: aaEnabled, aaOnboarding: aaEnabled })
     expect(result.pid).toBe(child.pid)
     expect(result.pid).not.toBe(process.pid)
     expect(shell).toBeDefined()
@@ -97,6 +96,8 @@ it.each([false, true])('boots a separate Web Host with client plugins (AA enable
     expect(bundle.status).toBe(200)
     expect(await bundle.text()).toContain('isolatedClientFixture')
     expect(html).toContain('dsh-plugin-desktop-beta')
+    await expect.poll(async () => (await rpc!.call<{ services: { aaRuntime: boolean; aaOnboarding: boolean } }>('status')).services, { timeout: 3000 })
+      .toEqual({ aaRuntime: aaEnabled, aaOnboarding: aaEnabled })
     await rpc.call('stop')
     await expect(fetch(spec.url, { headers })).rejects.toThrow()
   } catch (error) {

--- a/dsh-plugin-desktop-beta/tests/host-process.spec.ts
+++ b/dsh-plugin-desktop-beta/tests/host-process.spec.ts
@@ -1,0 +1,43 @@
+import { EventEmitter } from 'node:events'
+import { expect, it, vi } from 'vitest'
+import { createLaunchEnvironmentSnapshot } from '@deepseek-ai/dsh-launch-environment'
+import type { DesktopStartupGenerationHost } from '../src/startup-generation.ts'
+const state = vi.hoisted(() => ({ fork: vi.fn() }))
+vi.mock('electron', () => ({ utilityProcess: { fork: state.fork } }))
+import { startIsolatedDesktopHost, type IsolatedHostOptions } from '../src/host-process.ts'
+
+function fixture() {
+  const child = Object.assign(new EventEmitter(), {
+    stdout: new EventEmitter(), stderr: new EventEmitter(),
+    postMessage: vi.fn((message: { kind: string; id: number; method?: string }) => {
+      if (message.kind === 'call') queueMicrotask(() => child.emit('message', { kind: 'result', id: message.id, value: { pid: 123 } }))
+    }),
+    kill: vi.fn(() => { queueMicrotask(() => child.emit('exit', 0)); return true }),
+  })
+  state.fork.mockReturnValue(child)
+  let host!: DesktopStartupGenerationHost
+  const onFailure = vi.fn()
+  const options = {
+    host: { desktopLaunchEnvironment: createLaunchEnvironmentSnapshot([]) },
+    runtime: { platform: 'win32', locale: 'en', updates: { currentVersion: '2.0.7-beta.1' } },
+    rendererToken: 'fixture', prepareCertificate: async () => ({ failureCode: 'fixture' }),
+    bindHost: (value: DesktopStartupGenerationHost) => { host = value }, requestQuit() {}, onFailure,
+  } as unknown as IsolatedHostOptions
+  return { child, options, onFailure, host: () => host }
+}
+it('binds the child before startup and makes repeated teardown idempotent', async () => {
+  const f = fixture()
+  await startIsolatedDesktopHost(f.options)
+  await Promise.all([f.host().fiber.dispose(), f.host().fiber.dispose()])
+  expect(f.child.kill).toHaveBeenCalledOnce()
+  expect(f.onFailure).not.toHaveBeenCalled()
+  expect(f.child.postMessage.mock.calls.filter(([m]) => m.method === 'stop')).toHaveLength(1)
+})
+it('reports unexpected Host exit without automatically relaunching or replaying work', async () => {
+  const f = fixture()
+  await startIsolatedDesktopHost(f.options)
+  f.child.emit('exit', 9)
+  expect(f.onFailure).toHaveBeenCalledOnce()
+  await f.host().fiber.dispose()
+  expect(f.child.kill).not.toHaveBeenCalled()
+})

--- a/dsh-plugin-desktop-beta/tests/host-rpc.spec.ts
+++ b/dsh-plugin-desktop-beta/tests/host-rpc.spec.ts
@@ -1,0 +1,52 @@
+import { MessageChannel } from 'node:worker_threads'
+import { afterEach, describe, expect, it } from 'vitest'
+import { HostRpc } from '../src/host-rpc.ts'
+
+const cleanup: (() => void)[] = []
+afterEach(() => cleanup.splice(0).forEach(close => close()))
+function pair(timeout = 1000) {
+  const { port1, port2 } = new MessageChannel()
+  const peers = [port1, port2].map(port => new HostRpc({
+    send: message => port.postMessage(message),
+    listen: receive => { port.on('message', receive); return () => { port.off('message', receive) } },
+  }, timeout)) as [HostRpc, HostRpc]
+  cleanup.push(() => { peers.forEach(peer => peer.close()); port1.close(); port2.close() })
+  return peers
+}
+
+describe('private Host control transport', () => {
+  it('supports concurrent bidirectional calls, errors and unknown-method rejection', async () => {
+    const [parent, child] = pair()
+    child.handle('echo', async ([value]) => { await new Promise(resolve => setTimeout(resolve, 2)); return value })
+    parent.handle('native', ([value]) => value + 1)
+    child.handle('nested', async ([value]) => child.call('native', [value]))
+    child.handle('fail', () => { throw new Error('fixture failure') })
+    expect(await Promise.all([parent.call('echo', ['a']), parent.call('nested', [4])])).toEqual(['a', 5])
+    await expect(parent.call('fail')).rejects.toThrow('fixture failure')
+    await expect(parent.call('absent')).rejects.toThrow('Unknown Host operation')
+  })
+  it('propagates cancellation to active native operations', async () => {
+    const [parent, child] = pair()
+    let cancelled!: () => void
+    const cancellation = new Promise<void>(resolve => { cancelled = resolve })
+    let entered!: () => void
+    const started = new Promise<void>(resolve => { entered = resolve })
+    child.handle('wait', (_args, signal) => new Promise<void>(resolve => {
+      signal.addEventListener('abort', () => { cancelled(); resolve() }, { once: true }); entered()
+    }))
+    const controller = new AbortController()
+    const call = parent.call('wait', [], controller.signal)
+    const rejected = expect(call).rejects.toThrow('cancelled')
+    await started; controller.abort()
+    await rejected; await cancellation
+  })
+  it('rejects pending calls on exit and times out a nonresponsive peer', async () => {
+    const [parent, child] = pair(20)
+    child.handle('never', () => new Promise(() => {}))
+    await expect(parent.call('never')).rejects.toThrow('timed out')
+    const request = parent.call('pending')
+    parent.close('worker exited')
+    await expect(request).rejects.toThrow('worker exited')
+    await expect(parent.call('later')).rejects.toThrow('closed')
+  })
+})

--- a/dsh-plugin-desktop-beta/tests/host-runtime-bridge.spec.ts
+++ b/dsh-plugin-desktop-beta/tests/host-runtime-bridge.spec.ts
@@ -1,0 +1,57 @@
+import { MessageChannel } from 'node:worker_threads'
+import { expect, it, vi } from 'vitest'
+import { HostRpc } from '../src/host-rpc.ts'
+import { bindNativeRuntime, createHostRuntime, runtimeSnapshot } from '../src/host-runtime-bridge.ts'
+import type { DesktopRuntime, DesktopShellSpec, DesktopTrayItem } from '../src/runtime.ts'
+
+it('preserves the Web URL and authentication while projecting shell and tray callbacks', async () => {
+  const { port1, port2 } = new MessageChannel()
+  const [parent, child] = [port1, port2].map(port => new HostRpc({
+    send: value => port.postMessage(value),
+    listen: receive => { port.on('message', receive); return () => { port.off('message', receive) } },
+  })) as [HostRpc, HostRpc]
+  let shell!: DesktopShellSpec
+  let tray!: DesktopTrayItem
+  const disposeShell = vi.fn(async () => {})
+  const disposeTray = vi.fn()
+  const native = {
+    platform: 'win32', windowsBuild: 22631, locale: 'en',
+    updates: { isPackaged: true, canDownload: true, currentVersion: '2.0.7-beta.1', statePath: '/tmp/update',
+      request: vi.fn(async () => new Response('{"version":"2.0.8-beta.1"}', { headers: { 'x-test': 'yes' } })),
+    },
+    schedule: (value: DesktopShellSpec) => { shell = value; return disposeShell },
+    registerTrayItem: (value: DesktopTrayItem) => { tray = value; return { refresh() {}, dispose: disposeTray } },
+  } as unknown as DesktopRuntime
+  const release = bindNativeRuntime(parent, native)
+  try {
+    const runtime = createHostRuntime(child, runtimeSnapshot(native))
+    let language: 'zh' | undefined
+    const mode = vi.fn(async () => {})
+    const invoke = vi.fn(async () => {})
+    const spec = { url: 'http://127.0.0.1:1234/?dsh-desktop-mode=advanced',
+      authenticationUrl: 'http://127.0.0.1:1234/?token=fixture',
+      rendererAccessHeader: { name: 'x-dsh-desktop-renderer', value: 'fixture' },
+      readLocalePreference: () => language, readThemeSource: () => 'dark',
+      requestQuit() {}, requestModeChange: mode,
+    } as unknown as DesktopShellSpec
+    const stopShell = runtime.schedule(spec)
+    runtime.registerTrayItem({ group: 'tools', order: 1, label: () => 'Plugin action', invoke,
+      submenu: () => [{ label: () => 'Child', invoke }] })
+    language = 'zh'
+    await runtime.mountScheduled()
+    expect(shell.url).toBe(spec.url)
+    expect(shell.authenticationUrl).toBe(spec.authenticationUrl)
+    expect(shell.rendererAccessHeader).toEqual(spec.rendererAccessHeader)
+    expect(shell.readLocalePreference()).toBe('zh')
+    await shell.requestModeChange('extended')
+    expect(mode).toHaveBeenCalledWith('extended')
+    expect(tray.label()).toBe('Plugin action')
+    await tray.submenu?.()[0]?.invoke()
+    expect(invoke).toHaveBeenCalledOnce()
+    const response = await runtime.updates.request('https://example.invalid', { headers: { accept: 'application/json' } })
+    expect(response.headers.get('x-test')).toBe('yes')
+    expect(await response.json()).toEqual({ version: '2.0.8-beta.1' })
+    await stopShell()
+    expect(disposeShell).toHaveBeenCalledOnce()
+  } finally { await release(); parent.close(); child.close(); port1.close(); port2.close() }
+})

--- a/dsh-plugin-desktop-beta/tsdown.config.ts
+++ b/dsh-plugin-desktop-beta/tsdown.config.ts
@@ -31,6 +31,7 @@ export default defineConfig([
       'windows-pwsh-sandbox': 'src/windows-pwsh-sandbox.ts',
       'windows-acl-runner': 'src/windows-acl-runner.ts',
       main: 'src/main.ts',
+      'host-process-entry': 'src/host-process-entry.ts',
     },
     outDir: 'lib',
     format: 'esm',

--- a/dsh-plugin-desktop/tests/electron-runtime.spec.ts
+++ b/dsh-plugin-desktop/tests/electron-runtime.spec.ts
@@ -1,4 +1,4 @@
-import { unlinkSync } from 'node:fs'
+import { readFileSync, unlinkSync } from 'node:fs'
 import { basename, dirname, join } from 'node:path'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { DesktopShellSpec } from '../src/runtime.ts'
@@ -39,6 +39,8 @@ const childProcess = vi.hoisted(() => {
     spawn: vi.fn(() => child),
   }
 })
+
+const PACKAGE_VERSION = (JSON.parse(readFileSync(new URL('../package.json', import.meta.url), 'utf8')) as { version: string }).version
 
 const MAIN_WINDOW_STATE_PATH = '/tmp/dsh-desktop-user-data/main-window-state.json'
 
@@ -1903,7 +1905,7 @@ describe('Electron desktop runtime', () => {
         appExecutable: process.execPath,
         electronVersion: '43.4.0',
         profileName: 'desktop',
-        productVersion: '2.0.6',
+        productVersion: PACKAGE_VERSION,
         profileDir: expect.stringMatching(/profiles[\\/]+desktop$/u),
         homeDir: expect.stringContaining('dsh-desktop-user-data'),
         spawn: expect.any(Function),
@@ -1939,7 +1941,7 @@ describe('Electron desktop runtime', () => {
     expect(diagnostics.export).toHaveBeenCalledWith(
       expect.stringContaining('dsh-desktop-user-data'),
       expect.objectContaining({
-        appVersion: '2.0.6',
+        appVersion: PACKAGE_VERSION,
         crashDumpsDir: expect.stringMatching(/[\\/]Crashpad$/u),
       }),
     )
@@ -2328,7 +2330,7 @@ describe('Electron desktop runtime', () => {
     expect(runtime.updates).toMatchObject({
       isPackaged: false,
       canDownload: false,
-      currentVersion: '2.0.6',
+      currentVersion: PACKAGE_VERSION,
       statePath: join('/tmp/dsh-desktop-user-data', 'updates', 'state.json'),
     })
     electron.app.isPackaged = true

--- a/scripts/verify-desktop-variants.mjs
+++ b/scripts/verify-desktop-variants.mjs
@@ -7,7 +7,7 @@ const betaRoot = join(root, 'dsh-plugin-desktop-beta', 'src')
 // PR #868's isolated compatibility chrome is beta-only. Stable retains the
 // single-document frame; both variants retain renderer crash recovery (#869).
 const betaOnlyPaths = new Set([
-  // Opt-in Host process experiment remains Beta-only until validated.
+  // Default Beta Host process experiment remains Beta-only until validated.
   'host-bootstrap.ts',
   'host-launch-environment.ts',
   'host-process.ts',
@@ -24,6 +24,10 @@ const betaOnlyPaths = new Set([
   'native-ui/compatibility-chrome/style.css',
 ])
 const allowedDifferences = new Set([
+  // Beta reserves the full enhanced drag strip and isolates extended chrome.
+  'client/styles.ts',
+  'client/extended-shell.ts',
+  'client/extended-styles.ts',
   // Compatibility chrome integration differs intentionally between channels.
   'client/ExtendedTitlebar.tsx',
   'client/window-service.ts',

--- a/scripts/verify-desktop-variants.mjs
+++ b/scripts/verify-desktop-variants.mjs
@@ -6,7 +6,14 @@ const stableRoot = join(root, 'dsh-plugin-desktop', 'src')
 const betaRoot = join(root, 'dsh-plugin-desktop-beta', 'src')
 // PR #868's isolated compatibility chrome is beta-only. Stable retains the
 // single-document frame; both variants retain renderer crash recovery (#869).
-const betaOnlyCompatibilityPaths = new Set([
+const betaOnlyPaths = new Set([
+  // Opt-in Host process experiment remains Beta-only until validated.
+  'host-bootstrap.ts',
+  'host-launch-environment.ts',
+  'host-process.ts',
+  'host-process-entry.ts',
+  'host-rpc.ts',
+  'host-runtime-bridge.ts',
   'client/DesktopFrameTitlebarView.tsx',
   'compatibility-chrome-contract.ts',
   'compatibility-preload.ts',
@@ -59,7 +66,7 @@ function files(directory, base = directory) {
   return result
 }
 
-const sharedPaths = new Set([...files(stableRoot), ...files(betaRoot), ...betaOnlyCompatibilityPaths])
+const sharedPaths = new Set([...files(stableRoot), ...files(betaRoot), ...betaOnlyPaths])
 const differences = []
 for (const path of [...sharedPaths].sort()) {
   if (allowedDifferences.has(path)) continue
@@ -67,7 +74,7 @@ for (const path of [...sharedPaths].sort()) {
   let beta
   try { stable = readFileSync(join(stableRoot, path)) } catch { stable = undefined }
   try { beta = readFileSync(join(betaRoot, path)) } catch { beta = undefined }
-  if (betaOnlyCompatibilityPaths.has(path)) {
+  if (betaOnlyPaths.has(path)) {
     if (stable !== undefined || beta === undefined) differences.push(`${path} (must exist only in beta)`)
     continue
   }
@@ -78,4 +85,4 @@ if (differences.length > 0) {
   throw new Error(`Desktop variant source drift is not declared:\n${differences.map(path => `- src/${path}`).join('\n')}`)
 }
 
-process.stdout.write(`verify-desktop-variants: ${String(sharedPaths.size - allowedDifferences.size - betaOnlyCompatibilityPaths.size)} shared source files are aligned; beta-only compatibility chrome is isolated\n`)
+process.stdout.write(`verify-desktop-variants: ${String(sharedPaths.size - allowedDifferences.size - betaOnlyPaths.size)} shared source files are aligned; beta-only compatibility chrome and Host experiment are isolated\n`)


### PR DESCRIPTION
Beta now starts the DSH Cordis Host in a separate Electron utility process by default, so Host/AA work does not run on Electron's main event loop. The existing authenticated HTTP/WebSocket transport and client-plugin composition remain intact. Native windows, menus, dialogs, updates and certificate protection stay in Electron and use a private control channel. Set `DSH_DESKTOP_ISOLATED_HOST=0` for comparison with the previous path. Stable behavior is unchanged.

Compatibility and extended modes on macOS/Windows now share the separate packaged chrome WebContentsView. Content plugins cannot alter the titlebar through DOM, CSS or slots, and the content viewport no longer reserves a duplicate titlebar inset. Enhanced macOS mode reserves all 32px of its drag strip above the main/right panels, removing the previous 12px overlap.

Validation: Beta build and typecheck; all 128 test files (1308 passed, 7 skipped); runtime closure, CLI, Loader, profile, AA, licenses and operation checks; variant alignment and bilingual-document verification. A real Node child-process fixture verifies authenticated Web access, third-party client bundle serving, AA on/off activation and orderly shutdown. Native chrome tests cover both modes and reject other renderers/frames.

Manual testing still needed: actual Electron utility-process behavior, packaged ASAR/native modules, Windows responsiveness, macOS visuals, plugin activation/HMR and descendant-process cleanup. This process change does not by itself establish a fix for the separately reported request-extension package-inventory error. The fallback bootstrap remains duplicated during the Beta experiment and should be consolidated before stable promotion.
