### PR TITLE
fix: keep request inventory resolution when Desktop declines a package

### DIFF
--- a/dsh-plugin-desktop-beta/tests/request-inventory-resolution.spec.ts
+++ b/dsh-plugin-desktop-beta/tests/request-inventory-resolution.spec.ts
@@ -3,7 +3,7 @@ import { createRequire } from 'node:module'
 import { fileURLToPath } from 'node:url'
 import { expect, it } from 'vitest'
 
-it('prepares request inventory for Desktop-owned entries and private-manifest plugins', () => {
+it('prepares request inventory for Desktop-owned entries and Profile-owned plugins', () => {
   const require = createRequire(import.meta.url)
   const script = `
     import assert from 'node:assert/strict';
@@ -17,8 +17,13 @@ it('prepares request inventory for Desktop-owned entries and private-manifest pl
     const root = mkdtempSync(join(tmpdir(), 'desktop-inventory-'));
     let release;
     try {
-      writeFileSync(join(root, 'package.json'), '{"type":"module"}');
-      const baseUrl = pathToFileURL(join(root, 'package.json')).href;
+      // Installed layout: <root>/profiles/desktop is the active Profile and
+      // <root>/profiles/node_modules is the shared fallback tree that the
+      // Desktop overlay deliberately refuses to select.
+      const profile = join(root, 'profiles', 'desktop');
+      mkdirSync(profile, { recursive: true });
+      writeFileSync(join(profile, 'package.json'), '{"type":"module"}');
+      const baseUrl = pathToFileURL(join(profile, 'package.json')).href;
       const collect = async names => {
         let provider;
         const tree = { ctx: { baseUrl }, entries: () => names.map(name => ({
@@ -37,13 +42,27 @@ it('prepares request inventory for Desktop-owned entries and private-manifest pl
         desktop.name + '/diagnostics', desktop.name + '/notifications',
         desktop.name + '/profiles', desktop.name + '/updates'
       ]), [{ name: desktop.name, version: desktop.version }]);
-      const plugin = join(root, 'node_modules', 'private-manifest-plugin');
+      const plugin = join(profile, 'node_modules', 'private-manifest-plugin');
       mkdirSync(plugin, { recursive: true });
       writeFileSync(join(plugin, 'package.json'), JSON.stringify({
         name: 'private-manifest-plugin', version: '1.2.3', exports: './index.js'
       }));
       writeFileSync(join(plugin, 'index.js'), 'throw new Error("inventory evaluated plugin")');
       assert.deepEqual(await collect(['private-manifest-plugin']), [{ name: 'private-manifest-plugin', version: '1.2.3' }]);
+      // A plugin the official CLI installed into the shared fallback still resolves
+      // through the physical lookup, so it must not fail the whole request.
+      const shared = join(root, 'profiles', 'node_modules', 'shared-fallback-plugin');
+      mkdirSync(shared, { recursive: true });
+      writeFileSync(join(shared, 'package.json'), JSON.stringify({
+        name: 'shared-fallback-plugin', version: '3.0.0', main: 'index.js'
+      }));
+      writeFileSync(join(shared, 'index.js'), 'throw new Error("inventory evaluated plugin")');
+      assert.deepEqual(await collect(['shared-fallback-plugin']), [{ name: 'shared-fallback-plugin', version: '3.0.0' }]);
+      // A broken manifest must fail loudly instead of being silently skipped.
+      const broken = join(profile, 'node_modules', 'malformed-manifest-plugin');
+      mkdirSync(broken, { recursive: true });
+      writeFileSync(join(broken, 'package.json'), '{ "name": "malformed-manifest-plugin",');
+      await assert.rejects(() => collect(['malformed-manifest-plugin']), /cannot read|Unexpected token|not valid JSON|must declare/u);
       await assert.rejects(() => collect(['inventory-nonexistent-package']), /cannot resolve.*package/);
       writeFileSync(join(plugin, 'package.json'), JSON.stringify({ name: 'private-manifest-plugin', exports: './index.js' }));
       await assert.rejects(() => collect(['private-manifest-plugin']), /non-empty name and version/);

--- a/dsh-plugin-desktop/tests/request-inventory-resolution.spec.ts
+++ b/dsh-plugin-desktop/tests/request-inventory-resolution.spec.ts
@@ -3,7 +3,7 @@ import { createRequire } from 'node:module'
 import { fileURLToPath } from 'node:url'
 import { expect, it } from 'vitest'
 
-it('prepares request inventory for Desktop-owned entries and private-manifest plugins', () => {
+it('prepares request inventory for Desktop-owned entries and Profile-owned plugins', () => {
   const require = createRequire(import.meta.url)
   const script = `
     import assert from 'node:assert/strict';
@@ -17,8 +17,13 @@ it('prepares request inventory for Desktop-owned entries and private-manifest pl
     const root = mkdtempSync(join(tmpdir(), 'desktop-inventory-'));
     let release;
     try {
-      writeFileSync(join(root, 'package.json'), '{"type":"module"}');
-      const baseUrl = pathToFileURL(join(root, 'package.json')).href;
+      // Installed layout: <root>/profiles/desktop is the active Profile and
+      // <root>/profiles/node_modules is the shared fallback tree that the
+      // Desktop overlay deliberately refuses to select.
+      const profile = join(root, 'profiles', 'desktop');
+      mkdirSync(profile, { recursive: true });
+      writeFileSync(join(profile, 'package.json'), '{"type":"module"}');
+      const baseUrl = pathToFileURL(join(profile, 'package.json')).href;
       const collect = async names => {
         let provider;
         const tree = { ctx: { baseUrl }, entries: () => names.map(name => ({
@@ -37,13 +42,27 @@ it('prepares request inventory for Desktop-owned entries and private-manifest pl
         desktop.name + '/diagnostics', desktop.name + '/notifications',
         desktop.name + '/profiles', desktop.name + '/updates'
       ]), [{ name: desktop.name, version: desktop.version }]);
-      const plugin = join(root, 'node_modules', 'private-manifest-plugin');
+      const plugin = join(profile, 'node_modules', 'private-manifest-plugin');
       mkdirSync(plugin, { recursive: true });
       writeFileSync(join(plugin, 'package.json'), JSON.stringify({
         name: 'private-manifest-plugin', version: '1.2.3', exports: './index.js'
       }));
       writeFileSync(join(plugin, 'index.js'), 'throw new Error("inventory evaluated plugin")');
       assert.deepEqual(await collect(['private-manifest-plugin']), [{ name: 'private-manifest-plugin', version: '1.2.3' }]);
+      // A plugin the official CLI installed into the shared fallback still resolves
+      // through the physical lookup, so it must not fail the whole request.
+      const shared = join(root, 'profiles', 'node_modules', 'shared-fallback-plugin');
+      mkdirSync(shared, { recursive: true });
+      writeFileSync(join(shared, 'package.json'), JSON.stringify({
+        name: 'shared-fallback-plugin', version: '3.0.0', main: 'index.js'
+      }));
+      writeFileSync(join(shared, 'index.js'), 'throw new Error("inventory evaluated plugin")');
+      assert.deepEqual(await collect(['shared-fallback-plugin']), [{ name: 'shared-fallback-plugin', version: '3.0.0' }]);
+      // A broken manifest must fail loudly instead of being silently skipped.
+      const broken = join(profile, 'node_modules', 'malformed-manifest-plugin');
+      mkdirSync(broken, { recursive: true });
+      writeFileSync(join(broken, 'package.json'), '{ "name": "malformed-manifest-plugin",');
+      await assert.rejects(() => collect(['malformed-manifest-plugin']), /cannot read|Unexpected token|not valid JSON|must declare/u);
       await assert.rejects(() => collect(['inventory-nonexistent-package']), /cannot resolve.*package/);
       writeFileSync(join(plugin, 'package.json'), JSON.stringify({ name: 'private-manifest-plugin', exports: './index.js' }));
       await assert.rejects(() => collect(['private-manifest-plugin']), /non-empty name and version/);

--- a/patches/dsh-plugin-package-inventory-deepseek@0.1.5-rc.1.patch
+++ b/patches/dsh-plugin-package-inventory-deepseek@0.1.5-rc.1.patch
@@ -1,20 +1,28 @@
 diff --git a/lib/index.js b/lib/index.js
 --- a/lib/index.js
 +++ b/lib/index.js
-@@ -43,2 +43,16 @@
+@@ -41,4 +41,24 @@ function identityFromManifest(path, allowAnonymous) {
+ function barePackageManifest(packageName, anchors) {
  	for (const anchor of anchors) {
 +		const desktopResolverCount = globalThis[Symbol.for("dsh-plugin-desktop.asar-module-resolver")];
 +		if (typeof desktopResolverCount === "number" && desktopResolverCount > 0) {
-+			// Desktop's own package lives in app.asar rather than node_modules.
-+			// Honor the same resolver used to load it; resolving never evaluates it.
++			// Desktop's own package lives in app.asar rather than node_modules, so
++			// only the resolver that loaded it can report its manifest. Resolving
++			// a package manifest never evaluates the package.
 +			try {
 +				return createRequire(anchor).resolve(`${packageName}/package.json`);
 +			} catch (error) {
-+				// Packages may keep their manifest private. Retain the upstream
-+				// filesystem lookup for those packages, without hiding other errors.
++				// That resolver also declines packages the filesystem lookup below
++				// still serves: manifests kept private by their exports map, and
++				// packages installed only into the shared Profile fallback that the
++				// Desktop overlay excludes by policy. Keep the upstream lookup as the
++				// fallback, so one such entry cannot fail the whole request. Every
++				// other failure is a real one and keeps propagating from here.
 +				if (error?.code !== "MODULE_NOT_FOUND"
 +					&& error?.code !== "ERR_MODULE_NOT_FOUND"
-+					&& error?.code !== "ERR_PACKAGE_PATH_NOT_EXPORTED") throw error;
++					&& error?.code !== "ERR_PACKAGE_PATH_NOT_EXPORTED"
++					&& error?.name !== "PackageOverlayNotFoundError") throw error;
 +			}
 +		}
  		const searchPaths = createRequire(anchor).resolve.paths(packageName);
+ 		/* v8 ignore next -- active non-builtin package entries always have Node package search paths */

--- a/yarn.lock
+++ b/yarn.lock
@@ -2923,7 +2923,7 @@ __metadata:
 
 "@deepseek-ai/dsh-plugin-package-inventory-deepseek@patch:@deepseek-ai/dsh-plugin-package-inventory-deepseek@file%3Avendor/dsh-runtime/0.1.5-rc.1/deepseek-ai-dsh-plugin-package-inventory-deepseek-0.1.5-rc.1.tgz#./patches/dsh-plugin-package-inventory-deepseek@0.1.5-rc.1.patch::locator=deepseek-harness-desktop%40workspace%3A.":
   version: 0.1.5-rc.1
-  resolution: "@deepseek-ai/dsh-plugin-package-inventory-deepseek@patch:@deepseek-ai/dsh-plugin-package-inventory-deepseek@file%3Avendor/dsh-runtime/0.1.5-rc.1/deepseek-ai-dsh-plugin-package-inventory-deepseek-0.1.5-rc.1.tgz%23vendor/dsh-runtime/0.1.5-rc.1/deepseek-ai-dsh-plugin-package-inventory-deepseek-0.1.5-rc.1.tgz%3A%3Ahash=36e720&locator=deepseek-harness-desktop%2540workspace%253A.#./patches/dsh-plugin-package-inventory-deepseek@0.1.5-rc.1.patch::version=0.1.5-rc.1&hash=9efbcb&locator=deepseek-harness-desktop%40workspace%3A."
+  resolution: "@deepseek-ai/dsh-plugin-package-inventory-deepseek@patch:@deepseek-ai/dsh-plugin-package-inventory-deepseek@file%3Avendor/dsh-runtime/0.1.5-rc.1/deepseek-ai-dsh-plugin-package-inventory-deepseek-0.1.5-rc.1.tgz%23vendor/dsh-runtime/0.1.5-rc.1/deepseek-ai-dsh-plugin-package-inventory-deepseek-0.1.5-rc.1.tgz%3A%3Ahash=36e720&locator=deepseek-harness-desktop%2540workspace%253A.#./patches/dsh-plugin-package-inventory-deepseek@0.1.5-rc.1.patch::version=0.1.5-rc.1&hash=bbb1c1&locator=deepseek-harness-desktop%40workspace%3A."
   dependencies:
     "@deepseek-ai/dsh-brand": "npm:^0.1.5-rc.1"
     "@deepseek-ai/schemastery": "npm:^3.18.2"
@@ -2937,7 +2937,7 @@ __metadata:
   peerDependenciesMeta:
     "@deepseek-ai/dsh-agent-presets":
       optional: true
-  checksum: 10c0/fc9ee339c8dc9777431070c2a78e1fbd11c7d4a3d76945a57a9474387e7d5c6e3c8ee856abfd82390967241de6d427181788f716f4c62b7234debc69976a81a0
+  checksum: 10c0/ae468c55e0caa7c50a43120cc1a7e203f70b32db5b8c1a053d1037fca123a82d88ecbf0ca53ac72e06cf018772a9dfa82fedb8a37d815a7c2c4ea7c986fd0283
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Problem

Desktop 2.0.6+ fails every DeepSeek request with `DeepSeek request extension preparation failed` (`REQUEST_EXTENSION`) — issue #918, also reported as #904. Active-package inventory searches only physical `node_modules` paths, while Desktop-owned Loader entries resolve from the application package (`app.asar` root), so they were reported as missing.

That part is already fixed on `master` (e073215, identical to the patch content of #925). This PR closes the remaining gap in the same code path.

## Remaining gap

The Desktop-resolver branch keeps the upstream filesystem fallback only for the error codes it enumerates:

```js
if (error?.code !== "MODULE_NOT_FOUND"
  && error?.code !== "ERR_MODULE_NOT_FOUND"
  && error?.code !== "ERR_PACKAGE_PATH_NOT_EXPORTED") throw error;
```

The Desktop resolver also **declines packages the filesystem lookup still serves**, and reports those declines as `PackageOverlayNotFoundError`, which carries no `error.code` — so they were re-thrown:

- manifests kept private by their `exports` map, and
- packages installed only into the shared Profile fallback directory (`<dsh-home>/profiles/node_modules`) that the Desktop overlay excludes by policy (`selectedOverlayCandidate()` in `dsh-plugin-desktop/src/module-resolution.ts`).

`prepare()` then failed for the whole request, which surfaces as the same `REQUEST_EXTENSION` error — so affected users still see #918 after updating.

## Change

Treat `PackageOverlayNotFoundError` as one more "this lookup has nothing to offer" result and continue with the upstream filesystem lookup:

```js
if (error?.code !== "MODULE_NOT_FOUND"
  && error?.code !== "ERR_MODULE_NOT_FOUND"
  && error?.code !== "ERR_PACKAGE_PATH_NOT_EXPORTED"
  && error?.name !== "PackageOverlayNotFoundError") throw error;
```

Every other failure still propagates immediately with its own cause, so a genuinely broken package is never reported as merely unresolvable, and a package that no lookup can supply still fails with the inventory's own `cannot resolve active package "<name>"` error. Nothing is silently skipped. Both editions receive the pinned runtime patch; the upstream submodule is untouched.

## Tests

`tests/request-inventory-resolution.spec.ts` in both editions (kept byte-identical). The fixture now mirrors the installed layout (`<root>/profiles/desktop` is the active Profile, `<root>/profiles/node_modules` is the shared fallback tree) and adds:

- a plugin that exists **only** in the shared Profile fallback — it must resolve instead of failing the request;
- a manifest that must **fail loudly** (`cannot read … manifest` / `not valid JSON`) instead of being silently skipped.

All previous coverage is retained: the seven Desktop-owned entry names plus deduplication, a private-manifest plugin resolved without evaluating it, a missing package, invalid metadata, and resolver disposal.

`yarn.lock` was refreshed with `yarn install --mode=update-lockfile` (patch-content hash and checksum only).

## Validation

- The spec body was executed with the real Desktop resolver in both editions — `request inventory passed`.
- With the pre-fix patch the new shared-fallback case fails with `PackageOverlayNotFoundError: cannot resolve package "shared-fallback-plugin"` thrown from `selectedOverlayCandidate` (`module-resolution.ts:379`).
- Not covered locally: the `vitest run` wrapper itself needs the Electron binary, which could not be downloaded in my environment, so the embedded test body was run with the same argv instead. CI runs the wrapper.

Refs #918, #904. Supersedes #925, whose patch content is already on `master`.
