### PR TITLE
fix: follow latest AA main after v2 retirement

### DIFF
--- a/scripts/prepare-agents-anywhere-release.mjs
+++ b/scripts/prepare-agents-anywhere-release.mjs
@@ -7,7 +7,7 @@ import { fileURLToPath } from 'node:url'
 
 const root = resolve(dirname(fileURLToPath(import.meta.url)), '..')
 const sourceRepository = process.env.DSH_AA_SOURCE_REPOSITORY ?? 'https://github.com/anywhere-labs/Agents-Anywhere.git'
-const sourceRef = process.env.DSH_AA_SOURCE_REF ?? 'v2'
+const sourceRef = process.env.DSH_AA_SOURCE_REF ?? 'main'
 const vendorRoot = resolve(root, 'vendor/agents-anywhere')
 const provenancePath = join(vendorRoot, 'provenance.json')
 const currentProvenance = existsSync(provenancePath) ? JSON.parse(readFileSync(provenancePath, 'utf8')) : {}
@@ -170,7 +170,7 @@ function prepare() {
     }
     const provenance = {
       repository: sourceRepository,
-      branch: /^[0-9a-f]{40}$/iu.test(sourceRef) ? (process.env.DSH_AA_SOURCE_BRANCH ?? 'v2') : sourceRef,
+      branch: /^[0-9a-f]{40}$/iu.test(sourceRef) ? (process.env.DSH_AA_SOURCE_BRANCH ?? 'main') : sourceRef,
       commit,
       packageDirectory: 'dsh-bridge-next',
       sourceVersion,

--- a/vendor/agents-anywhere/README.md
+++ b/vendor/agents-anywhere/README.md
@@ -12,7 +12,7 @@ explicit peers for both Desktop runtime versions (including the emitted
 
 Root `dev`, `dev:beta`, `dist:*` and `package:dir*` commands first run
 `yarn aa:prepare-release`.
-This resolves the latest GitHub `v2` commit once, fetches that exact commit into
+This resolves the latest GitHub `main` commit once, fetches that exact commit into
 an isolated temporary checkout, and builds `dsh-bridge-next` with the Connector
 sources from the same commit. It never changes an adjacent AA checkout.
 Each development launch checks GitHub once before starting Desktop; it does
@@ -21,7 +21,7 @@ installed pin; PR CI continues to validate the committed pin without querying
 AA's moving branch.
 
 ```sh
-# Read-only comparison with the current remote v2 head
+# Read-only comparison with the current remote main head
 corepack yarn aa:check
 # Prepare the latest AA package without packaging Electron
 corepack yarn aa:prepare-release


### PR DESCRIPTION
AA retired its v2 branch, so the development and packaging preflight stopped at git ls-remote before Desktop could launch. Resolve the latest main commit by default and update the provenance fallback and usage documentation. Each normal dev/package invocation still queries the remote branch before reusing or rebuilding an artifact; explicit reproducibility overrides remain available.

Validated against the remote default branch: main resolved to af3d03f4194717c6cf1923a1a82b1cfacfc4b630. Also ran the JavaScript syntax check and git diff --check. No GUI was launched and no bundled AA artifact was changed by this fix.
