### PR TITLE
chore: bump Desktop to 2.0.9 and Beta to 2.0.9-beta.1

### DIFF
--- a/dsh-plugin-desktop-beta/package.json
+++ b/dsh-plugin-desktop-beta/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-plugin-desktop-beta",
-  "version": "2.0.8-beta.1",
+  "version": "2.0.9-beta.1",
   "description": "DSH Desktop Beta: an Electron shell composed as a DeepSeek Harness Cordis plugin",
   "license": "MIT",
   "publishConfig": {

--- a/dsh-plugin-desktop-beta/tests/package.spec.ts
+++ b/dsh-plugin-desktop-beta/tests/package.spec.ts
@@ -76,7 +76,7 @@ const dshResolution = (name: string): unknown =>
 describe('published package surface', () => {
   it('keeps the private workspace version-neutral and versions the Beta package', () => {
     expect(workspaceManifest.version).toBeUndefined()
-    expect(manifest.version).toBe('2.0.8-beta.1')
+    expect(manifest.version).toBe('2.0.9-beta.1')
   })
 
   it('runs desktop and community market typechecks from the root command', () => {
@@ -839,7 +839,7 @@ describe('published package surface', () => {
 
   it('fixes the installed application identity', () => {
     expect(workspaceManifest.version).toBeUndefined()
-    expect(manifest.version).toBe('2.0.8-beta.1')
+    expect(manifest.version).toBe('2.0.9-beta.1')
     expect(manifest.name).toBe('dsh-plugin-desktop-beta')
     expect(manifest.bin).toEqual({
       'dsh-desktop-beta': 'lib/bin.js',

--- a/dsh-plugin-desktop/package.json
+++ b/dsh-plugin-desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-plugin-desktop",
-  "version": "2.0.8",
+  "version": "2.0.9",
   "description": "DSH Desktop: an Electron shell composed as a DeepSeek Harness Cordis plugin",
   "license": "MIT",
   "publishConfig": {

--- a/dsh-plugin-desktop/tests/package.spec.ts
+++ b/dsh-plugin-desktop/tests/package.spec.ts
@@ -761,7 +761,7 @@ describe('published package surface', () => {
 
   it('fixes the installed application identity', () => {
     expect(workspaceManifest.version).toBeUndefined()
-    expect(manifest.version).toBe('2.0.8')
+    expect(manifest.version).toBe('2.0.9')
     expect(manifest.build?.productName).toBe('DSH Desktop')
     expect(manifest.build?.appId).toBe('ai.deepseek.dsh.desktop')
     expect(manifest.build?.asar).toEqual({ smartUnpack: true })


### PR DESCRIPTION
Bump Desktop from 2.0.8 to 2.0.9 and Beta from 2.0.8-beta.1 to 2.0.9-beta.1. Update package version assertions for both variants. Validation: desktop variant consistency passed; package tests passed (88 passed, 2 skipped); git diff --check passed. Installers were not built.