### PR TITLE
fix(beta): align extended titlebar and sidebar tint

### DIFF
--- a/dsh-plugin-desktop-beta/src/client/DesktopFrameTitlebarView.tsx
+++ b/dsh-plugin-desktop-beta/src/client/DesktopFrameTitlebarView.tsx
@@ -168,6 +168,7 @@ export function DesktopFrameTitlebarView({ api, environment, setMode, t }: Deskt
     <header
       className="dshDesktopFrameTitlebar"
       data-dsh-desktop-frame="titlebar"
+      data-mode={environment.mode}
       data-platform={environment.platform}
       data-material={environment.material}
     >

--- a/dsh-plugin-desktop-beta/src/native-ui/compatibility-chrome/style.css
+++ b/dsh-plugin-desktop-beta/src/native-ui/compatibility-chrome/style.css
@@ -26,6 +26,9 @@ html, body, #root { background: transparent; font-size: 13px; }
 .dshDesktopFrameTitlebar:not([data-material="off"]) {
   --dsh-desktop-frame-fill: color-mix(in srgb, var(--dsw-alias-bg-base) 54%, transparent);
 }
+.dshDesktopFrameTitlebar[data-mode="extended"]:not([data-material="off"]) {
+  --dsh-desktop-frame-fill: color-mix(in srgb, var(--dsw-alias-bg-base) 18%, transparent);
+}
 .dshDesktopFrameTitlebar {
   position: fixed;
   z-index: 2147483647;


### PR DESCRIPTION
The isolated titlebar retained compatibility mode's 54% background tint even in extended mode, while the sidebar used 18%. Expose the existing presentation mode on the packaged titlebar and apply the extended 18% tint there too. Compatibility and material-off styles remain unchanged, as does the separate chrome document.

Validation: 31 focused UI/environment tests, Beta typecheck, variant alignment and git diff --check. Actual appearance still requires a manual app restart and visual check.
